### PR TITLE
SDKQE-2716: Skip analytics tests in 6.0

### DIFF
--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -114,7 +114,7 @@ struct server_version {
 
     [[nodiscard]] bool supports_analytics() const
     {
-        return is_enterprise() && (is_alice() || is_mad_hatter() || is_cheshire_cat() || is_neo());
+        return is_enterprise() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
     }
 
     [[nodiscard]] bool supports_analytics_pending_mutations() const


### PR DESCRIPTION
The analytics service was introduced in 6.0 so there are likely bugs that are causing test failures. The failures do not occur on any later version so it is safe to disable this