### PR TITLE
CXXCBC-203: disable clustermap nofication by default

### DIFF
--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -56,7 +56,7 @@ struct cluster_options {
     bool enable_dns_srv{ true };
     bool show_queries{ false };
     bool enable_unordered_execution{ true };
-    bool enable_clustermap_notification{ true };
+    bool enable_clustermap_notification{ false };
     bool enable_compression{ true };
     bool enable_tracing{ true };
     bool enable_metrics{ true };

--- a/test/tools/tool_kv_loader.cxx
+++ b/test/tools/tool_kv_loader.cxx
@@ -245,15 +245,16 @@ main()
     fmt::print("total time: {}s ({}ms)\n",
                std::chrono::duration_cast<std::chrono::seconds>(total_time).count(),
                std::chrono::duration_cast<std::chrono::milliseconds>(total_time).count());
-    auto diff = std::chrono::duration_cast<std::chrono::seconds>(total_time).count();
-    if (diff > 0) {
+    if (auto diff = std::chrono::duration_cast<std::chrono::seconds>(total_time).count(); diff > 0) {
         fmt::print("total rate: {} ops/s\n", total / static_cast<std::uint64_t>(diff));
     }
-    std::scoped_lock lock(errors_mutex);
-    if (!errors.empty()) {
-        fmt::print("error stats:\n");
-        for (auto [ec, count] : errors) {
-            fmt::print("    {} ({}): {}\n", ec.message(), ec.value(), count);
+    {
+        std::scoped_lock lock(errors_mutex);
+        if (!errors.empty()) {
+            fmt::print("error stats:\n");
+            for (auto [ec, count] : errors) {
+                fmt::print("    {}: {}\n", ec.message(), count);
+            }
         }
     }
 


### PR DESCRIPTION
In order to optimize freeze/thaw cycle clustermap notification should be
disabled. Otherwise the SDK will be required to process all stale
notifications after thaw.