### PR TITLE
add missing header

### DIFF
--- a/couchbase/topology/configuration.hxx
+++ b/couchbase/topology/configuration.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
gcc 11 complains that `<optional>` is not included yet in `configuration.hxx`