### PR TITLE
return subdocument error context from future-based subdoc methods

### DIFF
--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -787,9 +787,9 @@ class collection
      * @committed
      */
     [[nodiscard]] auto mutate_in(std::string document_id, mutate_in_specs specs, const mutate_in_options& options) const
-      -> std::future<std::pair<key_value_error_context, mutate_in_result>>
+      -> std::future<std::pair<subdocument_error_context, mutate_in_result>>
     {
-        auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutate_in_result>>>();
+        auto barrier = std::make_shared<std::promise<std::pair<subdocument_error_context, mutate_in_result>>>();
         auto future = barrier->get_future();
         mutate_in(std::move(document_id), std::move(specs), options, [barrier](auto ctx, auto result) {
             barrier->set_value({ std::move(ctx), std::move(result) });
@@ -805,9 +805,9 @@ class collection
     }
 
     [[nodiscard]] auto lookup_in(std::string document_id, lookup_in_specs specs, const lookup_in_options& options) const
-      -> std::future<std::pair<key_value_error_context, lookup_in_result>>
+      -> std::future<std::pair<subdocument_error_context, lookup_in_result>>
     {
-        auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, lookup_in_result>>>();
+        auto barrier = std::make_shared<std::promise<std::pair<subdocument_error_context, lookup_in_result>>>();
         auto future = barrier->get_future();
         lookup_in(std::move(document_id), std::move(specs), options, [barrier](auto ctx, auto result) {
             barrier->set_value({ std::move(ctx), std::move(result) });

--- a/test/test_integration_transcoders.cxx
+++ b/test/test_integration_transcoders.cxx
@@ -477,6 +477,8 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                                         {})
                              .get();
         REQUIRE_FALSE(ctx.ec());
+        REQUIRE_FALSE(ctx.first_error_index());
+        REQUIRE_FALSE(ctx.first_error_path());
         REQUIRE_FALSE(resp.cas().empty());
         cas = resp.cas();
     }


### PR DESCRIPTION
The error context were up-casted to base class which does not have subdoc-specific fields (like index of the first error)