### PR TITLE
SDKQE-2495: Temporarily add sleep after scope and collection changes

### DIFF
--- a/test/test_integration_collections.cxx
+++ b/test/test_integration_collections.cxx
@@ -99,11 +99,8 @@ TEST_CASE("integration: get and insert non default scope and collection", "[inte
         current_manifest_uid = resp.uid;
     }
 
-    auto created = test::utils::wait_until([&integration, current_manifest_uid]() {
-        couchbase::operations::management::collections_manifest_get_request req{ { integration.ctx.bucket, "_default", "_default", "" } };
-        auto resp = test::utils::execute(integration.cluster, req);
-        return resp.manifest.uid >= current_manifest_uid;
-    });
+    auto created =
+      test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, current_manifest_uid);
     REQUIRE(created);
 
     {
@@ -148,11 +145,8 @@ TEST_CASE("integration: insert into dropped scope", "[integration]")
         current_manifest_uid = resp.uid;
     }
 
-    auto created = test::utils::wait_until([&integration, current_manifest_uid]() {
-        couchbase::operations::management::collections_manifest_get_request req{ { integration.ctx.bucket, "_default", "_default", "" } };
-        auto resp = test::utils::execute(integration.cluster, req);
-        return resp.manifest.uid >= current_manifest_uid;
-    });
+    auto created =
+      test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, current_manifest_uid);
     REQUIRE(created);
 
     {
@@ -175,11 +169,8 @@ TEST_CASE("integration: insert into dropped scope", "[integration]")
         REQUIRE_FALSE(resp.ctx.ec);
     }
 
-    auto dropped = test::utils::wait_until([&integration, current_manifest_uid]() {
-        couchbase::operations::management::collections_manifest_get_request req{ { integration.ctx.bucket, "_default", "_default", "" } };
-        auto resp = test::utils::execute(integration.cluster, req);
-        return resp.manifest.uid >= current_manifest_uid;
-    });
+    auto dropped =
+      test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, current_manifest_uid);
     REQUIRE(dropped);
 
     {

--- a/test/utils/wait_until.hxx
+++ b/test/utils/wait_until.hxx
@@ -20,6 +20,7 @@
 #include "server_version.hxx"
 #include <couchbase/cluster.hxx>
 #include <couchbase/operations/management/bucket.hxx>
+#include <couchbase/operations/management/collections.hxx>
 #include "integration_shortcuts.hxx"
 
 namespace test::utils
@@ -54,4 +55,9 @@ wait_until(ConditionChecker&& condition_checker)
 
 bool
 wait_until_bucket_healthy(couchbase::cluster& cluster, const std::string& bucket_name);
+
+bool
+wait_until_collection_manifest_propagated(couchbase::cluster& cluster,
+                                          const std::string& bucket_name,
+                                          const std::uint64_t current_manifest_uid);
 } // namespace test::utils


### PR DESCRIPTION
The collection manifest can be partially propagated in a multi node cluster. Until all nodes can be checked, add a sleep after create/drop