### PR TITLE
Fix tests running against older server versions

### DIFF
--- a/test/test_helper.hxx
+++ b/test/test_helper.hxx
@@ -81,6 +81,11 @@ struct test_server_version {
         return is_mad_hatter() || is_cheshire_cat();
     }
 
+    [[nodiscard]] bool supports_enhanced_durability() const
+    {
+        return is_mad_hatter() || is_cheshire_cat();
+    }
+
     [[nodiscard]] bool supports_scoped_queries() const
     {
         return is_cheshire_cat();

--- a/test/test_native_durability.cxx
+++ b/test/test_native_durability.cxx
@@ -28,6 +28,10 @@ TEST_CASE("native: durable operations", "[native]")
     auto ctx = test_context::load_from_environment();
     native_init_logger();
 
+    if (!ctx.version.supports_enhanced_durability()) {
+        return;
+    }
+
     auto connstr = couchbase::utils::parse_connection_string(ctx.connection_string);
     couchbase::cluster_credentials auth{};
     auth.username = ctx.username;

--- a/test/test_native_trivial_query.cxx
+++ b/test/test_native_trivial_query.cxx
@@ -33,7 +33,9 @@ TEST_CASE("native: trivial non-data query", "[native]")
     auto io_thread = std::thread([&io]() { io.run(); });
 
     open_cluster(cluster, couchbase::origin(auth, connstr));
-    open_bucket(cluster, ctx.bucket);
+    if (!ctx.version.supports_gcccp()) {
+        open_bucket(cluster, ctx.bucket);
+    }
 
     {
         couchbase::operations::query_request req{ R"(SELECT "ruby rules" AS greeting)" };


### PR DESCRIPTION
- Skip durability tests on version < 6.5.
- We only need to open a bucket for query tests if the server doesn't support gcccp.