### PR TITLE
CXXCBC-55: External Tracing and Metrics support

### DIFF
--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -70,15 +70,26 @@ class cluster : public std::enable_shared_from_this<cluster>
         }
 
         origin_ = origin;
-        if (origin_.options().enable_tracing) {
-            tracer_ = std::make_shared<tracing::threshold_logging_tracer>(ctx_, origin.options().tracing_options);
+        // ignore the enable_tracing flag if a tracer was passed in
+        if (nullptr != origin_.options().tracer) {
+            tracer_ = origin_.options().tracer;
         } else {
-            tracer_ = std::make_shared<tracing::noop_tracer>();
+            if (origin_.options().enable_tracing) {
+                tracer_ = std::make_shared<tracing::threshold_logging_tracer>(ctx_, origin.options().tracing_options);
+            } else {
+                tracer_ = std::make_shared<tracing::noop_tracer>();
+            }
         }
-        if (origin_.options().enable_metrics) {
-            meter_ = std::make_shared<metrics::logging_meter>(ctx_, origin.options().metrics_options);
+        // ignore the metrics options if a meter was passed in.
+        if (nullptr != origin_.options().meter) {
+            meter_ = origin_.options().meter;
         } else {
-            meter_ = std::make_shared<metrics::noop_meter>();
+
+            if (origin_.options().enable_metrics) {
+                meter_ = std::make_shared<metrics::logging_meter>(ctx_, origin.options().metrics_options);
+            } else {
+                meter_ = std::make_shared<metrics::noop_meter>();
+            }
         }
         session_manager_->set_tracer(tracer_);
         if (origin_.options().enable_dns_srv) {

--- a/couchbase/cluster_options.hxx
+++ b/couchbase/cluster_options.hxx
@@ -19,8 +19,10 @@
 
 #include <couchbase/io/ip_protocol.hxx>
 #include <couchbase/metrics/logging_meter_options.hxx>
+#include <couchbase/metrics/meter.hxx>
 #include <couchbase/service_type.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 #include <couchbase/tracing/threshold_logging_options.hxx>
 
 #include <chrono>
@@ -62,6 +64,8 @@ struct cluster_options {
     tracing::threshold_logging_options tracing_options{};
     metrics::logging_meter_options metrics_options{};
     tls_verify_mode tls_verify{ tls_verify_mode::peer };
+    std::shared_ptr<tracing::request_tracer> tracer{ nullptr };
+    std::shared_ptr<metrics::meter> meter{ nullptr };
 
     std::chrono::milliseconds tcp_keep_alive_interval = timeout_defaults::tcp_keep_alive_interval;
     std::chrono::milliseconds config_poll_interval = timeout_defaults::config_poll_interval;

--- a/couchbase/io/http_traits.hxx
+++ b/couchbase/io/http_traits.hxx
@@ -27,4 +27,12 @@ struct supports_sticky_node : public std::false_type {
 
 template<typename T>
 inline constexpr bool supports_sticky_node_v = supports_sticky_node<T>::value;
+
+template<typename T>
+struct supports_parent_span : public std::false_type {
+};
+
+template<typename T>
+inline constexpr bool supports_parent_span_v = supports_parent_span<T>::value;
+
 } // namespace couchbase::io::http_traits

--- a/couchbase/io/mcbp_traits.hxx
+++ b/couchbase/io/mcbp_traits.hxx
@@ -27,4 +27,12 @@ struct supports_durability : public std::false_type {
 
 template<typename T>
 inline constexpr bool supports_durability_v = supports_durability<T>::value;
+
+template<typename T>
+struct supports_parent_span : public std::false_type {
+};
+
+template<typename T>
+inline constexpr bool supports_parent_span_v = supports_parent_span<T>::value;
+
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_analytics.hxx
+++ b/couchbase/operations/document_analytics.hxx
@@ -21,6 +21,7 @@
 #include <couchbase/error_context/analytics.hxx>
 #include <couchbase/io/http_context.hxx>
 #include <couchbase/io/http_message.hxx>
+#include <couchbase/io/http_traits.hxx>
 #include <couchbase/json_string.hxx>
 #include <couchbase/platform/uuid.h>
 #include <couchbase/timeout_defaults.hxx>
@@ -100,6 +101,13 @@ struct analytics_request {
     [[nodiscard]] analytics_response make_response(error_context::analytics&& ctx, const encoded_response_type& encoded) const;
 
     std::string body_str{};
+    std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 };
 
 } // namespace couchbase::operations
+namespace couchbase::io::http_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::analytics_request> : public std::true_type {
+};
+} // namespace couchbase::io::http_traits

--- a/couchbase/operations/document_append.hxx
+++ b/couchbase/operations/document_append.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_append.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -47,6 +48,7 @@ struct append_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -59,5 +61,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::append_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::append_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_decrement.hxx
+++ b/couchbase/operations/document_decrement.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_decrement.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -50,6 +51,7 @@ struct decrement_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -62,5 +64,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::decrement_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::decrement_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_exists.hxx
+++ b/couchbase/operations/document_exists.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_get_meta.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -52,6 +54,7 @@ struct exists_request {
     std::uint32_t opaque{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -59,3 +62,10 @@ struct exists_request {
 };
 
 } // namespace couchbase::operations
+
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::exists_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_get.hxx
+++ b/couchbase/operations/document_get.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_get.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -44,10 +46,17 @@ struct get_request {
     std::uint32_t opaque{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ true };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
     [[nodiscard]] get_response make_response(error_context::key_value&& ctx, const encoded_response_type& encoded) const;
 };
-
 } // namespace couchbase::operations
+
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::get_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_get_and_lock.hxx
+++ b/couchbase/operations/document_get_and_lock.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_get_and_lock.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -45,6 +47,7 @@ struct get_and_lock_request {
     std::uint32_t lock_time{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -52,3 +55,10 @@ struct get_and_lock_request {
 };
 
 } // namespace couchbase::operations
+
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::get_and_lock_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_get_and_touch.hxx
+++ b/couchbase/operations/document_get_and_touch.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_get_and_touch.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -45,6 +47,7 @@ struct get_and_touch_request {
     uint32_t expiry{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -52,3 +55,10 @@ struct get_and_touch_request {
 };
 
 } // namespace couchbase::operations
+
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::get_and_touch_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_get_projected.hxx
+++ b/couchbase/operations/document_get_projected.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_lookup_in.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -49,6 +51,7 @@ struct get_projected_request {
     bool preserve_array_indexes{ false };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ true };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
 
@@ -56,3 +59,10 @@ struct get_projected_request {
 };
 
 } // namespace couchbase::operations
+
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::get_projected_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_increment.hxx
+++ b/couchbase/operations/document_increment.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_increment.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -50,6 +51,7 @@ struct increment_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -62,5 +64,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::increment_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::increment_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_insert.hxx
+++ b/couchbase/operations/document_insert.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_insert.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -49,6 +50,7 @@ struct insert_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -61,5 +63,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::insert_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::insert_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_lookup_in.hxx
+++ b/couchbase/operations/document_lookup_in.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_lookup_in.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -55,6 +57,7 @@ struct lookup_in_request {
     protocol::lookup_in_request_body::lookup_in_specs specs{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
 
@@ -62,3 +65,10 @@ struct lookup_in_request {
 };
 
 } // namespace couchbase::operations
+namespace couchbase::io::mcbp_traits
+{
+
+template<>
+struct supports_parent_span<couchbase::operations::lookup_in_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_mutate_in.hxx
+++ b/couchbase/operations/document_mutate_in.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_mutate_in.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -66,6 +67,7 @@ struct mutate_in_request {
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
     bool preserve_expiry{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
 
@@ -78,5 +80,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::mutate_in_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::mutate_in_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_prepend.hxx
+++ b/couchbase/operations/document_prepend.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_prepend.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -47,6 +48,7 @@ struct prepend_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -59,5 +61,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::prepend_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::prepend_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_query.hxx
+++ b/couchbase/operations/document_query.hxx
@@ -111,6 +111,7 @@ struct query_request {
     std::optional<http_context> ctx_{};
     bool extract_encoded_plan_{ false };
     std::string body_str{};
+    std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 };
 
 } // namespace couchbase::operations
@@ -119,5 +120,9 @@ namespace couchbase::io::http_traits
 {
 template<>
 struct supports_sticky_node<couchbase::operations::query_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::query_request> : public std::true_type {
 };
 } // namespace couchbase::io::http_traits

--- a/couchbase/operations/document_remove.hxx
+++ b/couchbase/operations/document_remove.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_remove.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -47,6 +48,7 @@ struct remove_request {
     protocol::durability_level durability_level{ protocol::durability_level::none };
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -59,5 +61,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::remove_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::remove_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_replace.hxx
+++ b/couchbase/operations/document_replace.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_replace.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -51,6 +52,7 @@ struct replace_request {
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
     bool preserve_expiry{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -63,5 +65,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::replace_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::replace_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_search.hxx
+++ b/couchbase/operations/document_search.hxx
@@ -20,6 +20,7 @@
 #include <couchbase/error_context/search.hxx>
 #include <couchbase/io/http_context.hxx>
 #include <couchbase/io/http_message.hxx>
+#include <couchbase/io/http_traits.hxx>
 #include <couchbase/json_string.hxx>
 #include <couchbase/mutation_token.hxx>
 #include <couchbase/platform/uuid.h>
@@ -148,6 +149,14 @@ struct search_request {
     [[nodiscard]] search_response make_response(error_context::search&& ctx, const encoded_response_type& encoded) const;
 
     std::string body_str{};
+
+    std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 };
 
 } // namespace couchbase::operations
+namespace couchbase::io::http_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::search_request> : public std::true_type {
+};
+} // namespace couchbase::io::http_traits

--- a/couchbase/operations/document_touch.hxx
+++ b/couchbase/operations/document_touch.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_touch.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -43,6 +45,7 @@ struct touch_request {
     std::uint32_t expiry{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -50,3 +53,9 @@ struct touch_request {
 };
 
 } // namespace couchbase::operations
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::touch_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_unlock.hxx
+++ b/couchbase/operations/document_unlock.hxx
@@ -19,10 +19,12 @@
 
 #include <couchbase/error_context/key_value.hxx>
 #include <couchbase/io/mcbp_context.hxx>
+#include <couchbase/io/mcbp_traits.hxx>
 #include <couchbase/io/retry_context.hxx>
 #include <couchbase/protocol/client_request.hxx>
 #include <couchbase/protocol/cmd_unlock.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -43,6 +45,7 @@ struct unlock_request {
     couchbase::cas cas{};
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -50,3 +53,9 @@ struct unlock_request {
 };
 
 } // namespace couchbase::operations
+namespace couchbase::io::mcbp_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::unlock_request> : public std::true_type {
+};
+} // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_upsert.hxx
+++ b/couchbase/operations/document_upsert.hxx
@@ -25,6 +25,7 @@
 #include <couchbase/protocol/cmd_upsert.hxx>
 #include <couchbase/protocol/durability_level.hxx>
 #include <couchbase/timeout_defaults.hxx>
+#include <couchbase/tracing/request_tracer.hxx>
 
 namespace couchbase::operations
 {
@@ -50,6 +51,7 @@ struct upsert_request {
     std::optional<std::chrono::milliseconds> timeout{};
     io::retry_context<io::retry_strategy::best_effort> retries{ false };
     bool preserve_expiry{ false };
+    std::shared_ptr<tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context) const;
 
@@ -62,5 +64,9 @@ namespace couchbase::io::mcbp_traits
 {
 template<>
 struct supports_durability<couchbase::operations::upsert_request> : public std::true_type {
+};
+
+template<>
+struct supports_parent_span<couchbase::operations::upsert_request> : public std::true_type {
 };
 } // namespace couchbase::io::mcbp_traits

--- a/couchbase/operations/document_view.hxx
+++ b/couchbase/operations/document_view.hxx
@@ -21,6 +21,7 @@
 #include <couchbase/error_context/view.hxx>
 #include <couchbase/io/http_context.hxx>
 #include <couchbase/io/http_message.hxx>
+#include <couchbase/io/http_traits.hxx>
 #include <couchbase/platform/uuid.h>
 #include <couchbase/timeout_defaults.hxx>
 #include <couchbase/view_scan_consistency.hxx>
@@ -89,6 +90,7 @@ struct document_view_request {
     std::optional<std::function<utils::json::stream_control(std::string)>> row_callback{};
     std::optional<std::string> client_context_id{};
     std::optional<std::chrono::milliseconds> timeout{};
+    std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
 
@@ -96,3 +98,10 @@ struct document_view_request {
 };
 
 } // namespace couchbase::operations
+
+namespace couchbase::io::http_traits
+{
+template<>
+struct supports_parent_span<couchbase::operations::document_view_request> : public std::true_type {
+};
+} // namespace couchbase::io::http_traits

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,8 @@ integration_test(collections)
 integration_test(subdoc)
 integration_test(analytics)
 integration_test(read_replica)
+integration_test(tracer)
+integration_test(meter)
 
 unit_test(connection_string)
 unit_test(utils)

--- a/test/test_integration_meter.cxx
+++ b/test/test_integration_meter.cxx
@@ -1,0 +1,179 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+#include <couchbase/platform/uuid.h>
+
+class test_value_recorder : public couchbase::metrics::value_recorder
+{
+  public:
+    test_value_recorder(const std::string& name, const std::map<std::string, std::string>& tags)
+      : name_(name)
+      , tags_(tags)
+    {
+    }
+    void record_value(std::int64_t value) override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_.emplace_back(value);
+    }
+    std::map<std::string, std::string> tags() const
+    {
+        return tags_;
+    }
+    std::list<std::uint64_t> values()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return values_;
+    }
+    void reset()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_.clear();
+    }
+
+  private:
+    std::string name_;
+    std::map<std::string, std::string> tags_;
+    std::mutex mutex_;
+    std::list<std::uint64_t> values_;
+};
+
+class test_meter : public couchbase::metrics::meter
+{
+  public:
+    test_meter()
+      : couchbase::metrics::meter()
+    {
+    }
+    std::shared_ptr<couchbase::metrics::value_recorder> get_value_recorder(const std::string& name,
+                                                                           const std::map<std::string, std::string>& tags) override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = value_recorders_.equal_range(name);
+        if (it.first != it.second) {
+
+            for (auto itr = it.first; itr != it.second; itr++) {
+                if (tags == itr->second->tags())
+                    return itr->second;
+            }
+        }
+        return value_recorders_.insert({ name, std::make_shared<test_value_recorder>(name, tags) })->second;
+    }
+
+    void reset()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto v : value_recorders_) {
+            v.second->reset();
+        }
+    }
+    std::list<std::shared_ptr<test_value_recorder>> get_recorders(const std::string& name)
+    {
+        std::list<std::shared_ptr<test_value_recorder>> retval;
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = value_recorders_.equal_range(name);
+        for (auto itr = it.first; itr != it.second; itr++) {
+            retval.push_back(itr->second);
+        }
+        return retval;
+    }
+
+  private:
+    std::multimap<std::string, std::shared_ptr<test_value_recorder>> value_recorders_;
+    std::mutex mutex_;
+};
+
+void
+assert_kv_recorder_tags(std::list<std::shared_ptr<test_value_recorder>> recorders, const std::string& op)
+{
+    // you'd expect one of these (only one) to have a matching op
+    REQUIRE(recorders.size() == 1);
+    REQUIRE(recorders.front()->tags()["db.couchbase.service"] == "kv");
+    // db.operation always _starts_ with the op -- like '<op> 0x<NN'
+    REQUIRE(recorders.front()->tags()["db.operation"].find(op, 0) == 0);
+}
+
+couchbase::document_id
+make_id(const test::utils::test_context& ctx, std::string key = "")
+{
+    if (key.empty()) {
+        key = test::utils::uniq_id("tracer");
+    }
+    return couchbase::document_id{ ctx.bucket, "_default", "_default", key };
+}
+
+TEST_CASE("integration: use external meter", "[integration]")
+{
+    couchbase::cluster_options opts{};
+    auto meter = std::make_shared<test_meter>();
+    opts.meter = meter;
+    test::utils::integration_test_guard guard(opts);
+    test::utils::open_bucket(guard.cluster, guard.ctx.bucket);
+    auto value = couchbase::utils::to_binary("{\"some\": \"thing\"");
+    auto existing_id = make_id(guard.ctx, "foo");
+    SECTION("add doc 'foo'")
+    {
+        couchbase::operations::upsert_request r{ existing_id, value };
+        auto response = test::utils::execute(guard.cluster, r);
+        REQUIRE_FALSE(response.ctx.ec);
+    }
+    SECTION("test KV ops")
+    {
+        SECTION("upsert")
+        {
+            meter->reset();
+            couchbase::operations::upsert_request r{ existing_id, value };
+            auto response = test::utils::execute(guard.cluster, r);
+            REQUIRE_FALSE(response.ctx.ec);
+            auto recorders = meter->get_recorders("db.couchbase.operations");
+            REQUIRE_FALSE(recorders.empty());
+            assert_kv_recorder_tags(recorders, "upsert");
+        }
+        SECTION("insert")
+        {
+            meter->reset();
+            couchbase::operations::insert_request r{ make_id(guard.ctx), value };
+            auto response = test::utils::execute(guard.cluster, r);
+            REQUIRE_FALSE(response.ctx.ec);
+            auto recorders = meter->get_recorders("db.couchbase.operations");
+            REQUIRE_FALSE(recorders.empty());
+            assert_kv_recorder_tags(recorders, "insert");
+        }
+        SECTION("replace")
+        {
+            meter->reset();
+            auto new_value = couchbase::utils::to_binary("{\"some\": \"thing else\"");
+            couchbase::operations::replace_request r{ existing_id, new_value };
+            auto response = test::utils::execute(guard.cluster, r);
+            REQUIRE_FALSE(response.ctx.ec);
+            auto recorders = meter->get_recorders("db.couchbase.operations");
+            REQUIRE_FALSE(recorders.empty());
+            assert_kv_recorder_tags(recorders, "replace");
+        }
+        SECTION("get")
+        {
+            meter->reset();
+            couchbase::operations::get_request r{ existing_id };
+            auto response = test::utils::execute(guard.cluster, r);
+            REQUIRE_FALSE(response.ctx.ec);
+            auto meters = meter->get_recorders("db.couchbase.operations");
+            REQUIRE_FALSE(meters.empty());
+            assert_kv_recorder_tags(meters, "get");
+        }
+    }
+}

--- a/test/test_integration_tracer.cxx
+++ b/test/test_integration_tracer.cxx
@@ -1,0 +1,334 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+#include <couchbase/platform/uuid.h>
+
+class test_span : public couchbase::tracing::request_span
+{
+  public:
+    test_span(const std::string& name)
+      : test_span(name, nullptr)
+    {
+    }
+    test_span(const std::string& name, std::shared_ptr<couchbase::tracing::request_span> parent)
+      : request_span(name, parent)
+    {
+        start_ = std::chrono::steady_clock::now();
+        id_ = test::utils::uniq_id("span");
+    }
+    void add_tag(const std::string& name, std::uint64_t value) override
+    {
+        int_tags_[name] = value;
+    }
+    void add_tag(const std::string& name, const std::string& value) override
+    {
+        string_tags_[name] = value;
+    }
+    void end() override
+    {
+        duration_ = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start_);
+    }
+    std::map<std::string, std::string> string_tags()
+    {
+        return string_tags_;
+    }
+    std::map<std::string, std::uint64_t> int_tags()
+    {
+        return int_tags_;
+    }
+    std::chrono::nanoseconds duration()
+    {
+        return duration_;
+    }
+    std::chrono::time_point<std::chrono::steady_clock> start()
+    {
+        return start_;
+    }
+    std::string id()
+    {
+        return id_;
+    }
+
+  private:
+    std::string id_;
+    std::chrono::time_point<std::chrono::steady_clock> start_;
+    std::chrono::nanoseconds duration_{ 0 };
+    std::map<std::string, std::string> string_tags_;
+    std::map<std::string, std::uint64_t> int_tags_;
+};
+
+class test_tracer : public couchbase::tracing::request_tracer
+{
+  public:
+    std::shared_ptr<couchbase::tracing::request_span> start_span(std::string name,
+                                                                 std::shared_ptr<couchbase::tracing::request_span> parent = {})
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        spans_.push_back(std::make_shared<test_span>(name, parent));
+        return spans_.back();
+    }
+    std::vector<std::shared_ptr<test_span>> spans()
+    {
+        return spans_;
+    }
+    void reset()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        spans_.clear();
+    }
+
+  private:
+    std::vector<std::shared_ptr<test_span>> spans_;
+    std::mutex mutex_;
+};
+
+class tracer_test_guard
+{
+  public:
+    tracer_test_guard()
+    {
+        tracer = std::make_shared<test_tracer>();
+        ctx = test::utils::test_context::load_from_environment();
+        auto auth = ctx.build_auth();
+        couchbase::cluster_options opts{};
+        opts.tracer = tracer;
+        auto conn_str = couchbase::utils::parse_connection_string(ctx.connection_string);
+        auto addr = conn_str.bootstrap_nodes.front().address;
+        auto port = conn_str.default_port;
+        couchbase::origin orig(auth, addr, port, opts);
+        cluster = couchbase::cluster::create(io);
+        io_thread = std::thread([this]() { io.run(); });
+        test::utils::open_cluster(cluster, orig);
+        test::utils::open_bucket(cluster, ctx.bucket);
+    }
+    ~tracer_test_guard()
+    {
+        // close cluster
+        {
+            auto barrier = std::make_shared<std::promise<void>>();
+            auto f = barrier->get_future();
+            cluster->close([barrier]() { barrier->set_value(); });
+            f.get();
+        }
+        // now shutdown io and iothread
+        io.stop();
+        if (io_thread.joinable()) {
+            io_thread.join();
+        }
+    }
+
+    couchbase::document_id make_id(std::string key = "")
+    {
+        if (key.empty()) {
+            key = test::utils::uniq_id("tracer");
+        }
+        return couchbase::document_id{ ctx.bucket, "_default", "_default", key };
+    }
+
+    test::utils::test_context ctx;
+    std::thread io_thread{};
+    asio::io_context io{};
+    std::shared_ptr<couchbase::cluster> cluster;
+    std::shared_ptr<test_tracer> tracer;
+};
+void
+assert_kv_op_span_ok(tracer_test_guard& guard,
+                     std::shared_ptr<test_span> span,
+                     const std::string& op,
+                     std::shared_ptr<test_span> parent = nullptr)
+{
+    auto server_duration = span->int_tags()["cb.server_duration"];
+    REQUIRE(op == span->name());
+    REQUIRE(static_cast<uint64_t>(span->duration().count()) >= server_duration);
+    REQUIRE(span->string_tags()["cb.service"] == "kv");
+    REQUIRE_FALSE(span->string_tags()["cb.local_id"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.local_socket"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.remote_socket"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.operation_id"].empty());
+    REQUIRE(span->string_tags()["db.instance"] == guard.ctx.bucket);
+    REQUIRE(span->parent() == parent);
+    if (parent) {
+        // the parent span should not be closed yet
+        REQUIRE(parent->duration().count() == 0);
+    }
+}
+
+void
+assert_http_op_span_ok(std::shared_ptr<test_span> span, const std::string& op, std::shared_ptr<test_span> parent = nullptr)
+{
+    REQUIRE(span->name().find(op) != std::string::npos);
+    REQUIRE_FALSE(span->string_tags()["cb.local_id"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.local_socket"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.operation_id"].empty());
+    REQUIRE_FALSE(span->string_tags()["cb.remote_socket"].empty());
+    REQUIRE(span->string_tags()["cb.service"] == op);
+    REQUIRE(span->parent() == parent);
+    REQUIRE(span->duration().count() > 0);
+    if (parent) {
+        // the parent span should not be closed yet
+        REQUIRE(parent->duration().count() == 0);
+    }
+    // spec has some specific fields for query, analytics, etc...
+}
+
+TEST_CASE("integration: enable external tracer", "[integration]")
+{
+    tracer_test_guard guard;
+    auto parent_span = GENERATE(std::shared_ptr<test_span>{ nullptr }, std::make_shared<test_span>("parent"));
+    auto value = couchbase::utils::to_binary(R"({"some":"thing"})");
+    auto existing_id = guard.make_id();
+    SECTION("upsert doc 'foo'")
+    {
+        couchbase::operations::upsert_request r{ existing_id, value };
+        auto response = test::utils::execute(guard.cluster, r);
+        REQUIRE_FALSE(response.ctx.ec);
+
+        SECTION("test some KV ops:")
+        {
+            SECTION("upsert")
+            {
+                guard.tracer->reset();
+                couchbase::operations::upsert_request req{ guard.make_id(), value };
+                req.parent_span = parent_span;
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.upsert", parent_span);
+            }
+            SECTION("insert")
+            {
+                guard.tracer->reset();
+                couchbase::operations::insert_request req{ guard.make_id(), value };
+                req.parent_span = parent_span;
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.insert", parent_span);
+                guard.tracer->reset();
+            }
+
+            SECTION("get")
+            {
+                guard.tracer->reset();
+                couchbase::operations::get_request req{ existing_id };
+                req.parent_span = parent_span;
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.get", parent_span);
+            }
+            SECTION("replace")
+            {
+                guard.tracer->reset();
+                auto new_value = couchbase::utils::to_binary(R"({"some": "thing else")");
+                couchbase::operations::replace_request req{ existing_id, new_value };
+                req.parent_span = parent_span;
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.replace", parent_span);
+            }
+            SECTION("lookup_in")
+            {
+                guard.tracer->reset();
+                couchbase::operations::lookup_in_request req{};
+                req.parent_span = parent_span;
+                req.id = existing_id;
+                req.specs.add_spec(couchbase::protocol::subdoc_opcode::get, false, "some");
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.lookup_in", parent_span);
+            }
+            SECTION("mutate_in")
+            {
+                guard.tracer->reset();
+                couchbase::operations::mutate_in_request req{};
+                req.parent_span = parent_span;
+                req.id = existing_id;
+                req.specs.add_spec(couchbase::protocol::subdoc_opcode::dict_upsert, false, false, false, "another", R"("field")");
+                auto resp = test::utils::execute(guard.cluster, req);
+                REQUIRE_FALSE(resp.ctx.ec);
+                auto spans = guard.tracer->spans();
+                REQUIRE_FALSE(spans.empty());
+                assert_kv_op_span_ok(guard, spans.front(), "cb.mutate_in", parent_span);
+            }
+        }
+    }
+    SECTION("test http ops:")
+    {
+        SECTION("query")
+        {
+            guard.tracer->reset();
+            couchbase::operations::query_request req{ R"(SELECT "ruby rules" AS greeting)" };
+            req.parent_span = parent_span;
+            auto resp = test::utils::execute(guard.cluster, req);
+            REQUIRE_FALSE(resp.ctx.ec);
+            auto spans = guard.tracer->spans();
+            REQUIRE_FALSE(spans.empty());
+            assert_http_op_span_ok(spans.front(), "query", parent_span);
+        }
+        SECTION("search")
+        {
+            guard.tracer->reset();
+            couchbase::operations::search_request req{};
+            req.parent_span = parent_span;
+            req.index_name = "idontexist";
+            req.query = R"("foo")";
+            auto resp = test::utils::execute(guard.cluster, req);
+            // we didn't create an index, so this will fail
+            REQUIRE(resp.ctx.ec);
+            auto spans = guard.tracer->spans();
+            REQUIRE_FALSE(spans.empty());
+            assert_http_op_span_ok(spans.front(), "search", parent_span);
+        }
+        SECTION("analytics")
+        {
+            guard.tracer->reset();
+            couchbase::operations::analytics_request req{};
+            req.parent_span = parent_span;
+            req.bucket_name = guard.ctx.bucket;
+            req.statement = R"(SELECT "ruby rules" AS greeting)";
+            auto resp = test::utils::execute(guard.cluster, req);
+            REQUIRE_FALSE(resp.ctx.ec);
+            auto spans = guard.tracer->spans();
+            REQUIRE_FALSE(spans.empty());
+            assert_http_op_span_ok(spans.front(), "analytics", parent_span);
+        }
+        SECTION("view")
+        {
+            guard.tracer->reset();
+            couchbase::operations::document_view_request req{};
+            req.parent_span = parent_span;
+            req.bucket_name = guard.ctx.bucket;
+            req.view_name = "idontexist";
+            req.document_name = "nordoi";
+            auto resp = test::utils::execute(guard.cluster, req);
+            // we didn't setup a view, so this will fail.
+            REQUIRE(resp.ctx.ec);
+            auto spans = guard.tracer->spans();
+            REQUIRE_FALSE(spans.empty());
+            assert_http_op_span_ok(spans.front(), "views", parent_span);
+        }
+    }
+}

--- a/test/test_integration_tracer.cxx
+++ b/test/test_integration_tracer.cxx
@@ -97,57 +97,17 @@ class test_tracer : public couchbase::tracing::request_tracer
     std::mutex mutex_;
 };
 
-class tracer_test_guard
+couchbase::document_id
+make_id(const test::utils::test_context& ctx, std::string key = "")
 {
-  public:
-    tracer_test_guard()
-    {
-        tracer = std::make_shared<test_tracer>();
-        ctx = test::utils::test_context::load_from_environment();
-        auto auth = ctx.build_auth();
-        couchbase::cluster_options opts{};
-        opts.tracer = tracer;
-        auto conn_str = couchbase::utils::parse_connection_string(ctx.connection_string);
-        auto addr = conn_str.bootstrap_nodes.front().address;
-        auto port = conn_str.default_port;
-        couchbase::origin orig(auth, addr, port, opts);
-        cluster = couchbase::cluster::create(io);
-        io_thread = std::thread([this]() { io.run(); });
-        test::utils::open_cluster(cluster, orig);
-        test::utils::open_bucket(cluster, ctx.bucket);
+    if (key.empty()) {
+        key = test::utils::uniq_id("tracer");
     }
-    ~tracer_test_guard()
-    {
-        // close cluster
-        {
-            auto barrier = std::make_shared<std::promise<void>>();
-            auto f = barrier->get_future();
-            cluster->close([barrier]() { barrier->set_value(); });
-            f.get();
-        }
-        // now shutdown io and iothread
-        io.stop();
-        if (io_thread.joinable()) {
-            io_thread.join();
-        }
-    }
+    return couchbase::document_id{ ctx.bucket, "_default", "_default", key };
+}
 
-    couchbase::document_id make_id(std::string key = "")
-    {
-        if (key.empty()) {
-            key = test::utils::uniq_id("tracer");
-        }
-        return couchbase::document_id{ ctx.bucket, "_default", "_default", key };
-    }
-
-    test::utils::test_context ctx;
-    std::thread io_thread{};
-    asio::io_context io{};
-    std::shared_ptr<couchbase::cluster> cluster;
-    std::shared_ptr<test_tracer> tracer;
-};
 void
-assert_kv_op_span_ok(tracer_test_guard& guard,
+assert_kv_op_span_ok(test::utils::integration_test_guard& guard,
                      std::shared_ptr<test_span> span,
                      const std::string& op,
                      std::shared_ptr<test_span> parent = nullptr)
@@ -188,10 +148,14 @@ assert_http_op_span_ok(std::shared_ptr<test_span> span, const std::string& op, s
 
 TEST_CASE("integration: enable external tracer", "[integration]")
 {
-    tracer_test_guard guard;
+    couchbase::cluster_options opts{};
+    auto tracer = std::make_shared<test_tracer>();
+    opts.tracer = tracer;
+    test::utils::integration_test_guard guard(opts);
+    test::utils::open_bucket(guard.cluster, guard.ctx.bucket);
     auto parent_span = GENERATE(std::shared_ptr<test_span>{ nullptr }, std::make_shared<test_span>("parent"));
     auto value = couchbase::utils::to_binary(R"({"some":"thing"})");
-    auto existing_id = guard.make_id();
+    auto existing_id = make_id(guard.ctx);
     SECTION("upsert doc 'foo'")
     {
         couchbase::operations::upsert_request r{ existing_id, value };
@@ -202,74 +166,73 @@ TEST_CASE("integration: enable external tracer", "[integration]")
         {
             SECTION("upsert")
             {
-                guard.tracer->reset();
-                couchbase::operations::upsert_request req{ guard.make_id(), value };
+                tracer->reset();
+                couchbase::operations::upsert_request req{ make_id(guard.ctx), value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.upsert", parent_span);
             }
             SECTION("insert")
             {
-                guard.tracer->reset();
-                couchbase::operations::insert_request req{ guard.make_id(), value };
+                tracer->reset();
+                couchbase::operations::insert_request req{ make_id(guard.ctx), value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.insert", parent_span);
-                guard.tracer->reset();
             }
 
             SECTION("get")
             {
-                guard.tracer->reset();
+                tracer->reset();
                 couchbase::operations::get_request req{ existing_id };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.get", parent_span);
             }
             SECTION("replace")
             {
-                guard.tracer->reset();
+                tracer->reset();
                 auto new_value = couchbase::utils::to_binary(R"({"some": "thing else")");
                 couchbase::operations::replace_request req{ existing_id, new_value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.replace", parent_span);
             }
             SECTION("lookup_in")
             {
-                guard.tracer->reset();
+                tracer->reset();
                 couchbase::operations::lookup_in_request req{};
                 req.parent_span = parent_span;
                 req.id = existing_id;
                 req.specs.add_spec(couchbase::protocol::subdoc_opcode::get, false, "some");
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.lookup_in", parent_span);
             }
             SECTION("mutate_in")
             {
-                guard.tracer->reset();
+                tracer->reset();
                 couchbase::operations::mutate_in_request req{};
                 req.parent_span = parent_span;
                 req.id = existing_id;
                 req.specs.add_spec(couchbase::protocol::subdoc_opcode::dict_upsert, false, false, false, "another", R"("field")");
                 auto resp = test::utils::execute(guard.cluster, req);
                 REQUIRE_FALSE(resp.ctx.ec);
-                auto spans = guard.tracer->spans();
+                auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.mutate_in", parent_span);
             }
@@ -279,18 +242,18 @@ TEST_CASE("integration: enable external tracer", "[integration]")
     {
         SECTION("query")
         {
-            guard.tracer->reset();
+            tracer->reset();
             couchbase::operations::query_request req{ R"(SELECT "ruby rules" AS greeting)" };
             req.parent_span = parent_span;
             auto resp = test::utils::execute(guard.cluster, req);
             REQUIRE_FALSE(resp.ctx.ec);
-            auto spans = guard.tracer->spans();
+            auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "query", parent_span);
         }
         SECTION("search")
         {
-            guard.tracer->reset();
+            tracer->reset();
             couchbase::operations::search_request req{};
             req.parent_span = parent_span;
             req.index_name = "idontexist";
@@ -298,26 +261,29 @@ TEST_CASE("integration: enable external tracer", "[integration]")
             auto resp = test::utils::execute(guard.cluster, req);
             // we didn't create an index, so this will fail
             REQUIRE(resp.ctx.ec);
-            auto spans = guard.tracer->spans();
+            auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "search", parent_span);
         }
         SECTION("analytics")
         {
-            guard.tracer->reset();
+            if (!guard.cluster_version().supports_analytics()) {
+                return;
+            }
+            tracer->reset();
             couchbase::operations::analytics_request req{};
             req.parent_span = parent_span;
             req.bucket_name = guard.ctx.bucket;
             req.statement = R"(SELECT "ruby rules" AS greeting)";
             auto resp = test::utils::execute(guard.cluster, req);
             REQUIRE_FALSE(resp.ctx.ec);
-            auto spans = guard.tracer->spans();
+            auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "analytics", parent_span);
         }
         SECTION("view")
         {
-            guard.tracer->reset();
+            tracer->reset();
             couchbase::operations::document_view_request req{};
             req.parent_span = parent_span;
             req.bucket_name = guard.ctx.bucket;
@@ -326,7 +292,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
             auto resp = test::utils::execute(guard.cluster, req);
             // we didn't setup a view, so this will fail.
             REQUIRE(resp.ctx.ec);
-            auto spans = guard.tracer->spans();
+            auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "views", parent_span);
         }

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -39,6 +39,20 @@ integration_test_guard::integration_test_guard()
     open_cluster(cluster, origin);
 }
 
+integration_test_guard::integration_test_guard(const couchbase::cluster_options& opts)
+{
+    init_logger();
+    ctx = test_context::load_from_environment();
+    auto auth = ctx.build_auth();
+    auto conn_str = couchbase::utils::parse_connection_string(ctx.connection_string);
+    auto addr = conn_str.bootstrap_nodes.front().address;
+    auto port = conn_str.default_port;
+    couchbase::origin orig(auth, addr, port, opts);
+    cluster = couchbase::cluster::create(io);
+    io_thread = std::thread([this]() { io.run(); });
+    open_cluster(cluster, orig);
+}
+
 integration_test_guard::~integration_test_guard()
 {
     close_cluster(cluster);

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -39,14 +39,17 @@ integration_test_guard::integration_test_guard()
     open_cluster(cluster, origin);
 }
 
-integration_test_guard::integration_test_guard(const couchbase::cluster_options& opts)
+integration_test_guard::integration_test_guard(couchbase::cluster_options& opts)
 {
     init_logger();
     ctx = test_context::load_from_environment();
     auto auth = ctx.build_auth();
     auto conn_str = couchbase::utils::parse_connection_string(ctx.connection_string);
     auto addr = conn_str.bootstrap_nodes.front().address;
-    auto port = conn_str.default_port;
+    auto port = conn_str.bootstrap_nodes.front().port;
+    // NOTE: this OVERRIDES any tls option you set in the options, so we match
+    // what the environment is setup to use.
+    opts.enable_tls = conn_str.tls;
     couchbase::origin orig(auth, addr, port, opts);
     cluster = couchbase::cluster::create(io);
     io_thread = std::thread([this]() { io.run(); });

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -39,18 +39,16 @@ integration_test_guard::integration_test_guard()
     open_cluster(cluster, origin);
 }
 
-integration_test_guard::integration_test_guard(couchbase::cluster_options& opts)
+integration_test_guard::integration_test_guard(const couchbase::cluster_options& opts)
 {
     init_logger();
     ctx = test_context::load_from_environment();
     auto auth = ctx.build_auth();
-    auto conn_str = couchbase::utils::parse_connection_string(ctx.connection_string);
-    auto addr = conn_str.bootstrap_nodes.front().address;
-    auto port = conn_str.bootstrap_nodes.front().port;
-    // NOTE: this OVERRIDES any tls option you set in the options, so we match
-    // what the environment is setup to use.
-    opts.enable_tls = conn_str.tls;
-    couchbase::origin orig(auth, addr, port, opts);
+    auto connstr = couchbase::utils::parse_connection_string(ctx.connection_string);
+    // for now, lets _only_ add a tracer or meter from the incoming options
+    connstr.options.meter = opts.meter;
+    connstr.options.tracer = opts.tracer;
+    couchbase::origin orig(auth, connstr);
     cluster = couchbase::cluster::create(io);
     io_thread = std::thread([this]() { io.run(); });
     open_cluster(cluster, orig);

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -32,7 +32,7 @@ class integration_test_guard
 {
   public:
     integration_test_guard();
-    integration_test_guard(const couchbase::cluster_options& opts);
+    integration_test_guard(couchbase::cluster_options& opts);
     ~integration_test_guard();
 
     inline const couchbase::operations::management::bucket_describe_response::bucket_info& load_bucket_info(bool refresh = false)

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -32,6 +32,7 @@ class integration_test_guard
 {
   public:
     integration_test_guard();
+    integration_test_guard(const couchbase::cluster_options& opts);
     ~integration_test_guard();
 
     inline const couchbase::operations::management::bucket_describe_response::bucket_info& load_bucket_info(bool refresh = false)

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -32,7 +32,7 @@ class integration_test_guard
 {
   public:
     integration_test_guard();
-    integration_test_guard(couchbase::cluster_options& opts);
+    integration_test_guard(const couchbase::cluster_options& opts);
     ~integration_test_guard();
 
     inline const couchbase::operations::management::bucket_describe_response::bucket_info& load_bucket_info(bool refresh = false)


### PR DESCRIPTION
Motivation
==========
Allow clients to plug in their own tracing and/or metrics solutions,
such as OpenTelemetry

Modifications
=============
Expose the tracer and meter in cluster_options.  Then, add a parent_span
to many (but for now, not all) requests.   The tests use a simple tracer
and meter implementation to facilitate testing.

*** Will update this with a header that wraps OpenTelemetry objects in
particular, which will not be referenced by anything in the client so we
will only require otel when it is used.

Results
=======
Tests pass