### PR TITLE
Fix live cluster version parse

### DIFF
--- a/test/utils/server_version.cxx
+++ b/test/utils/server_version.cxx
@@ -24,7 +24,7 @@ namespace test::utils
 server_version
 server_version::parse(const std::string& str)
 {
-    std::regex version_regex(R"((\d+).(\d+).(\d+(-(\d+))?)?)");
+    std::regex version_regex(R"((\d+).(\d+).(\d+)(-(\d+))?(-(.+))?)");
     std::smatch version_match{};
     server_version ver{};
     if (std::regex_match(str, version_match, version_regex) && version_match.ready()) {
@@ -34,6 +34,13 @@ server_version::parse(const std::string& str)
             ver.micro = std::stoul(version_match[3]);
             if (version_match.length(5) > 0) {
                 ver.build = std::stoul(version_match[5]);
+                if (version_match.length(7) > 0) {
+                    if (version_match[7] == "enterprise") {
+                        ver.edition = server_edition::enterprise;
+                    } else if (version_match[7] == "community") {
+                        ver.edition = server_edition::community;
+                    }
+                }
             }
         }
     } else {

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -22,12 +22,16 @@
 
 namespace test::utils
 {
+
+enum class server_edition { unknown, enterprise, community };
+
 struct server_version {
     unsigned long major{ 0 };
     unsigned long minor{ 0 };
     unsigned long micro{ 0 };
     unsigned long build{ 0 };
     bool developer_preview{ false };
+    server_edition edition{ server_edition::unknown };
 
     static server_version parse(const std::string& str);
 
@@ -52,7 +56,7 @@ struct server_version {
     [[nodiscard]] bool is_neo() const
     {
         // [7.1.0, inf)
-        return major >= 7 && minor >= 1;
+        return (major == 7 && minor >= 1) || major > 7;
     }
 
     [[nodiscard]] bool supports_gcccp() const


### PR DESCRIPTION
Cluster version appends -edition. Account for this and parse it so we can test community edition
Fix neo version to apply to all future versions