### PR TITLE
Fix flaky bucket management test

### DIFF
--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -37,6 +37,15 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
 
     {
+        auto created = test::utils::wait_until([&integration, bucket_name]() {
+            couchbase::operations::management::bucket_get_request req{ bucket_name };
+            auto resp = test::utils::execute(integration.cluster, req);
+            return !resp.ctx.ec;
+        });
+        REQUIRE(created);
+    }
+
+    {
         couchbase::operations::management::bucket_get_all_request req;
         auto resp = test::utils::execute(integration.cluster, req);
         REQUIRE_FALSE(resp.ctx.ec);
@@ -50,6 +59,15 @@ TEST_CASE("integration: bucket management", "[integration]")
         couchbase::operations::management::bucket_drop_request req{ bucket_name };
         auto resp = test::utils::execute(integration.cluster, req);
         REQUIRE_FALSE(resp.ctx.ec);
+    }
+
+    {
+        auto dropped = test::utils::wait_until([&integration, bucket_name]() {
+            couchbase::operations::management::bucket_get_request req{ bucket_name };
+            auto resp = test::utils::execute(integration.cluster, req);
+            return resp.ctx.ec == couchbase::error::common_errc::bucket_not_found;
+        });
+        REQUIRE(dropped);
     }
 
     {

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(
   logger.cxx
   server_version.cxx
   test_context.cxx
-  uniq_id.cxx)
+  uniq_id.cxx
+  wait_until.cxx)
 set_target_properties(test_utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(test_utils PRIVATE project_options project_warnings)
 target_include_directories(test_utils PRIVATE ${PROJECT_SOURCE_DIR})

--- a/test/utils/wait_until.hxx
+++ b/test/utils/wait_until.hxx
@@ -1,0 +1,57 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "server_version.hxx"
+#include <couchbase/cluster.hxx>
+#include <couchbase/operations/management/bucket.hxx>
+#include "integration_shortcuts.hxx"
+
+namespace test::utils
+{
+template<class ConditionChecker>
+bool
+wait_until(ConditionChecker&& condition_checker, std::chrono::milliseconds timeout, std::chrono::milliseconds delay)
+{
+    const auto start = std::chrono::high_resolution_clock::now();
+    while (!condition_checker()) {
+        if (std::chrono::high_resolution_clock::now() > start + timeout) {
+            return false;
+        }
+        std::this_thread::sleep_for(delay);
+    }
+    return true;
+}
+
+template<class ConditionChecker>
+bool
+wait_until(ConditionChecker&& condition_checker, std::chrono::milliseconds timeout)
+{
+    return wait_until(condition_checker, timeout, std::chrono::milliseconds(100));
+}
+
+template<class ConditionChecker>
+bool
+wait_until(ConditionChecker&& condition_checker)
+{
+    return wait_until(condition_checker, std::chrono::minutes(1));
+}
+
+bool
+wait_until_bucket_healthy(couchbase::cluster& cluster, const std::string& bucket_name);
+} // namespace test::utils


### PR DESCRIPTION
Add test helpers that wait for an arbitrary condition
Add test helper that waits for a bucket to become healthy