### PR TITLE
SDKQE-2432: Support for Multiple Root Certs testing

### DIFF
--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -27,8 +27,13 @@ integration_test_guard::integration_test_guard()
     init_logger();
     auto connstr = couchbase::utils::parse_connection_string(ctx.connection_string);
     couchbase::cluster_credentials auth{};
-    auth.username = ctx.username;
-    auth.password = ctx.password;
+    if (!ctx.certificate_path.empty()) {
+        auth.certificate_path = ctx.certificate_path;
+        auth.key_path = ctx.key_path;
+    } else {
+        auth.username = ctx.username;
+        auth.password = ctx.password;
+    }
     io_thread = std::thread([this]() { io.run(); });
     origin = couchbase::origin(auth, connstr);
     open_cluster(cluster, origin);

--- a/test/utils/test_context.cxx
+++ b/test/utils/test_context.cxx
@@ -40,6 +40,14 @@ test_context::load_from_environment()
     if (var != nullptr) {
         ctx.password = var;
     }
+    var = getenv("TEST_CERTIFICATE_PATH");
+    if (var != nullptr) {
+        ctx.certificate_path = var;
+    }
+    var = getenv("TEST_KEY_PATH");
+    if (var != nullptr) {
+        ctx.key_path = var;
+    }
     var = getenv("TEST_BUCKET");
     if (var != nullptr) {
         ctx.bucket = var;

--- a/test/utils/test_context.hxx
+++ b/test/utils/test_context.hxx
@@ -27,6 +27,8 @@ struct test_context {
     std::string connection_string{ "couchbase://127.0.0.1" };
     std::string username{ "Administrator" };
     std::string password{ "password" };
+    std::string certificate_path{};
+    std::string key_path{};
     std::string bucket{ "default" };
     server_version version{ 6, 6, 0 };
 


### PR DESCRIPTION
Allow passing in a certificate and key path for cert auth testing