### PR TITLE
Fix transcoder options for get_replica API

### DIFF
--- a/core/impl/get_all_replicas.cxx
+++ b/core/impl/get_all_replicas.cxx
@@ -74,7 +74,8 @@ initiate_get_all_replicas_operation(std::shared_ptr<cluster> core,
                               return;
                           }
                       } else {
-                          ctx->result_.emplace_back(resp.cas, true /* replica */, std::move(resp.value), resp.flags);
+                          ctx->result_.emplace_back(
+                            get_replica_result{ resp.cas, true /* replica */, { std::move(resp.value), resp.flags } });
                       }
                       if (ctx->expected_responses_ == 0) {
                           ctx->done_ = true;
@@ -103,7 +104,7 @@ initiate_get_all_replicas_operation(std::shared_ptr<cluster> core,
                           return;
                       }
                   } else {
-                      ctx->result_.emplace_back(resp.cas, false /* active */, std::move(resp.value), resp.flags);
+                      ctx->result_.emplace_back(get_replica_result{ resp.cas, false /* active */, { std::move(resp.value), resp.flags } });
                   }
                   if (ctx->expected_responses_ == 0) {
                       ctx->done_ = true;

--- a/core/impl/get_any_replica.cxx
+++ b/core/impl/get_any_replica.cxx
@@ -40,7 +40,7 @@ initiate_get_any_replica_operation(std::shared_ptr<cluster> core,
       bucket_name,
       [core, r = std::move(request), h = std::move(handler)](std::error_code ec, const core::topology::configuration& config) mutable {
           if (ec) {
-              return h(make_key_value_error_context(ec, r->id()), get_any_replica_result{});
+              return h(make_key_value_error_context(ec, r->id()), get_replica_result{});
           }
           struct replica_context {
               replica_context(get_any_replica_handler&& handler, std::uint32_t expected_responses)
@@ -80,7 +80,7 @@ initiate_get_any_replica_operation(std::shared_ptr<cluster> core,
                   }
                   if (local_handler) {
                       return local_handler(std::move(resp.ctx),
-                                           get_any_replica_result{ resp.cas, true /* replica */, std::move(resp.value), resp.flags });
+                                           get_replica_result{ resp.cas, true /* replica */, { std::move(resp.value), resp.flags } });
                   }
               });
           }
@@ -108,7 +108,7 @@ initiate_get_any_replica_operation(std::shared_ptr<cluster> core,
               }
               if (local_handler) {
                   return local_handler(std::move(resp.ctx),
-                                       get_any_replica_result{ resp.cas, false /* active */, std::move(resp.value), resp.flags });
+                                       get_replica_result{ resp.cas, false /* active */, { std::move(resp.value), resp.flags } });
               }
           });
       });

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -445,9 +445,9 @@ class collection
      * @committed
      */
     [[nodiscard]] auto get_any_replica(std::string document_id, const get_any_replica_options& options) const
-      -> std::future<std::pair<key_value_error_context, get_any_replica_result>>
+      -> std::future<std::pair<key_value_error_context, get_replica_result>>
     {
-        auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_any_replica_result>>>();
+        auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_replica_result>>>();
         auto future = barrier->get_future();
         get_any_replica(std::move(document_id), options, [barrier](auto ctx, auto result) {
             barrier->set_value({ std::move(ctx), std::move(result) });

--- a/couchbase/get_any_replica_options.hxx
+++ b/couchbase/get_any_replica_options.hxx
@@ -61,28 +61,12 @@ struct get_any_replica_options : public common_options<get_any_replica_options> 
 };
 
 /**
- * The error context for the @ref collection#get_any_replica() operation
- *
- * @since 1.0.0
- * @committed
- */
-using get_any_replica_error_context = couchbase::key_value_error_context;
-
-/**
- * The result for the @ref collection#get_any_replica() operation
- *
- * @since 1.0.0
- * @uncommitted
- */
-using get_any_replica_result = get_replica_result;
-
-/**
  * The signature for the handler of the @ref collection#get_any_replica() operation
  *
  * @since 1.0.0
  * @uncommitted
  */
-using get_any_replica_handler = std::function<void(get_any_replica_error_context, get_any_replica_result)>;
+using get_any_replica_handler = std::function<void(key_value_error_context, get_replica_result)>;
 
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
 namespace core

--- a/couchbase/get_result.hxx
+++ b/couchbase/get_result.hxx
@@ -64,7 +64,7 @@ class get_result : public result
      * Decodes content of the document using given codec.
      *
      * @tparam Document custom type that `Transcoder` returns
-     * @tparam Transcoder type that has static function `decode` that takes codec::encoded_value and returns Document
+     * @tparam Transcoder type that has static function `decode` that takes codec::encoded_value and returns `Document`
      * @return decoded document content
      *
      * @since 1.0.0
@@ -84,6 +84,12 @@ class get_result : public result
      *
      * @tparam Transcoder type that has static function `decode` that takes codec::encoded_value and returns `Transcoder::value_type`
      * @return decoded document content
+     *
+     * @par Get flags and value as they are stored in the result
+     *  Here is an example of custom transcoder, that just extracts value and flags as they are stored in the result.
+     * @snippet test_integration_read_replica.cxx smuggling-transcoder
+     *  Usage
+     * @snippet test_integration_read_replica.cxx smuggling-transcoder-usage
      *
      * @since 1.0.0
      * @committed


### PR DESCRIPTION
@thejcfactor this patch also removes "hacks" to access flags/content directly, but instead adds more handy API for `content_as`, just like for `get`/`get_and_touch`.

Your passthrough transcoder will look like this:
```c++
struct passthrough_transcoder {
    using document_type = couchbase::codec::encoded_value;

    static auto decode(const couchbase::codec::encoded_value& data) -> document_type
    {
        return data;
    }
};
```
```c++
auto encoded = result.content_as<passthrough_transcoder>();
encoded.data    // => std::vector<std::byte>
encoded.flags   // => std::uint32_t
```

Also I plan to add other types of the transcoders, described in the RFC