### PR TITLE
CXXCBC-54 Add log forwarding

### DIFF
--- a/couchbase/logger/configuration.hxx
+++ b/couchbase/logger/configuration.hxx
@@ -47,6 +47,11 @@ struct configuration {
      * The default log level to initialize the logger to
      */
     level log_level{ level::info };
+
+    /**
+     * Custom sink to use, if desired
+     */
+    std::shared_ptr<spdlog::sinks::sink> sink{ nullptr };
 };
 
 } // namespace couchbase::logger

--- a/couchbase/logger/logger.cxx
+++ b/couchbase/logger/logger.cxx
@@ -211,6 +211,10 @@ create_file_logger(const configuration& logger_settings)
             }
             sink->add_sink(stderrsink);
         }
+        if (nullptr != logger_settings.sink) {
+            logger_settings.sink->set_pattern(log_pattern);
+            sink->add_sink(logger_settings.sink);
+        }
 
         spdlog::drop(logger_name);
 


### PR DESCRIPTION
Motivation
==========
When the client is used in the sdk wrappers (python, node, etc...), it
would be nice to allow the logging to be forwarded to the wrapper's
logging handlers.

Modification
============
Simplest thing to do is add a spdlog::sinks::sink to the logger
configuration.  If it is set, we add it.   Then the wrappers can
implement a sink that does the handoff.

Results
=======
I didn't add tests, as there are no logging tests anyways.  I did for
the transactions logging, and I've used this in python.