### PR TITLE
CXXCBC-5 Handle no meter in http requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 
 include(cmake/VersionInfo.cmake)
 
-include_directories(${CMAKE_SOURCE_DIR}/couchbase)
+include_directories(${PROJECT_SOURCE_DIR}/couchbase)
 
 add_library(
   platform OBJECT

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -1,11 +1,11 @@
 if(ENABLE_TESTING)
   add_subdirectory(third_party/catch2)
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/third_party/catch2/contrib")
+  list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/third_party/catch2/contrib")
   enable_testing()
   include(Catch)
 
   macro(native_test name)
-    add_executable(test_native_${name} "${CMAKE_SOURCE_DIR}/test/test_native_${name}.cxx")
+    add_executable(test_native_${name} "${PROJECT_SOURCE_DIR}/test/test_native_${name}.cxx")
     target_include_directories(test_native_${name} PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(
       test_native_${name}
@@ -24,5 +24,5 @@ if(ENABLE_TESTING)
     catch_discover_tests(test_native_${name})
   endmacro()
 
-  add_subdirectory(${CMAKE_SOURCE_DIR}/test)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 endif()

--- a/couchbase/io/http_command.hxx
+++ b/couchbase/io/http_command.hxx
@@ -101,9 +101,10 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
                   { "db.couchbase.service", fmt::format("{}", self->request.type) },
                   { "db.operation", self->encoded.path },
               };
-              self->meter_->get_value_recorder(meter_name, tags)
-                ->record_value(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count());
-
+              if(self->meter_) {
+                  self->meter_->get_value_recorder(meter_name, tags)
+                    ->record_value(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count());
+              }
               self->deadline.cancel();
               self->finish_dispatch(session->remote_address(), session->local_address());
               encoded_response_type resp(msg);

--- a/test/test_helper.hxx
+++ b/test/test_helper.hxx
@@ -121,9 +121,11 @@ struct test_context {
         if (var != nullptr) {
             ctx.bucket = var;
         }
+
+        // TODO: I believe this + TEST_DEVELOPER_PREVIEW will conflict
         var = getenv("TEST_SERVER_VERSION");
         if (var != nullptr) {
-            ctx.bucket = var;
+            ctx.version = test_server_version::parse(var);
         }
         var = getenv("TEST_DEVELOPER_PREVIEW");
         if (var != nullptr) {


### PR DESCRIPTION
Motivation
==========
The diagnostics ping test is segfaulting.

Modification
============
Simply guarded against calling into it if null.   We can follow up later
and decide how to deal with it generally (like, use a noop_meter).

While there, fixed up some issues with building this inside another
project - CMAKE_SOURCE_DIR is the _outer_ source directory, so migrated
to PROJECT_SOURCE_DIR throughout.

Also a small issue with the test helpers.  Now, we can pass in the server version.  However,
I believe we may have an issue specifying DP, will follow up later on that.

Results
=======
passing tests.