### PR TITLE
fix snappy compression of the value

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(utils)
 
 integration_test(management)
-integration_test(trivial_crud)
+integration_test(crud)
 integration_test(trivial_query)
 integration_test(diagnostics)
 integration_test(binary_operations)


### PR DESCRIPTION
When the value was compressed, the body length and datatype fields were
not updated because of non-reference argument. The patch improves API a
bit, and modification of the packet done by the caller now.