### PR TITLE
add synchronous versions of open, close and open_bucket

### DIFF
--- a/test/test_helper_native.hxx
+++ b/test/test_helper_native.hxx
@@ -43,3 +43,36 @@ native_init_logger()
         initialized = true;
     }
 }
+
+std::error_code
+open_cluster(couchbase::cluster& cluster, const couchbase::origin& origin)
+{
+    auto barrier = std::make_shared<std::promise<std::error_code>>();
+    auto f = barrier->get_future();
+    cluster.open(origin, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
+    auto rc = f.get();
+    INFO(rc.message());
+    REQUIRE_FALSE(rc);
+    return rc;
+}
+
+void
+close_cluster(couchbase::cluster& cluster)
+{
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    cluster.close([barrier]() { barrier->set_value(); });
+    f.get();
+}
+
+std::error_code
+open_bucket(couchbase::cluster& cluster, const std::string& bucket_name)
+{
+    auto barrier = std::make_shared<std::promise<std::error_code>>();
+    auto f = barrier->get_future();
+    cluster.open_bucket(bucket_name, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
+    auto rc = f.get();
+    INFO(rc.message());
+    REQUIRE_FALSE(rc);
+    return rc;
+}

--- a/test/test_native_durability.cxx
+++ b/test/test_native_durability.cxx
@@ -38,22 +38,8 @@ TEST_CASE("native: durable operations", "[native]")
     couchbase::cluster cluster(io);
     auto io_thread = std::thread([&io]() { io.run(); });
 
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open(couchbase::origin(auth, connstr), [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open_bucket(ctx.bucket, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
+    open_cluster(cluster, couchbase::origin(auth, connstr));
+    open_bucket(cluster, ctx.bucket);
 
     couchbase::document_id id{ ctx.bucket, "_default._default", uniq_id("foo") };
     {

--- a/test/test_native_management.cxx
+++ b/test/test_native_management.cxx
@@ -40,22 +40,7 @@ TEST_CASE("native: bucket management", "[native]")
     couchbase::cluster cluster(io);
     auto io_thread = std::thread([&io]() { io.run(); });
 
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open(couchbase::origin(auth, connstr), [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open_bucket(ctx.bucket, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
+    open_cluster(cluster, couchbase::origin(auth, connstr));
 
     auto bucket_name = uniq_id("bucket");
 
@@ -108,12 +93,7 @@ TEST_CASE("native: bucket management", "[native]")
         REQUIRE(known_buckets == 0);
     }
 
-    {
-        auto barrier = std::make_shared<std::promise<void>>();
-        auto f = barrier->get_future();
-        cluster.close([barrier]() { barrier->set_value(); });
-        f.get();
-    }
+    close_cluster(cluster);
 
     io_thread.join();
 }

--- a/test/test_native_trivial_crud.cxx
+++ b/test/test_native_trivial_crud.cxx
@@ -38,22 +38,9 @@ TEST_CASE("native: upsert document into default collection", "[native]")
     couchbase::cluster cluster(io);
     auto io_thread = std::thread([&io]() { io.run(); });
 
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open(couchbase::origin(auth, connstr), [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
-    {
-        auto barrier = std::make_shared<std::promise<std::error_code>>();
-        auto f = barrier->get_future();
-        cluster.open_bucket(ctx.bucket, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
-        auto rc = f.get();
-        INFO(rc.message());
-        REQUIRE_FALSE(rc);
-    }
+    open_cluster(cluster, couchbase::origin(auth, connstr));
+    open_bucket(cluster, ctx.bucket);
+
     {
         couchbase::document_id id{ ctx.bucket, "_default._default", uniq_id("foo") };
         const tao::json::value value = {
@@ -72,12 +59,8 @@ TEST_CASE("native: upsert document into default collection", "[native]")
         INFO("seqno=" << resp.token.sequence_number);
         REQUIRE(resp.token.sequence_number != 0);
     }
-    {
-        auto barrier = std::make_shared<std::promise<void>>();
-        auto f = barrier->get_future();
-        cluster.close([barrier]() { barrier->set_value(); });
-        f.get();
-    }
+
+    close_cluster(cluster);
 
     io_thread.join();
 }


### PR DESCRIPTION
To reduce verbosity in the simplest cases, the cluster class implements
shortcuts that are waiting for completion internally