### PR TITLE
CXXCBC-134: Close http_session before conecting to next endpoint

### DIFF
--- a/couchbase/io/http_session.hxx
+++ b/couchbase/io/http_session.hxx
@@ -397,7 +397,11 @@ class http_session : public std::enable_shared_from_this<http_session>
                         it->endpoint().port(),
                         ec.message(),
                         (ec == asio::error::connection_refused) ? ", check server ports and cluster encryption setting" : "");
-            do_connect(++it);
+            if (stream_->is_open()) {
+                stream_->close(std::bind(&http_session::do_connect, shared_from_this(), ++it));
+            } else {
+                do_connect(++it);
+            }
         } else {
             state_ = diag::endpoint_state::connected;
             connected_ = true;


### PR DESCRIPTION
We fixed this for mcbp_session in #151. Do the same for http_session