### PR TITLE
record line, file, and function names into log message

### DIFF
--- a/core/logger/logger.cxx
+++ b/core/logger/logger.cxx
@@ -102,10 +102,10 @@ should_log(level lvl)
 namespace detail
 {
 void
-log(level lvl, std::string_view msg)
+log(const char* file, int line, const char* function, level lvl, std::string_view msg)
 {
     if (is_initialized()) {
-        return file_logger->log(translate_level(lvl), msg);
+        return file_logger->log(spdlog::source_loc{ file, line, function }, translate_level(lvl), msg);
     }
 }
 } // namespace detail

--- a/test/utils/logger.cxx
+++ b/test/utils/logger.cxx
@@ -18,6 +18,7 @@
 #include "core/logger/logger.hxx"
 
 #include <spdlog/details/os.h>
+#include <spdlog/spdlog.h>
 
 namespace test::utils
 {
@@ -31,6 +32,7 @@ init_logger()
         if (auto env_val = spdlog::details::os::getenv("TEST_LOG_LEVEL"); !env_val.empty()) {
             couchbase::core::logger::set_log_levels(couchbase::core::logger::level_from_str(env_val));
         }
+        spdlog::set_pattern("[%Y-%m-%d %T.%e] [%P,%t] [%^%l%$] %oms, %v at %@ %!");
         initialized = true;
     }
 }


### PR DESCRIPTION
the default pattern does not include file location info to reduce
verbosity, but the tests enable it for easier debugging.