### PR TITLE
CXXCBC-18: support ErrorMap v2

### DIFF
--- a/couchbase/io/mcbp_session.hxx
+++ b/couchbase/io/mcbp_session.hxx
@@ -867,6 +867,7 @@ class mcbp_session : public std::enable_shared_from_this<mcbp_session>
             case protocol::status::invalid:
             case protocol::status::xattr_invalid:
             case protocol::status::subdoc_invalid_combo:
+            case protocol::status::subdoc_deleted_document_cannot_have_value:
                 return error::common_errc::invalid_argument;
 
             case protocol::status::delta_bad_value:
@@ -955,6 +956,7 @@ class mcbp_session : public std::enable_shared_from_this<mcbp_session>
                 return error::key_value_errc::xattr_invalid_key_combo;
 
             case protocol::status::subdoc_xattr_unknown_macro:
+            case protocol::status::subdoc_xattr_unknown_vattr_macro:
                 return error::key_value_errc::xattr_unknown_macro;
 
             case protocol::status::subdoc_xattr_unknown_vattr:
@@ -962,6 +964,16 @@ class mcbp_session : public std::enable_shared_from_this<mcbp_session>
 
             case protocol::status::subdoc_xattr_cannot_modify_vattr:
                 return error::key_value_errc::xattr_cannot_modify_virtual_attribute;
+
+            case protocol::status::subdoc_can_only_revive_deleted_documents:
+                return error::key_value_errc::cannot_revive_living_document;
+
+            case protocol::status::rate_limited_network_ingress:
+            case protocol::status::rate_limited_network_egress:
+            case protocol::status::rate_limited_max_connections:
+            case protocol::status::rate_limited_max_commands:
+            case protocol::status::scope_size_limit_exceeded:
+                return error::common_errc::rate_limiting_failure;
 
             case protocol::status::subdoc_invalid_xattr_order:
             case protocol::status::not_my_vbucket:
@@ -973,6 +985,8 @@ class mcbp_session : public std::enable_shared_from_this<mcbp_session>
             case protocol::status::cannot_apply_collections_manifest:
             case protocol::status::collections_manifest_is_ahead:
             case protocol::status::dcp_stream_id_invalid:
+            case protocol::status::dcp_stream_not_found:
+            case protocol::status::opaque_no_match:
                 break;
         }
         // FIXME: use error map here

--- a/couchbase/protocol/cmd_get_error_map.hxx
+++ b/couchbase/protocol/cmd_get_error_map.hxx
@@ -57,7 +57,7 @@ class get_error_map_request_body
     static const inline client_opcode opcode = client_opcode::get_error_map;
 
   private:
-    std::uint16_t version_{ 1 };
+    std::uint16_t version_{ 2 };
     std::vector<std::uint8_t> value_;
 
   public:

--- a/couchbase/protocol/cmd_mutate_in.hxx
+++ b/couchbase/protocol/cmd_mutate_in.hxx
@@ -105,11 +105,18 @@ class mutate_in_request_body
     static const inline uint8_t doc_flag_access_deleted = 0b0000'0100;
 
     /**
-     * Used with `doc_flag_mkdoc` / `doc_flag_add`; if the document does not exist then creat
+     * Used with `doc_flag_mkdoc` / `doc_flag_add`; if the document does not exist then create
      * it in the "Deleted" state, instead of the normal "Alive" state.
      * Not valid unless `doc_flag_mkdoc` or `doc_flag_add` specified.
      */
     static const inline uint8_t doc_flag_create_as_deleted = 0b0000'1000;
+
+    /**
+     * If the document exists and isn't deleted the operation will fail with .
+     * If the input document _is_ deleted the result of the operation will store the
+     * document as a "live" document instead of a deleted document.
+     */
+    static const inline uint8_t doc_flag_revive_document = 0b0001'0000;
 
     struct mutate_in_specs {
         /**

--- a/couchbase/protocol/status.hxx
+++ b/couchbase/protocol/status.hxx
@@ -31,6 +31,8 @@ enum class status : std::uint16_t {
     delta_bad_value = 0x06,
     not_my_vbucket = 0x07,
     no_bucket = 0x08,
+    dcp_stream_not_found = 0x0a,
+    opaque_no_match = 0x0b,
     locked = 0x09,
     auth_stale = 0x1f,
     auth_error = 0x20,
@@ -39,6 +41,11 @@ enum class status : std::uint16_t {
     rollback = 0x23,
     no_access = 0x24,
     not_initialized = 0x25,
+    rate_limited_network_ingress = 0x30,
+    rate_limited_network_egress = 0x31,
+    rate_limited_max_connections = 0x32,
+    rate_limited_max_commands = 0x33,
+    scope_size_limit_exceeded = 0x34,
     unknown_frame_info = 0x80,
     unknown_command = 0x81,
     no_memory = 0x82,
@@ -79,6 +86,9 @@ enum class status : std::uint16_t {
     subdoc_xattr_cannot_modify_vattr = 0xd2,
     subdoc_multi_path_failure_deleted = 0xd3,
     subdoc_invalid_xattr_order = 0xd4,
+    subdoc_xattr_unknown_vattr_macro = 0xd5,
+    subdoc_can_only_revive_deleted_documents = 0xd6,
+    subdoc_deleted_document_cannot_have_value = 0xd7,
 };
 
 constexpr bool
@@ -142,6 +152,16 @@ is_valid_status(uint16_t code)
         case status::subdoc_xattr_cannot_modify_vattr:
         case status::subdoc_multi_path_failure_deleted:
         case status::subdoc_invalid_xattr_order:
+        case status::dcp_stream_not_found:
+        case status::opaque_no_match:
+        case status::rate_limited_network_ingress:
+        case status::rate_limited_network_egress:
+        case status::rate_limited_max_connections:
+        case status::rate_limited_max_commands:
+        case status::scope_size_limit_exceeded:
+        case status::subdoc_xattr_unknown_vattr_macro:
+        case status::subdoc_can_only_revive_deleted_documents:
+        case status::subdoc_deleted_document_cannot_have_value:
             return true;
     }
     return false;
@@ -329,6 +349,36 @@ struct fmt::formatter<couchbase::protocol::status> : formatter<string_view> {
                 break;
             case couchbase::protocol::status::subdoc_invalid_xattr_order:
                 name = "subdoc_invalid_xattr_order (0xd4)";
+                break;
+            case couchbase::protocol::status::dcp_stream_not_found:
+                name = "dcp_stream_not_found (0x0a)";
+                break;
+            case couchbase::protocol::status::opaque_no_match:
+                name = "opaque_no_match (0x0b)";
+                break;
+            case couchbase::protocol::status::rate_limited_network_ingress:
+                name = "rate_limited_network_ingress (0x30)";
+                break;
+            case couchbase::protocol::status::rate_limited_network_egress:
+                name = "opaque_no_match (0x31)";
+                break;
+            case couchbase::protocol::status::rate_limited_max_connections:
+                name = "rate_limited_max_connections (0x32)";
+                break;
+            case couchbase::protocol::status::rate_limited_max_commands:
+                name = "rate_limited_max_commands (0x33)";
+                break;
+            case couchbase::protocol::status::scope_size_limit_exceeded:
+                name = "scope_size_limit_exceeded (0x34)";
+                break;
+            case couchbase::protocol::status::subdoc_xattr_unknown_vattr_macro:
+                name = "subdoc_xattr_unknown_vattr_macro (0xd5)";
+                break;
+            case couchbase::protocol::status::subdoc_can_only_revive_deleted_documents:
+                name = "subdoc_can_only_revive_deleted_documents (0xd6)";
+                break;
+            case couchbase::protocol::status::subdoc_deleted_document_cannot_have_value:
+                name = "subdoc_deleted_document_cannot_have_value (0xd7)";
                 break;
         }
         return formatter<string_view>::format(name, ctx);

--- a/couchbase/topology/error_map.hxx
+++ b/couchbase/topology/error_map.hxx
@@ -25,10 +25,14 @@
 namespace couchbase
 {
 struct error_map {
+    /**
+     * This enum defines known attributes, that could be associated with the error code in the error map.
+     * Complete list could be found at https://github.com/couchbase/kv_engine/blob/master/docs/ErrorMap.md#error-attributes.
+     */
     enum class attribute {
         /**
-         * The operation was successful for those situations where the error code is indicating successful (i.e. subdoc operations carried
-         * out on a deleted document)
+         * The operation was successful for those situations where the error code is indicating successful (i.e. subdocument operations
+         * carried out on a deleted document)
          */
         success,
 
@@ -109,7 +113,7 @@ struct error_map {
         auto_retry,
 
         /**
-         * This attribute specifies that the requested item is currently locked.
+         * This attribute means that the error is related to operating on a locked document.
          */
         item_locked,
 
@@ -117,6 +121,11 @@ struct error_map {
          * This attribute means that the error is related to operating on a soft-deleted document.
          */
         item_deleted,
+
+        /**
+         * The error is related to rate limitation for the client (version 2)
+         */
+        rate_limit,
     };
 
     struct error_info {
@@ -195,6 +204,9 @@ struct fmt::formatter<couchbase::error_map::attribute> : formatter<string_view> 
                 break;
             case couchbase::error_map::attribute::item_deleted:
                 name = "item-deleted";
+                break;
+            case couchbase::error_map::attribute::rate_limit:
+                name = "rate-limit";
                 break;
         }
         return formatter<string_view>::format(name, ctx);


### PR DESCRIPTION
* sync protocol errors with current server implementation
* update doc strings for attributes using server docs
* add new rate-limit attribute

C++ SDK does not enforce strict check for unknown attributes as libcouchbase does, so no need extra work there