### PR TITLE
improve readability of the error_code assertions

### DIFF
--- a/test/benchmark_integration_get.cxx
+++ b/test/benchmark_integration_get.cxx
@@ -32,14 +32,13 @@ TEST_CASE("benchmark: get a document", "[benchmark]")
         };
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::json::generate_binary(value) };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     BENCHMARK("get")
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     };
 }

--- a/test/test_helper.hxx
+++ b/test/test_helper.hxx
@@ -24,3 +24,5 @@
 #include "utils/uniq_id.hxx"
 
 #include <catch2/catch.hpp>
+
+#define REQUIRE_SUCCESS(ec) INFO((ec).message()) REQUIRE_FALSE(ec)

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -37,13 +37,13 @@ TEST_CASE("integration: analytics query")
         req.dataset_name = dataset_name;
         req.bucket_name = integration.ctx.bucket;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
         couchbase::core::operations::management::analytics_link_connect_request req{};
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     auto key = test::utils::uniq_id("key");
@@ -53,7 +53,7 @@ TEST_CASE("integration: analytics query")
         auto id = couchbase::core::document_id(integration.ctx.bucket, "_default", "_default", key);
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::to_binary(value) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("simple query")
@@ -65,7 +65,7 @@ TEST_CASE("integration: analytics query")
             resp = test::utils::execute(integration.cluster, req);
             return resp.rows.size() == 1;
         }));
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows[0] == value);
         REQUIRE_FALSE(resp.meta.request_id.empty());
         REQUIRE_FALSE(resp.meta.client_context_id.empty());
@@ -82,7 +82,7 @@ TEST_CASE("integration: analytics query")
             resp = test::utils::execute(integration.cluster, req);
             return resp.rows.size() == 1;
         }));
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows[0] == value);
     }
 
@@ -96,7 +96,7 @@ TEST_CASE("integration: analytics query")
             resp = test::utils::execute(integration.cluster, req);
             return resp.rows.size() == 1;
         }));
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows[0] == value);
     }
 
@@ -110,7 +110,7 @@ TEST_CASE("integration: analytics query")
             resp = test::utils::execute(integration.cluster, req);
             return resp.rows.size() == 1;
         }));
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows[0] == value);
     }
 
@@ -124,7 +124,7 @@ TEST_CASE("integration: analytics query")
             resp = test::utils::execute(integration.cluster, req);
             return resp.rows.size() == 1;
         }));
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows[0] == value);
     }
 
@@ -134,7 +134,7 @@ TEST_CASE("integration: analytics query")
         req.statement = fmt::format(R"(SELECT testkey FROM `Default`.`{}` WHERE testkey = "{}")", dataset_name, test_value);
         req.scan_consistency = couchbase::core::analytics_scan_consistency::request_plus;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.rows.size() == 1);
         REQUIRE(resp.rows[0] == value);
     }
@@ -172,7 +172,7 @@ TEST_CASE("integration: analytics scope query")
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -180,7 +180,7 @@ TEST_CASE("integration: analytics scope query")
     {
         couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -190,7 +190,7 @@ TEST_CASE("integration: analytics scope query")
         req.statement =
           fmt::format("ALTER COLLECTION `{}`.`{}`.`{}` ENABLE ANALYTICS", integration.ctx.bucket, scope_name, collection_name);
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     auto key = test::utils::uniq_id("key");
@@ -200,7 +200,7 @@ TEST_CASE("integration: analytics scope query")
         auto id = couchbase::core::document_id(integration.ctx.bucket, scope_name, collection_name, key);
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::to_binary(value) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     couchbase::core::operations::analytics_response resp{};
@@ -212,7 +212,7 @@ TEST_CASE("integration: analytics scope query")
         resp = test::utils::execute(integration.cluster, req);
         return resp.rows.size() == 1;
     }));
-    REQUIRE_FALSE(resp.ctx.ec);
+    REQUIRE_SUCCESS(resp.ctx.ec);
     REQUIRE(resp.rows[0] == value);
 
     {
@@ -242,7 +242,7 @@ TEST_CASE("unit: analytics query")
         couchbase::core::operations::analytics_request req{};
         req.priority = true;
         auto ec = req.encode_to(http_req, ctx);
-        REQUIRE_FALSE(ec);
+        REQUIRE_SUCCESS(ec);
         auto priority_header = http_req.headers.find("analytics-priority");
         REQUIRE(priority_header != http_req.headers.end());
         REQUIRE(priority_header->second == "-1");
@@ -255,7 +255,7 @@ TEST_CASE("unit: analytics query")
         couchbase::core::operations::analytics_request req{};
         req.priority = false;
         auto ec = req.encode_to(http_req, ctx);
-        REQUIRE_FALSE(ec);
+        REQUIRE_SUCCESS(ec);
         REQUIRE(http_req.headers.find("analytics-priority") == http_req.headers.end());
     }
 }

--- a/test/test_integration_arithmetic.cxx
+++ b/test/test_integration_arithmetic.cxx
@@ -32,14 +32,14 @@ TEST_CASE("integration: increment", "[integration]")
         {
             couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary("0") };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         for (uint64_t expected = 2; expected <= 20; expected += 2) {
             couchbase::core::operations::increment_request req{ id };
             req.delta = 2;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
             REQUIRE(resp.content == expected);
         }
     }
@@ -50,7 +50,7 @@ TEST_CASE("integration: increment", "[integration]")
         req.delta = 2;
         req.initial_value = 10;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.content == 10);
     }
 
@@ -61,7 +61,7 @@ TEST_CASE("integration: increment", "[integration]")
             req.initial_value = 2;
             req.durability_level = couchbase::durability_level::persist_to_majority;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
             REQUIRE(resp.content == 2);
         }
     }
@@ -84,13 +84,13 @@ TEST_CASE("integration: increment with public API", "[integration]")
         {
             const auto ascii_zero = couchbase::core::utils::to_binary("0");
             auto [ctx, resp] = collection.insert<couchbase::codec::raw_binary_transcoder>(id, ascii_zero, {}).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE_FALSE(resp.cas().empty());
         }
 
         for (uint64_t expected = 2; expected <= 20; expected += 2) {
             auto [ctx, resp] = collection.binary().increment(id, couchbase::increment_options{}.delta(2)).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE(resp.content() == expected);
         }
     }
@@ -98,7 +98,7 @@ TEST_CASE("integration: increment with public API", "[integration]")
     SECTION("initial value")
     {
         auto [ctx, resp] = collection.binary().increment(id, couchbase::increment_options{}.delta(2).initial(10)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE(resp.content() == 10);
     }
 
@@ -109,7 +109,7 @@ TEST_CASE("integration: increment with public API", "[integration]")
               collection.binary()
                 .increment(id, couchbase::increment_options{}.initial(2).durability(couchbase::durability_level::persist_to_majority))
                 .get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE(resp.content() == 2);
         }
     }
@@ -127,14 +127,14 @@ TEST_CASE("integration: decrement", "[integration]")
         {
             couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary("20") };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         for (uint64_t expected = 18; expected > 0; expected -= 2) {
             couchbase::core::operations::decrement_request req{ id };
             req.delta = 2;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
             REQUIRE(resp.content == expected);
         }
     }
@@ -145,7 +145,7 @@ TEST_CASE("integration: decrement", "[integration]")
         req.delta = 2;
         req.initial_value = 10;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.content == 10);
     }
 
@@ -156,7 +156,7 @@ TEST_CASE("integration: decrement", "[integration]")
             req.initial_value = 2;
             req.durability_level = couchbase::durability_level::persist_to_majority;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
             REQUIRE(resp.content == 2);
         }
     }
@@ -179,13 +179,13 @@ TEST_CASE("integration: decrement with public API", "[integration]")
         {
             const auto ascii_twenty = couchbase::core::utils::to_binary("20");
             auto [ctx, resp] = collection.insert<couchbase::codec::raw_binary_transcoder>(id, ascii_twenty, {}).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE_FALSE(resp.cas().empty());
         }
 
         for (uint64_t expected = 18; expected > 0; expected -= 2) {
             auto [ctx, resp] = collection.binary().decrement(id, couchbase::decrement_options{}.delta(2)).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE(resp.content() == expected);
         }
     }
@@ -193,7 +193,7 @@ TEST_CASE("integration: decrement with public API", "[integration]")
     SECTION("initial value")
     {
         auto [ctx, resp] = collection.binary().decrement(id, couchbase::decrement_options{}.delta(2).initial(10)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE(resp.content() == 10);
     }
 
@@ -204,7 +204,7 @@ TEST_CASE("integration: decrement with public API", "[integration]")
               collection.binary()
                 .decrement(id, couchbase::decrement_options{}.initial(2).durability(couchbase::durability_level::persist_to_majority))
                 .get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
             REQUIRE(resp.content() == 2);
         }
     }

--- a/test/test_integration_binary_operations.cxx
+++ b/test/test_integration_binary_operations.cxx
@@ -29,24 +29,21 @@ TEST_CASE("integration: append", "[integration]")
     {
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::to_binary("world") };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::append_request req{ id, couchbase::core::utils::to_binary("!") };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.value == couchbase::core::utils::to_binary("world!"));
     }
@@ -62,24 +59,21 @@ TEST_CASE("integration: prepend", "[integration]")
     {
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::to_binary("world") };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::prepend_request req{ id, couchbase::core::utils::to_binary("Hello, ") };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.value == couchbase::core::utils::to_binary("Hello, world"));
     }

--- a/test/test_integration_collections.cxx
+++ b/test/test_integration_collections.cxx
@@ -88,7 +88,7 @@ TEST_CASE("integration: get and insert non default scope and collection", "[inte
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -96,7 +96,7 @@ TEST_CASE("integration: get and insert non default scope and collection", "[inte
     {
         couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -104,13 +104,13 @@ TEST_CASE("integration: get and insert non default scope and collection", "[inte
     {
         couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary(key) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(key));
     }
 }
@@ -132,7 +132,7 @@ TEST_CASE("integration: insert into dropped scope", "[integration]")
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -140,7 +140,7 @@ TEST_CASE("integration: insert into dropped scope", "[integration]")
     {
         couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -148,20 +148,20 @@ TEST_CASE("integration: insert into dropped scope", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary(key) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(key));
     }
 
     {
         couchbase::core::operations::management::scope_drop_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto dropped = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(dropped);
     }

--- a/test/test_integration_connect.cxx
+++ b/test/test_integration_connect.cxx
@@ -62,7 +62,7 @@ TEST_CASE("integration: connecting with unresponsive first node in bootstrap nod
     auto f = barrier->get_future();
     cluster->open(origin, [barrier](std::error_code ec) mutable { barrier->set_value(ec); });
     auto rc = f.get();
-    REQUIRE_FALSE(rc);
+    REQUIRE_SUCCESS(rc);
     test::utils::close_cluster(cluster);
     io_thread.join();
 }
@@ -133,14 +133,14 @@ TEST_CASE("integration: destroy cluster without waiting for close completion", "
         couchbase::core::document_id id{ ctx.bucket, "_default", "_default", test::utils::uniq_id("foo") };
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::to_binary("{{}}") };
         auto resp = test::utils::execute(cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // hit Query
     {
         couchbase::core::operations::query_request req{ R"(SELECT 42 AS the_answer)" };
         auto resp = test::utils::execute(cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     // close but do not explicitly wait for callback

--- a/test/test_integration_crud.cxx
+++ b/test/test_integration_crud.cxx
@@ -39,8 +39,7 @@ TEST_CASE("integration: crud on default collection", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -61,7 +60,7 @@ TEST_CASE("integration: crud on default collection", "[integration]")
         {
             couchbase::core::operations::replace_request req{ id, json };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         {
@@ -73,7 +72,7 @@ TEST_CASE("integration: crud on default collection", "[integration]")
         {
             couchbase::core::operations::upsert_request req{ id, basic_doc_json };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         {
@@ -88,7 +87,7 @@ TEST_CASE("integration: crud on default collection", "[integration]")
         {
             couchbase::core::operations::remove_request req{ id };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         {
@@ -110,7 +109,6 @@ TEST_CASE("integration: get", "[integration]")
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message());
         REQUIRE(resp.ctx.ec() == couchbase::errc::key_value::document_not_found);
     }
 
@@ -121,12 +119,12 @@ TEST_CASE("integration: get", "[integration]")
             couchbase::core::operations::insert_request req{ id, basic_doc_json };
             req.flags = flags;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
         {
             couchbase::core::operations::get_request req{ id };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
             REQUIRE(resp.value == basic_doc_json);
             REQUIRE(resp.flags == flags);
         }
@@ -153,13 +151,13 @@ TEST_CASE("integration: touch", "[integration]")
         {
             couchbase::core::operations::insert_request req{ id, basic_doc_json };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
         {
             couchbase::core::operations::touch_request req{ id };
             req.expiry = 666;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
     }
 }
@@ -177,7 +175,7 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -186,7 +184,7 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
         couchbase::core::operations::get_and_lock_request req{ id };
         req.lock_time = lock_time;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(cas != resp.cas);
         cas = resp.cas;
     }
@@ -195,7 +193,7 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(cas != resp.cas);
     }
 
@@ -222,14 +220,14 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
         couchbase::core::operations::replace_request req{ id, basic_doc_json };
         req.cas = cas;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_and_lock_request req{ id };
         req.lock_time = lock_time;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -238,14 +236,14 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
         couchbase::core::operations::unlock_request req{ id };
         req.cas = cas;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // now the key is not locked
     {
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 }
 
@@ -259,7 +257,7 @@ TEST_CASE("integration: lock/unlock without lock time", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     couchbase::cas cas{};
@@ -267,7 +265,7 @@ TEST_CASE("integration: lock/unlock without lock time", "[integration]")
     {
         couchbase::core::operations::get_and_lock_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -275,7 +273,7 @@ TEST_CASE("integration: lock/unlock without lock time", "[integration]")
         couchbase::core::operations::unlock_request req{ id };
         req.cas = cas;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 }
 
@@ -289,7 +287,7 @@ TEST_CASE("integration: touch with zero expiry resets expiry", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // set expiry with touch
@@ -297,7 +295,7 @@ TEST_CASE("integration: touch with zero expiry resets expiry", "[integration]")
         couchbase::core::operations::touch_request req{ id };
         req.expiry = 1;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // reset expiry
@@ -305,7 +303,7 @@ TEST_CASE("integration: touch with zero expiry resets expiry", "[integration]")
         couchbase::core::operations::get_and_touch_request req{ id };
         req.expiry = 0;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // wait for original expiry to pass
@@ -315,7 +313,7 @@ TEST_CASE("integration: touch with zero expiry resets expiry", "[integration]")
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == basic_doc_json);
     }
 }
@@ -331,7 +329,7 @@ TEST_CASE("integration: exists", "[integration]")
         couchbase::core::operations::exists_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
         REQUIRE_FALSE(resp.exists());
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE_FALSE(resp.deleted);
         REQUIRE(resp.cas.empty());
         REQUIRE(resp.sequence_number == 0);
@@ -341,7 +339,7 @@ TEST_CASE("integration: exists", "[integration]")
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         req.expiry = 1878422400;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE_FALSE(resp.cas.empty());
     }
 
@@ -349,7 +347,7 @@ TEST_CASE("integration: exists", "[integration]")
         couchbase::core::operations::exists_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
         REQUIRE(resp.exists());
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE_FALSE(resp.deleted);
         REQUIRE_FALSE(resp.cas.empty());
         REQUIRE(resp.sequence_number != 0);
@@ -359,14 +357,14 @@ TEST_CASE("integration: exists", "[integration]")
     {
         couchbase::core::operations::remove_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::exists_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
         REQUIRE_FALSE(resp.exists());
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.deleted);
         REQUIRE_FALSE(resp.cas.empty());
         REQUIRE(resp.sequence_number != 0);
@@ -384,13 +382,13 @@ TEST_CASE("integration: zero length value", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary("") };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(""));
     }
 }
@@ -435,7 +433,7 @@ TEST_CASE("integration: cas replace", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -452,7 +450,7 @@ TEST_CASE("integration: cas replace", "[integration]")
         couchbase::core::operations::replace_request req{ id, couchbase::core::utils::to_binary("") };
         req.cas = cas;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 }
 
@@ -473,7 +471,7 @@ TEST_CASE("integration: upsert preserve expiry", "[integration]")
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         req.expiry = expiry;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
@@ -491,7 +489,7 @@ TEST_CASE("integration: upsert preserve expiry", "[integration]")
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         req.preserve_expiry = true;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
@@ -508,7 +506,7 @@ TEST_CASE("integration: upsert preserve expiry", "[integration]")
     {
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
@@ -541,8 +539,7 @@ TEST_CASE("integration: upsert with handler capturing non-copyable object", "[in
         };
         integration.cluster->execute(req, std::move(handler));
         auto resp = f.get();
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 }
 
@@ -588,8 +585,7 @@ TEST_CASE("integration: upsert may trigger snappy compression", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, compressible_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // read
@@ -663,7 +659,7 @@ TEST_CASE("integration: upsert returns valid mutation token", "[integration]")
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
         token = resp.token;
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(token.bucket_name() == integration.ctx.bucket);
         REQUIRE(token.partition_uuid() > 0);
         REQUIRE(token.sequence_number() > 0);
@@ -677,7 +673,7 @@ TEST_CASE("integration: upsert returns valid mutation token", "[integration]")
           }
             .specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         auto vbucket_uuid = test::utils::to_string(resp.fields[0].value);
         REQUIRE(vbucket_uuid.find("\"0x") == 0);
         REQUIRE(std::strtoull(vbucket_uuid.data() + 3, nullptr, 16) == token.partition_uuid());
@@ -732,7 +728,7 @@ TEST_CASE("integration: upsert is cancelled immediately if the cluster was close
     {
         couchbase::core::operations::upsert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     test::utils::close_cluster(integration.cluster);

--- a/test/test_integration_diagnostics.cxx
+++ b/test/test_integration_diagnostics.cxx
@@ -325,8 +325,7 @@ TEST_CASE("integration: fetch diagnostics after N1QL query", "[integration]")
     {
         couchbase::core::operations::query_request req{ "SELECT 'hello, couchbase' AS greetings" };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec.message())
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         INFO("rows.size() =" << resp.rows.size())
         REQUIRE(resp.rows.size() == 1);
         INFO("row=" << resp.rows[0])

--- a/test/test_integration_durability.cxx
+++ b/test/test_integration_durability.cxx
@@ -39,8 +39,7 @@ TEST_CASE("integration: durable operations", "[integration]")
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::json::generate_binary(value) };
         req.durability_level = couchbase::durability_level::majority_and_persist_to_active;
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -51,8 +50,7 @@ TEST_CASE("integration: durable operations", "[integration]")
         couchbase::core::operations::replace_request req{ id, couchbase::core::utils::json::generate_binary(value) };
         req.durability_level = couchbase::durability_level::majority_and_persist_to_active;
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -61,16 +59,14 @@ TEST_CASE("integration: durable operations", "[integration]")
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::upsert("baz", 42) }.specs();
         req.durability_level = couchbase::durability_level::majority_and_persist_to_active;
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(R"({"foo":"bar","baz":42})"));
     }
@@ -78,8 +74,7 @@ TEST_CASE("integration: durable operations", "[integration]")
         couchbase::core::operations::remove_request req{ id };
         req.durability_level = couchbase::durability_level::majority_and_persist_to_active;
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -107,7 +102,7 @@ TEST_CASE("integration: legacy durability persist to active and replicate to one
         profile fry{ "fry", "Philip J. Fry", 1974 };
         auto options = couchbase::upsert_options{}.durability(couchbase::persist_to::active, couchbase::replicate_to::one);
         auto [ctx, result] = collection.upsert(key, fry, options).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(result.cas().empty());
         REQUIRE(result.mutation_token().has_value());
         cas = result.cas();
@@ -115,7 +110,7 @@ TEST_CASE("integration: legacy durability persist to active and replicate to one
 
     {
         auto [ctx, result] = collection.get(key, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE(result.cas() == cas);
         auto fry = result.content_as<profile>();
         REQUIRE(fry.username == "fry");
@@ -179,8 +174,7 @@ TEST_CASE("integration: low level legacy durability persist to active and replic
             couchbase::replicate_to::one,
         };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -195,8 +189,7 @@ TEST_CASE("integration: low level legacy durability persist to active and replic
             couchbase::replicate_to::one,
         };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
@@ -209,16 +202,14 @@ TEST_CASE("integration: low level legacy durability persist to active and replic
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::upsert("baz", 42) }.specs();
 
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(R"({"foo":"bar","baz":42})"));
     }
@@ -229,8 +220,7 @@ TEST_CASE("integration: low level legacy durability persist to active and replic
             couchbase::replicate_to::one,
         };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.token.sequence_number() != 0);
     }

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -85,12 +85,12 @@ TEST_CASE("integration: bucket management", "[integration]")
             couchbase::core::operations::management::bucket_create_request req;
             req.bucket = bucket_settings;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             auto resp = wait_for_bucket_created(integration, bucket_name);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(bucket_settings.bucket_type == resp.bucket.bucket_type);
             REQUIRE(bucket_settings.name == resp.bucket.name);
             REQUIRE(Approx(bucket_settings.ram_quota_mb).margin(5) == resp.bucket.ram_quota_mb);
@@ -106,7 +106,7 @@ TEST_CASE("integration: bucket management", "[integration]")
             couchbase::core::operations::management::bucket_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
             INFO(resp.ctx.http_body)
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             bool found = false;
             for (const auto& bucket : resp.buckets) {
                 if (bucket.name != bucket_name) {
@@ -133,7 +133,7 @@ TEST_CASE("integration: bucket management", "[integration]")
             couchbase::core::operations::management::bucket_update_request req;
             req.bucket = bucket_settings;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         auto ram_quota_updated = test::utils::wait_until([&integration, &bucket_name, old_quota_mb]() {
@@ -146,7 +146,7 @@ TEST_CASE("integration: bucket management", "[integration]")
         {
             couchbase::core::operations::management::bucket_drop_request req{ bucket_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -158,7 +158,7 @@ TEST_CASE("integration: bucket management", "[integration]")
         {
             couchbase::core::operations::management::bucket_get_all_request req;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(!resp.buckets.empty());
             auto known_buckets =
               std::count_if(resp.buckets.begin(), resp.buckets.end(), [&bucket_name](auto& entry) { return entry.name == bucket_name; });
@@ -177,7 +177,7 @@ TEST_CASE("integration: bucket management", "[integration]")
                 req.bucket.name = bucket_name;
                 req.bucket.flush_enabled = true;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             REQUIRE(test::utils::wait_until_bucket_healthy(integration.cluster, bucket_name));
@@ -190,19 +190,19 @@ TEST_CASE("integration: bucket management", "[integration]")
                 };
                 couchbase::core::operations::insert_request req{ id, couchbase::core::utils::json::generate_binary(value) };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
             }
 
             {
                 couchbase::core::operations::get_request req{ id };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
             }
 
             {
                 couchbase::core::operations::management::bucket_flush_request req{ bucket_name };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             auto flushed = test::utils::wait_until([&integration, id]() {
@@ -227,7 +227,7 @@ TEST_CASE("integration: bucket management", "[integration]")
                 req.bucket.name = bucket_name;
                 req.bucket.flush_enabled = false;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             REQUIRE(test::utils::wait_until_bucket_healthy(integration.cluster, bucket_name));
@@ -249,12 +249,12 @@ TEST_CASE("integration: bucket management", "[integration]")
             bucket_settings.num_replicas = 0;
             couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             auto resp = wait_for_bucket_created(integration, bucket_name);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::memcached);
         }
     }
@@ -270,13 +270,12 @@ TEST_CASE("integration: bucket management", "[integration]")
             {
                 couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                 auto resp = test::utils::execute(integration.cluster, req);
-                INFO(resp.error_message)
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 auto resp = wait_for_bucket_created(integration, bucket_name);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::ephemeral);
                 REQUIRE(resp.bucket.eviction_policy == couchbase::core::management::cluster::bucket_eviction_policy::no_eviction);
             }
@@ -288,12 +287,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                 bucket_settings.eviction_policy = couchbase::core::management::cluster::bucket_eviction_policy::not_recently_used;
                 couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 auto resp = wait_for_bucket_created(integration, bucket_name);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::ephemeral);
                 REQUIRE(resp.bucket.eviction_policy == couchbase::core::management::cluster::bucket_eviction_policy::not_recently_used);
             }
@@ -306,12 +305,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                     bucket_settings.storage_backend = couchbase::core::management::cluster::bucket_storage_backend::couchstore;
                     couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                     auto resp = test::utils::execute(integration.cluster, req);
-                    REQUIRE_FALSE(resp.ctx.ec);
+                    REQUIRE_SUCCESS(resp.ctx.ec);
                 }
 
                 {
                     auto resp = wait_for_bucket_created(integration, bucket_name);
-                    REQUIRE_FALSE(resp.ctx.ec);
+                    REQUIRE_SUCCESS(resp.ctx.ec);
                     REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::ephemeral);
                     REQUIRE(resp.bucket.storage_backend == couchbase::core::management::cluster::bucket_storage_backend::unknown);
                 }
@@ -331,13 +330,12 @@ TEST_CASE("integration: bucket management", "[integration]")
 
                 couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                 auto resp = test::utils::execute(integration.cluster, req);
-                INFO(resp.error_message)
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 auto resp = wait_for_bucket_created(integration, bucket_name);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::couchbase);
                 REQUIRE(resp.bucket.eviction_policy == couchbase::core::management::cluster::bucket_eviction_policy::value_only);
             }
@@ -349,12 +347,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                 bucket_settings.eviction_policy = couchbase::core::management::cluster::bucket_eviction_policy::full;
                 couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 auto resp = wait_for_bucket_created(integration, bucket_name);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::couchbase);
                 REQUIRE(resp.bucket.eviction_policy == couchbase::core::management::cluster::bucket_eviction_policy::full);
             }
@@ -369,12 +367,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                         bucket_settings.storage_backend = couchbase::core::management::cluster::bucket_storage_backend::couchstore;
                         couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                         auto resp = test::utils::execute(integration.cluster, req);
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                     }
 
                     {
                         auto resp = wait_for_bucket_created(integration, bucket_name);
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                         REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::couchbase);
                         REQUIRE(resp.bucket.storage_backend == couchbase::core::management::cluster::bucket_storage_backend::couchstore);
                     }
@@ -387,12 +385,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                         bucket_settings.storage_backend = couchbase::core::management::cluster::bucket_storage_backend::magma;
                         couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                         auto resp = test::utils::execute(integration.cluster, req);
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                     }
 
                     {
                         auto resp = wait_for_bucket_created(integration, bucket_name);
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                         REQUIRE(resp.bucket.bucket_type == couchbase::core::management::cluster::bucket_type::couchbase);
                         REQUIRE(resp.bucket.storage_backend == couchbase::core::management::cluster::bucket_storage_backend::magma);
                     }
@@ -423,12 +421,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                 {
                     couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                     auto resp = test::utils::execute(integration.cluster, req);
-                    REQUIRE_FALSE(resp.ctx.ec);
+                    REQUIRE_SUCCESS(resp.ctx.ec);
                 }
 
                 {
                     auto resp = wait_for_bucket_created(integration, bucket_name);
-                    REQUIRE_FALSE(resp.ctx.ec);
+                    REQUIRE_SUCCESS(resp.ctx.ec);
                     REQUIRE(resp.bucket.minimum_durability_level == couchbase::durability_level::none);
                 }
             }
@@ -440,13 +438,12 @@ TEST_CASE("integration: bucket management", "[integration]")
                         bucket_settings.minimum_durability_level = couchbase::durability_level::majority;
                         couchbase::core::operations::management::bucket_create_request req{ bucket_settings };
                         auto resp = test::utils::execute(integration.cluster, req);
-                        INFO(resp.error_message)
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                     }
 
                     {
                         auto resp = wait_for_bucket_created(integration, bucket_name);
-                        REQUIRE_FALSE(resp.ctx.ec);
+                        REQUIRE_SUCCESS(resp.ctx.ec);
                         REQUIRE(resp.bucket.minimum_durability_level == couchbase::durability_level::majority);
                     }
                 }
@@ -516,7 +513,7 @@ TEST_CASE("integration: collection management", "[integration]")
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -538,7 +535,7 @@ TEST_CASE("integration: collection management", "[integration]")
             req.max_expiry = max_expiry;
         }
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -568,7 +565,7 @@ TEST_CASE("integration: collection management", "[integration]")
     {
         couchbase::core::operations::management::collection_drop_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -586,7 +583,7 @@ TEST_CASE("integration: collection management", "[integration]")
     {
         couchbase::core::operations::management::scope_drop_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -664,13 +661,13 @@ TEST_CASE("integration: user groups management", "[integration]")
         {
             couchbase::core::operations::management::group_upsert_request req{ group };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::group_get_request req{ group_name_1 };
             auto resp = retry_on_error(integration, req, couchbase::errc::management::group_not_found);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.group.name == group.name);
             REQUIRE(resp.group.description == group.description);
             REQUIRE(resp.group.ldap_group_reference == group.ldap_group_reference);
@@ -681,7 +678,7 @@ TEST_CASE("integration: user groups management", "[integration]")
             group.roles.push_back(couchbase::core::management::rbac::role{ "query_system_catalog" });
             couchbase::core::operations::management::group_upsert_request req{ group };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -697,14 +694,14 @@ TEST_CASE("integration: user groups management", "[integration]")
             group.name = group_name_2;
             couchbase::core::operations::management::group_upsert_request req{ group };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             auto created = test::utils::wait_until([&]() {
                 couchbase::core::operations::management::group_get_all_request req{ group_name_2 };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 return resp.groups.size() == 2;
             });
             REQUIRE(created);
@@ -713,20 +710,20 @@ TEST_CASE("integration: user groups management", "[integration]")
         {
             couchbase::core::operations::management::role_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.roles.size() > 0);
         }
 
         {
             couchbase::core::operations::management::group_drop_request req{ group_name_1 };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::group_drop_request req{ group_name_2 };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
     }
 
@@ -758,7 +755,7 @@ TEST_CASE("integration: user groups management", "[integration]")
         {
             couchbase::core::operations::management::group_upsert_request req{ group };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         couchbase::core::management::rbac::user user{ user_name };
@@ -773,7 +770,7 @@ TEST_CASE("integration: user groups management", "[integration]")
             couchbase::core::operations::management::user_upsert_request req{};
             req.user = user;
             auto resp = retry_on_error(integration, req, couchbase::errc::common::invalid_argument);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         couchbase::core::management::rbac::user_and_metadata expected{};
@@ -802,7 +799,7 @@ TEST_CASE("integration: user groups management", "[integration]")
         {
             couchbase::core::operations::management::user_get_request req{ user_name };
             auto resp = retry_on_error(integration, req, couchbase::errc::management::user_not_found);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             assert_user_and_metadata(resp.user, expected);
         }
 
@@ -813,7 +810,7 @@ TEST_CASE("integration: user groups management", "[integration]")
             couchbase::core::operations::management::user_upsert_request req{};
             req.user = user;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -823,14 +820,14 @@ TEST_CASE("integration: user groups management", "[integration]")
                 resp = test::utils::execute(integration.cluster, req);
                 return !resp.ctx.ec && resp.user.display_name == user.display_name;
             });
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             assert_user_and_metadata(resp.user, expected);
         }
 
         {
             couchbase::core::operations::management::user_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE_FALSE(resp.users.empty());
             auto upserted_user =
               std::find_if(resp.users.begin(), resp.users.end(), [&user_name](const auto& u) { return u.username == user_name; });
@@ -841,13 +838,13 @@ TEST_CASE("integration: user groups management", "[integration]")
         {
             couchbase::core::operations::management::user_drop_request req{ user_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::group_drop_request req{ group_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
     }
 }
@@ -882,7 +879,7 @@ TEST_CASE("integration: user management", "[integration]")
     {
         couchbase::core::operations::management::role_get_all_request req{};
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.roles.size() > 0);
     }
 }
@@ -904,7 +901,7 @@ TEST_CASE("integration: user management collections roles", "[integration]")
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -912,7 +909,7 @@ TEST_CASE("integration: user management collections roles", "[integration]")
     {
         couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -928,13 +925,13 @@ TEST_CASE("integration: user management collections roles", "[integration]")
         couchbase::core::operations::management::user_upsert_request req{};
         req.user = user;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
         couchbase::core::operations::management::user_get_request req{ user_name };
         auto resp = retry_on_error(integration, req, couchbase::errc::management::user_not_found);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.user.roles.size() == 1);
         REQUIRE(resp.user.roles[0].name == "data_reader");
         REQUIRE(resp.user.roles[0].bucket == integration.ctx.bucket);
@@ -949,13 +946,13 @@ TEST_CASE("integration: user management collections roles", "[integration]")
         couchbase::core::operations::management::user_upsert_request req{};
         req.user = user;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
         couchbase::core::operations::management::user_get_request req{ user_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.user.roles.size() == 1);
         REQUIRE(resp.user.roles[0].name == "data_reader");
         REQUIRE(resp.user.roles[0].bucket == integration.ctx.bucket);
@@ -999,14 +996,14 @@ TEST_CASE("integration: query index management", "[integration]")
                     return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
                 });
                 REQUIRE(operation_completed);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 couchbase::core::operations::management::query_index_get_all_request req{};
                 req.bucket_name = bucket_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 REQUIRE(resp.indexes.size() == 1);
                 REQUIRE(resp.indexes[0].name == "#primary");
                 REQUIRE(resp.indexes[0].is_primary);
@@ -1032,7 +1029,7 @@ TEST_CASE("integration: query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1051,14 +1048,14 @@ TEST_CASE("integration: query index management", "[integration]")
             req.fields = { "field" };
             req.ignore_if_exists = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::query_index_get_all_request req{};
             req.bucket_name = integration.ctx.bucket;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             auto index = std::find_if(
               resp.indexes.begin(), resp.indexes.end(), [&index_name](const auto& exp_index) { return exp_index.name == index_name; });
             REQUIRE(index != resp.indexes.end());
@@ -1077,7 +1074,7 @@ TEST_CASE("integration: query index management", "[integration]")
             req.bucket_name = integration.ctx.bucket;
             req.index_name = index_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1103,14 +1100,14 @@ TEST_CASE("integration: query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::query_index_get_all_request req{};
             req.bucket_name = integration.ctx.bucket;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             auto index = std::find_if(
               resp.indexes.begin(), resp.indexes.end(), [&index_name](const auto& exp_index) { return exp_index.name == index_name; });
             REQUIRE(index != resp.indexes.end());
@@ -1121,7 +1118,7 @@ TEST_CASE("integration: query index management", "[integration]")
         {
             auto manager = couchbase::cluster(integration.cluster).query_indexes();
             auto ctx = manager.build_deferred_indexes(integration.ctx.bucket, {}).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
         }
 
         test::utils::wait_until([&integration, &index_name]() {
@@ -1151,7 +1148,7 @@ TEST_CASE("integration: query index management", "[integration]")
         couchbase::core::operations::management::query_index_get_all_request req{};
         req.bucket_name = "missing_bucket";
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.indexes.empty());
     }
 
@@ -1187,7 +1184,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     {
         couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -1195,7 +1192,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     {
         couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket, scope_name, collection_name };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         auto created = test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
         REQUIRE(created);
     }
@@ -1214,7 +1211,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1223,7 +1220,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.scope_name = scope_name;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.indexes.size() == 1);
             REQUIRE(resp.indexes[0].name == "#primary");
             REQUIRE(resp.indexes[0].is_primary);
@@ -1245,7 +1242,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1254,7 +1251,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.scope_name = scope_name;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.indexes.size() == 1);
             REQUIRE(resp.indexes[0].name == index_name);
             REQUIRE(resp.indexes[0].is_primary);
@@ -1268,7 +1265,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.is_primary = true;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
     }
 
@@ -1287,7 +1284,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1310,7 +1307,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.fields = { "field" };
             req.ignore_if_exists = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1319,7 +1316,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.scope_name = scope_name;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.indexes.size() == 1);
             REQUIRE(resp.indexes[0].name == index_name);
             REQUIRE_FALSE(resp.indexes[0].is_primary);
@@ -1338,7 +1335,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.scope_name = scope_name;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1368,7 +1365,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
             });
             REQUIRE(operation_completed);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1377,7 +1374,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
             req.scope_name = scope_name;
             req.collection_name = collection_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.indexes.size() == 1);
             REQUIRE(resp.indexes[0].name == index_name);
             REQUIRE(resp.indexes[0].state == "deferred");
@@ -1386,7 +1383,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
         {
             auto manager = couchbase::cluster(integration.cluster).query_indexes();
             auto ctx = manager.build_deferred_indexes(integration.ctx.bucket, {}).get();
-            REQUIRE_FALSE(ctx.ec());
+            REQUIRE_SUCCESS(ctx.ec());
         }
 
         test::utils::wait_until([&integration, scope_name, collection_name]() {
@@ -1431,7 +1428,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
         req.scope_name = scope_name;
         req.collection_name = "missing_collection";
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.indexes.empty());
     }
 
@@ -1481,7 +1478,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             couchbase::core::operations::management::analytics_dataverse_create_request req{};
             req.dataverse_name = dataverse_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1496,7 +1493,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataverse_name = dataverse_name;
             req.ignore_if_exists = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1505,7 +1502,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.bucket_name = integration.ctx.bucket;
             req.dataverse_name = dataverse_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1524,7 +1521,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataverse_name = dataverse_name;
             req.ignore_if_exists = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1534,7 +1531,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.index_name = index_name;
             req.fields["testkey"] = "string";
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1555,19 +1552,19 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.fields["testkey"] = "string";
             req.ignore_if_exists = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::analytics_link_connect_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::analytics_dataset_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE_FALSE(resp.datasets.empty());
             auto dataset = std::find_if(resp.datasets.begin(), resp.datasets.end(), [&dataset_name](const auto& exp_dataset) {
                 return exp_dataset.name == dataset_name;
@@ -1581,7 +1578,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
         {
             couchbase::core::operations::management::analytics_index_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE_FALSE(resp.indexes.empty());
             auto index = std::find_if(
               resp.indexes.begin(), resp.indexes.end(), [&index_name](const auto& exp_index) { return exp_index.name == index_name; });
@@ -1594,14 +1591,14 @@ TEST_CASE("integration: analytics index management", "[integration]")
         if (integration.cluster_version().supports_analytics_pending_mutations()) {
             couchbase::core::operations::management::analytics_get_pending_mutations_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.stats[index_name] == 0);
         }
 
         {
             couchbase::core::operations::management::analytics_link_disconnect_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1610,7 +1607,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataverse_name = dataverse_name;
             req.dataset_name = dataset_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1629,7 +1626,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataset_name = dataset_name;
             req.ignore_if_does_not_exist = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1637,7 +1634,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataverse_name = dataverse_name;
             req.dataset_name = dataset_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1654,14 +1651,14 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataset_name = dataset_name;
             req.ignore_if_does_not_exist = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::analytics_dataverse_drop_request req{};
             req.dataverse_name = dataverse_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -1676,7 +1673,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
             req.dataverse_name = dataverse_name;
             req.ignore_if_does_not_exist = true;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
     }
 
@@ -1691,7 +1688,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
                 couchbase::core::operations::management::analytics_dataverse_create_request req{};
                 req.dataverse_name = dataverse_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -1700,7 +1697,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
                 req.dataverse_name = dataverse_name;
                 req.dataset_name = dataset_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -1710,21 +1707,21 @@ TEST_CASE("integration: analytics index management", "[integration]")
                 req.index_name = index_name;
                 req.fields["testkey"] = "string";
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 couchbase::core::operations::management::analytics_link_connect_request req{};
                 req.dataverse_name = dataverse_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 couchbase::core::operations::management::analytics_link_disconnect_request req{};
                 req.dataverse_name = dataverse_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -1733,7 +1730,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
                 req.dataset_name = dataset_name;
                 req.index_name = index_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -1741,14 +1738,14 @@ TEST_CASE("integration: analytics index management", "[integration]")
                 req.dataverse_name = dataverse_name;
                 req.dataset_name = dataset_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
                 couchbase::core::operations::management::analytics_dataverse_drop_request req{};
                 req.dataverse_name = dataverse_name;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
         }
     }
@@ -1761,7 +1758,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
         couchbase::core::operations::management::analytics_dataverse_create_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -1776,7 +1773,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
           req{};
         req.link = link;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -1798,7 +1795,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
         couchbase::core::operations::management::analytics_link_get_all_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.s3.size() == 1);
         REQUIRE(resp.s3[0].link_name == link_name);
         REQUIRE(resp.s3[0].dataverse == dataverse_name);
@@ -1813,7 +1810,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
         req.link_type = "s3";
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.s3.size() == 1);
         REQUIRE(resp.azure_blob.empty());
         REQUIRE(resp.couchbase.empty());
@@ -1824,7 +1821,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
         req.link_type = "couchbase";
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.s3.empty());
         REQUIRE(resp.azure_blob.empty());
         REQUIRE(resp.couchbase.empty());
@@ -1842,14 +1839,14 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
           req{};
         req.link = link;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
         couchbase::core::operations::management::analytics_link_get_all_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.s3.size() == 1);
         REQUIRE(resp.s3[0].region == "eu-west-1");
     }
@@ -1859,7 +1856,7 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
         req.dataverse_name = dataverse_name;
         req.link_name = link_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -1878,7 +1875,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
         couchbase::core::operations::management::analytics_dataverse_create_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -1893,7 +1890,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
           req{};
         req.link = link;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -1915,7 +1912,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
         couchbase::core::operations::management::analytics_link_get_all_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.azure_blob.size() == 1);
         REQUIRE(resp.azure_blob[0].link_name == link_name);
         REQUIRE(resp.azure_blob[0].dataverse == dataverse_name);
@@ -1932,7 +1929,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
         req.link_type = "azureblob";
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.azure_blob.size() == 1);
         REQUIRE(resp.s3.empty());
         REQUIRE(resp.couchbase.empty());
@@ -1943,7 +1940,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
         req.link_type = "couchbase";
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.s3.empty());
         REQUIRE(resp.azure_blob.empty());
         REQUIRE(resp.couchbase.empty());
@@ -1961,14 +1958,14 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
           req{};
         req.link = link;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
         couchbase::core::operations::management::analytics_link_get_all_request req{};
         req.dataverse_name = dataverse_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.azure_blob.size() == 1);
         REQUIRE(resp.azure_blob[0].blob_endpoint == "new_blob_endpoint");
     }
@@ -1978,7 +1975,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
         req.dataverse_name = dataverse_name;
         req.link_name = link_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     {
@@ -2065,7 +2062,7 @@ TEST_CASE("integration: analytics external link management", "[integration]")
             {
                 couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
                 auto created =
                   test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
                 REQUIRE(created);
@@ -2111,7 +2108,7 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_upsert_request req{};
             req.index = index;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -2137,7 +2134,7 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_upsert_request req{};
             req.index = index;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             if (resp.name != index2_name) {
                 // FIXME: server 7.2 might automatically prepend "{scope}.{collection}." in front of the index name
                 // to workaround it, we "patch" our variable with the name returned by the server
@@ -2155,14 +2152,14 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_upsert_request req{};
             req.index = index;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::search_index_get_request req{};
             req.index_name = index1_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.index.name == index1_name);
             REQUIRE(resp.index.type == "fulltext-index");
         }
@@ -2171,7 +2168,7 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_get_request req{};
             req.index_name = index2_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.index.name == index2_name);
             REQUIRE(resp.index.type == "fulltext-index");
         }
@@ -2180,7 +2177,7 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_get_request req{};
             req.index_name = alias_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.index.name == alias_name);
             REQUIRE(resp.index.type == "fulltext-alias");
         }
@@ -2195,7 +2192,7 @@ TEST_CASE("integration: search index management", "[integration]")
         {
             couchbase::core::operations::management::search_index_get_all_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE_FALSE(resp.indexes.empty());
 
             REQUIRE(1 == std::count_if(
@@ -2210,21 +2207,21 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_drop_request req{};
             req.index_name = index1_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::search_index_drop_request req{};
             req.index_name = index2_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::search_index_drop_request req{};
             req.index_name = alias_name;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         couchbase::core::operations::management::search_index_drop_request req{};
@@ -2258,7 +2255,7 @@ TEST_CASE("integration: search index management", "[integration]")
             couchbase::core::operations::management::search_index_upsert_request req{};
             req.index = index;
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         SECTION("ingest control")
@@ -2268,7 +2265,7 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.pause = true;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -2276,7 +2273,7 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.pause = false;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
         }
 
@@ -2287,7 +2284,7 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.allow = true;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -2295,7 +2292,7 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.allow = false;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
         }
 
@@ -2306,7 +2303,7 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.freeze = true;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
 
             {
@@ -2314,14 +2311,14 @@ TEST_CASE("integration: search index management", "[integration]")
                 req.index_name = index_name;
                 req.freeze = false;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
         }
 
         couchbase::core::operations::management::search_index_drop_request req{};
         req.index_name = index_name;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 }
 
@@ -2368,7 +2365,7 @@ TEST_CASE("integration: search index management analyze document", "[integration
         couchbase::core::operations::management::search_index_upsert_request req{};
         req.index = index;
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
     }
 
     REQUIRE(wait_for_search_pindexes_ready(integration, index_name));
@@ -2382,7 +2379,7 @@ TEST_CASE("integration: search index management analyze document", "[integration
         return resp.ctx.ec != couchbase::errc::common::internal_server_failure;
     });
     REQUIRE(operation_completed);
-    REQUIRE_FALSE(resp.ctx.ec);
+    REQUIRE_SUCCESS(resp.ctx.ec);
     REQUIRE_FALSE(resp.analysis.empty());
 }
 
@@ -2410,7 +2407,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
             req.method = "GET";
             req.path = "/admin/ping";
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.status == 200);
             REQUIRE_FALSE(resp.body.empty());
             INFO(resp.body)
@@ -2426,7 +2423,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
         req.method = "GET";
         req.path = "/api/ping";
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.status == 200);
         REQUIRE(resp.body.empty());
         REQUIRE_FALSE(resp.headers.empty());
@@ -2440,7 +2437,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
         req.method = "GET";
         req.path = "/admin/ping";
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.status == 200);
         REQUIRE_FALSE(resp.body.empty());
         INFO(resp.body)
@@ -2460,7 +2457,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
             req.path = fmt::format("/{}/_design/{}/_view/{}", integration.ctx.bucket, document_name, view_name);
             req.body = R"({"keys":["foo","bar"]})";
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.status == 404);
             REQUIRE_FALSE(resp.body.empty());
             auto result = couchbase::core::utils::json::parse(resp.body);
@@ -2476,7 +2473,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
         req.method = "GET";
         req.path = "/pools";
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec);
+        REQUIRE_SUCCESS(resp.ctx.ec);
         REQUIRE(resp.status == 200);
         REQUIRE_FALSE(resp.body.empty());
         auto result = couchbase::core::utils::json::parse(resp.body);
@@ -2496,7 +2493,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
             req.headers["content-type"] = "application/x-www-form-urlencoded";
             req.body = fmt::format("name={}", couchbase::core::utils::string_codec::form_encode(scope_name));
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.status == 200);
             REQUIRE_FALSE(resp.headers.empty());
             REQUIRE(resp.headers["content-type"].find("application/json") != std::string::npos);
@@ -2515,7 +2512,7 @@ TEST_CASE("integration: freeform HTTP request", "[integration]")
             req.method = "GET";
             req.path = "/api/v1/functions";
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.status == 200);
             REQUIRE_FALSE(resp.body.empty());
             auto result = couchbase::core::utils::json::parse(resp.body);
@@ -2603,13 +2600,13 @@ TEST_CASE("integration: eventing functions management", "[integration]")
                 couchbase::core::operations::management::bucket_create_request req;
                 req.bucket = bucket_settings;
                 auto resp = test::utils::execute(integration.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec);
+                REQUIRE_SUCCESS(resp.ctx.ec);
             }
         }
 
         {
             auto resp = wait_for_bucket_created(integration, meta_bucket_name);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         std::string source_code = R"(
@@ -2635,18 +2632,18 @@ function OnDelete(meta, options) {
             req.function.url_bindings.emplace_back(
               couchbase::core::management::eventing::function_url_binding{ "home", "https://couchbase.com" });
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             auto resp = wait_for_function_created(integration, function_name);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
             couchbase::core::operations::management::eventing_get_all_functions_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             auto function = std::find_if(
               resp.functions.begin(), resp.functions.end(), [&function_name](const auto& fun) { return function_name == fun.name; });
             REQUIRE(function != resp.functions.end());
@@ -2673,7 +2670,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_get_status_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             REQUIRE(resp.status.num_eventing_nodes > 0);
             auto function = std::find_if(resp.status.functions.begin(), resp.status.functions.end(), [&function_name](const auto& fun) {
                 return function_name == fun.name;
@@ -2693,7 +2690,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_deploy_function_request req{ function_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         REQUIRE(
@@ -2714,7 +2711,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_pause_function_request req{ function_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         REQUIRE(wait_for_function_reach_status(integration, function_name, couchbase::core::management::eventing::function_status::paused));
@@ -2728,7 +2725,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_resume_function_request req{ function_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         REQUIRE(
@@ -2737,7 +2734,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_undeploy_function_request req{ function_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         REQUIRE(
@@ -2746,7 +2743,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::eventing_drop_function_request req{ function_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
 
         {
@@ -2758,7 +2755,7 @@ function OnDelete(meta, options) {
         {
             couchbase::core::operations::management::bucket_drop_request req{ meta_bucket_name };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
         }
     }
 }

--- a/test/test_integration_read_replica.cxx
+++ b/test/test_integration_read_replica.cxx
@@ -78,14 +78,14 @@ TEST_CASE("integration: get any replica", "[integration]")
 
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         auto collection =
           couchbase::cluster(integration.cluster).bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
         auto [ctx, result] = collection.get_any_replica(key, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE(result.content_as<smuggling_transcoder>().first == basic_doc_json);
     }
 }
@@ -110,14 +110,14 @@ TEST_CASE("integration: get all replicas", "[integration]")
 
         couchbase::core::operations::insert_request req{ id, basic_doc_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         auto collection =
           couchbase::cluster(integration.cluster).bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
         auto [ctx, result] = collection.get_all_replicas(key, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE(result.size() == number_of_replicas + 1);
         auto responses_from_active = std::count_if(result.begin(), result.end(), [](const auto& r) { return !r.is_replica(); });
         REQUIRE(responses_from_active == 1);
@@ -187,14 +187,13 @@ TEST_CASE("integration: get any replica low-level version", "[integration]")
         };
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::json::generate_binary(value) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_any_replica_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(!resp.cas.empty());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(R"({"a":1.0,"b":2.0})"));
     }
@@ -219,14 +218,13 @@ TEST_CASE("integration: get all replicas low-level version", "[integration]")
         };
         couchbase::core::operations::upsert_request req{ id, couchbase::core::utils::json::generate_binary(value) };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_all_replicas_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        INFO(resp.ctx.ec().message())
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.entries.size() == number_of_replicas + 1);
         auto responses_from_active = std::count_if(resp.entries.begin(), resp.entries.end(), [](const auto& r) { return !r.replica; });
         REQUIRE(responses_from_active == 1);

--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -31,13 +31,13 @@ assert_single_lookup_success(test::utils::integration_test_guard& integration,
     req.specs = couchbase::lookup_in_specs{ spec }.specs();
     auto resp = test::utils::execute(integration.cluster, req);
     INFO(fmt::format("assert_single_lookup_success(\"{}\", \"{}\")", id, req.specs[0].path_))
-    REQUIRE_FALSE(resp.ctx.ec());
+    REQUIRE_SUCCESS(resp.ctx.ec());
     REQUIRE_FALSE(resp.cas.empty());
     REQUIRE(resp.fields.size() == 1);
     REQUIRE(resp.fields[0].exists);
     REQUIRE(resp.fields[0].path == req.specs[0].path_);
     REQUIRE(resp.fields[0].status == couchbase::key_value_status_code::success);
-    REQUIRE_FALSE(resp.fields[0].ec);
+    REQUIRE_SUCCESS(resp.fields[0].ec);
     if (expected_value.has_value()) {
         REQUIRE(couchbase::core::utils::to_binary(expected_value.value()) == resp.fields[0].value);
     }
@@ -55,7 +55,7 @@ assert_single_lookup_error(test::utils::integration_test_guard& integration,
     req.specs = couchbase::lookup_in_specs{ spec }.specs();
     auto resp = test::utils::execute(integration.cluster, req);
     INFO(fmt::format("assert_single_lookup_error(\"{}\", \"{}\")", id, req.specs[0].path_))
-    REQUIRE_FALSE(resp.ctx.ec());
+    REQUIRE_SUCCESS(resp.ctx.ec());
     REQUIRE_FALSE(resp.cas.empty());
     REQUIRE(resp.fields.size() == 1);
     REQUIRE_FALSE(resp.fields[0].exists);
@@ -68,12 +68,12 @@ assert_single_lookup_error(test::utils::integration_test_guard& integration,
 void
 assert_single_mutate_success(couchbase::core::operations::mutate_in_response resp, const std::string& path, const std::string& value = "")
 {
-    REQUIRE_FALSE(resp.ctx.ec());
+    REQUIRE_SUCCESS(resp.ctx.ec());
     REQUIRE_FALSE(resp.cas.empty());
     REQUIRE(resp.fields.size() == 1);
     REQUIRE(resp.fields[0].path == path);
     REQUIRE(resp.fields[0].status == couchbase::key_value_status_code::success);
-    REQUIRE_FALSE(resp.fields[0].ec);
+    REQUIRE_SUCCESS(resp.fields[0].ec);
     REQUIRE(resp.fields[0].value == couchbase::core::utils::to_binary(value));
 }
 
@@ -102,7 +102,7 @@ TEST_CASE("integration: subdoc get & exists", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("dict get")
@@ -192,7 +192,7 @@ TEST_CASE("integration: subdoc get & exists", "[integration]")
         {
             couchbase::core::operations::insert_request req{ non_json_id, non_json_doc };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         SECTION("non json get")
@@ -258,7 +258,7 @@ TEST_CASE("integration: subdoc store", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -389,7 +389,7 @@ TEST_CASE("integration: subdoc store", "[integration]")
             couchbase::core::operations::mutate_in_request req{ id };
             req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::replace(path, value) }.specs();
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
     }
 }
@@ -418,7 +418,7 @@ TEST_CASE("integration: subdoc unique", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // Push to a non-existent array (without parent)
@@ -475,7 +475,7 @@ TEST_CASE("integration: subdoc counter", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("simple increment")
@@ -530,7 +530,7 @@ TEST_CASE("integration: subdoc counter", "[integration]")
             auto value_json = couchbase::core::utils::to_binary(big_value);
             couchbase::core::operations::upsert_request req{ id, value_json };
             auto resp = test::utils::execute(integration.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec());
+            REQUIRE_SUCCESS(resp.ctx.ec());
         }
 
         {
@@ -579,7 +579,7 @@ TEST_CASE("integration: subdoc multi lookup", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("simple multi lookup")
@@ -594,7 +594,7 @@ TEST_CASE("integration: subdoc multi lookup", "[integration]")
           }
             .specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.fields.size() == 4);
 
         REQUIRE(resp.fields[0].value == couchbase::core::utils::to_binary(R"("dictval")"));
@@ -650,7 +650,7 @@ TEST_CASE("integration: subdoc multi mutation", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("simple multi mutation")
@@ -664,7 +664,7 @@ TEST_CASE("integration: subdoc multi mutation", "[integration]")
           }
             .specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.fields.size() == 2);
 
         REQUIRE(resp.fields[1].value == couchbase::core::utils::to_binary("42"));
@@ -702,7 +702,7 @@ TEST_CASE("integration: subdoc expiry")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
@@ -724,7 +724,7 @@ TEST_CASE("integration: subdoc get count", "[integration]")
         auto value_json = couchbase::core::utils::to_binary(R"({"dictkey":"dictval","array":[1,2,3,4,[10,20,30,[100,200,300]]]})");
         couchbase::core::operations::insert_request req{ id, value_json };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     SECTION("top level get count")
@@ -742,7 +742,7 @@ TEST_CASE("integration: subdoc get count", "[integration]")
           }
             .specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.fields.size() == 2);
 
         REQUIRE(resp.fields[0].value.empty());
@@ -763,7 +763,7 @@ TEST_CASE("integration: subdoc insert error consistency", "[integration]")
     {
         couchbase::core::operations::insert_request req{ id, couchbase::core::utils::to_binary("{}") };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         cas = resp.cas;
     }
 
@@ -814,7 +814,7 @@ TEST_CASE("integration: subdoc remove with empty path", "[integration]")
         auto initial_value = couchbase::core::utils::to_binary(R"({"bar":"foo"})");
         couchbase::core::operations::insert_request req{ id, initial_value };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     // replace with empty path sets root value
@@ -822,13 +822,13 @@ TEST_CASE("integration: subdoc remove with empty path", "[integration]")
         couchbase::core::operations::mutate_in_request req{ id };
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::replace(empty_path, value) }.specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::json::generate_binary(value));
     }
 
@@ -837,7 +837,7 @@ TEST_CASE("integration: subdoc remove with empty path", "[integration]")
         couchbase::core::operations::mutate_in_request req{ id };
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::remove(empty_path) }.specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
@@ -861,12 +861,12 @@ TEST_CASE("integration: subdoc top level array", "[integration]")
         req.store_semantics = couchbase::store_semantics::upsert;
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::array_prepend(empty_path, 1) }.specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary("[1]"));
     }
 
@@ -882,13 +882,13 @@ TEST_CASE("integration: subdoc top level array", "[integration]")
         couchbase::core::operations::mutate_in_request req{ id };
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::array_add_unique(empty_path, 42) }.specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary("[1,42]"));
     }
 
@@ -898,13 +898,13 @@ TEST_CASE("integration: subdoc top level array", "[integration]")
         couchbase::core::operations::mutate_in_request req{ id };
         req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::array_append(empty_path, 2) }.specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
     }
 
     {
         couchbase::core::operations::get_request req{ id };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary("[1,42,2]"));
     }
 
@@ -917,7 +917,7 @@ TEST_CASE("integration: subdoc top level array", "[integration]")
           }
             .specs();
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_FALSE(resp.ctx.ec());
+        REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.fields.size() == 1);
         REQUIRE(resp.fields[0].value == couchbase::core::utils::to_binary("3"));
     }

--- a/test/test_integration_tracer.cxx
+++ b/test/test_integration_tracer.cxx
@@ -174,7 +174,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 couchbase::core::operations::upsert_request req{ make_id(guard.ctx), value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.upsert", parent_span);
@@ -185,7 +185,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 couchbase::core::operations::insert_request req{ make_id(guard.ctx), value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.insert", parent_span);
@@ -197,7 +197,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 couchbase::core::operations::get_request req{ existing_id };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.get", parent_span);
@@ -209,7 +209,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 couchbase::core::operations::replace_request req{ existing_id, new_value };
                 req.parent_span = parent_span;
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.replace", parent_span);
@@ -222,7 +222,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 req.id = existing_id;
                 req.specs = couchbase::lookup_in_specs{ couchbase::lookup_in_specs::get("some") }.specs();
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.lookup_in", parent_span);
@@ -235,7 +235,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
                 req.id = existing_id;
                 req.specs = couchbase::mutate_in_specs{ couchbase::mutate_in_specs::upsert("another", "field") }.specs();
                 auto resp = test::utils::execute(guard.cluster, req);
-                REQUIRE_FALSE(resp.ctx.ec());
+                REQUIRE_SUCCESS(resp.ctx.ec());
                 auto spans = tracer->spans();
                 REQUIRE_FALSE(spans.empty());
                 assert_kv_op_span_ok(guard, spans.front(), "cb.mutate_in", parent_span);
@@ -250,7 +250,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
             couchbase::core::operations::query_request req{ R"(SELECT "ruby rules" AS greeting)" };
             req.parent_span = parent_span;
             auto resp = test::utils::execute(guard.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "query", parent_span);
@@ -280,7 +280,7 @@ TEST_CASE("integration: enable external tracer", "[integration]")
             req.bucket_name = guard.ctx.bucket;
             req.statement = R"(SELECT "ruby rules" AS greeting)";
             auto resp = test::utils::execute(guard.cluster, req);
-            REQUIRE_FALSE(resp.ctx.ec);
+            REQUIRE_SUCCESS(resp.ctx.ec);
             auto spans = tracer->spans();
             REQUIRE_FALSE(spans.empty());
             assert_http_op_span_ok(spans.front(), "analytics", parent_span);

--- a/test/test_integration_transcoders.cxx
+++ b/test/test_integration_transcoders.cxx
@@ -39,14 +39,14 @@ TEST_CASE("integration: upsert/get with json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.upsert(id, albert, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == albert);
     }
@@ -67,14 +67,14 @@ TEST_CASE("integration: insert/get with json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.insert(id, albert, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == albert);
     }
@@ -96,7 +96,7 @@ TEST_CASE("integration: insert/replace with json transcoder", "[integration]")
     couchbase::cas original_cas;
     {
         auto [ctx, resp] = collection.insert(id, albert, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
         original_cas = resp.cas();
@@ -104,7 +104,7 @@ TEST_CASE("integration: insert/replace with json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.cas() == original_cas);
         REQUIRE(resp.content_as<profile>() == albert);
@@ -113,14 +113,14 @@ TEST_CASE("integration: insert/replace with json transcoder", "[integration]")
     {
         albert.username += " (clone)";
         auto [ctx, resp] = collection.replace(id, albert, couchbase::replace_options{}.cas(original_cas)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.cas() != original_cas);
         REQUIRE(resp.content_as<profile>() == albert);
@@ -151,7 +151,7 @@ TEST_CASE("integration: upsert/remove with json transcoder", "[integration]")
     couchbase::cas original_cas;
     {
         auto [ctx, resp] = collection.upsert(id, albert, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
         original_cas = resp.cas();
@@ -159,7 +159,7 @@ TEST_CASE("integration: upsert/remove with json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.remove(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
         REQUIRE(resp.cas() != original_cas);
@@ -186,28 +186,28 @@ TEST_CASE("integration: upsert/append/prepend with raw binary transcoder", "[int
 
     {
         auto [ctx, resp] = collection.upsert<couchbase::codec::raw_binary_transcoder>(id, data, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<couchbase::codec::raw_binary_transcoder>() == std::vector{ std::byte{ 20 }, std::byte{ 21 } });
     }
 
     {
         auto [ctx, resp] = collection.binary().prepend(id, std::vector{ std::byte{ 10 }, std::byte{ 11 } }, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<couchbase::codec::raw_binary_transcoder>() ==
                 std::vector{ std::byte{ 10 }, std::byte{ 11 }, std::byte{ 20 }, std::byte{ 21 } });
@@ -215,14 +215,14 @@ TEST_CASE("integration: upsert/append/prepend with raw binary transcoder", "[int
 
     {
         auto [ctx, resp] = collection.binary().append(id, std::vector{ std::byte{ 30 }, std::byte{ 31 } }, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<couchbase::codec::raw_binary_transcoder>() ==
                 std::vector{ std::byte{ 10 }, std::byte{ 11 }, std::byte{ 20 }, std::byte{ 21 }, std::byte{ 30 }, std::byte{ 31 } });
@@ -245,14 +245,14 @@ TEST_CASE("integration: get with expiry and json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.upsert(id, albert, couchbase::upsert_options{}.expiry(skynet_birthday)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.with_expiry(true)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == albert);
         REQUIRE(resp.expiry_time().has_value());
@@ -275,14 +275,14 @@ TEST_CASE("integration: get with projections and json transcoder", "[integration
 
     {
         auto [ctx, resp] = collection.upsert(id, albert, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.project({ "username", "full_name" })).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         auto light_albert = resp.content_as<profile>();
         REQUIRE_FALSE(light_albert == albert);
@@ -311,14 +311,14 @@ TEST_CASE("integration: get_and_touch and json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.upsert(id, cecilia, couchbase::upsert_options{}.expiry(skynet_birthday)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.with_expiry(true)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == cecilia);
         REQUIRE(resp.expiry_time().has_value());
@@ -329,7 +329,7 @@ TEST_CASE("integration: get_and_touch and json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.get_and_touch(id, asteroid_99942_apophis_passage, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == cecilia);
         REQUIRE_FALSE(resp.expiry_time().has_value());
@@ -337,7 +337,7 @@ TEST_CASE("integration: get_and_touch and json transcoder", "[integration]")
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.with_expiry(true)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == cecilia);
         REQUIRE(resp.expiry_time().has_value());
@@ -369,14 +369,14 @@ TEST_CASE("integration: touch with public API", "[integration]")
 
     {
         auto [ctx, resp] = collection.upsert(id, cecilia, couchbase::upsert_options{}.expiry(skynet_birthday)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
     }
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.with_expiry(true)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == cecilia);
         REQUIRE(resp.expiry_time().has_value());
@@ -387,13 +387,13 @@ TEST_CASE("integration: touch with public API", "[integration]")
 
     {
         auto [ctx, resp] = collection.touch(id, asteroid_99942_apophis_passage, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
     }
 
     {
         auto [ctx, resp] = collection.get(id, couchbase::get_options{}.with_expiry(true)).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.content_as<profile>() == cecilia);
         REQUIRE(resp.expiry_time().has_value());
@@ -424,7 +424,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
     couchbase::mutation_token token{};
     {
         auto [ctx, resp] = collection.upsert(id, cixin, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         REQUIRE(resp.mutation_token().has_value());
         token = resp.mutation_token().value();
@@ -441,7 +441,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                                         },
                                         {})
                              .get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
 
         REQUIRE_FALSE(resp.is_deleted());
@@ -476,7 +476,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                                         },
                                         {})
                              .get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(ctx.first_error_index());
         REQUIRE_FALSE(ctx.first_error_path());
         REQUIRE_FALSE(resp.cas().empty());
@@ -492,7 +492,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                                         },
                                         {})
                              .get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
 
         REQUIRE(resp.exists(0));
@@ -506,7 +506,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
 
     {
         auto [ctx, resp] = collection.remove(id, {}).get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
         cas = resp.cas();
     }
@@ -519,7 +519,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                                         },
                                         couchbase::lookup_in_options{}.access_deleted(true))
                              .get();
-        REQUIRE_FALSE(ctx.ec());
+        REQUIRE_SUCCESS(ctx.ec());
         REQUIRE_FALSE(resp.cas().empty());
 
         REQUIRE(resp.is_deleted());

--- a/test/test_unit_json_streaming_lexer.cxx
+++ b/test/test_unit_json_streaming_lexer.cxx
@@ -58,7 +58,7 @@ null,1,false
         result.meta = std::move(meta);
     });
     lexer.feed(chunk);
-    REQUIRE_FALSE(result.ec);
+    REQUIRE_SUCCESS(result.ec);
     REQUIRE(result.number_of_rows == 5);
     REQUIRE(result.rows.size() == 5);
     REQUIRE(result.meta == R"(
@@ -109,7 +109,7 @@ TEST_CASE("unit: json_streaming_lexer parse query result", "[unit]")
     for (const auto& chunk : chunks) {
         lexer.feed(chunk);
     }
-    REQUIRE_FALSE(result.ec);
+    REQUIRE_SUCCESS(result.ec);
     REQUIRE(result.number_of_rows == 3);
     REQUIRE(result.rows.size() == 3);
     REQUIRE(result.meta == chunks[0] + chunks[4]);
@@ -140,7 +140,7 @@ TEST_CASE("unit: json_streaming_lexer parse query result in multiple chunks", "[
     for (const auto& chunk : chunks) {
         lexer.feed(chunk);
     }
-    REQUIRE_FALSE(result.ec);
+    REQUIRE_SUCCESS(result.ec);
     REQUIRE(result.number_of_rows == 1);
     REQUIRE(result.rows.size() == 1);
 
@@ -178,7 +178,7 @@ TEST_CASE("unit: json_streaming_lexer parse chunked metadata trailer", "[unit]")
     for (const auto& chunk : chunks) {
         lexer.feed(chunk);
     }
-    REQUIRE_FALSE(result.ec);
+    REQUIRE_SUCCESS(result.ec);
     REQUIRE(result.number_of_rows == 1);
     REQUIRE(result.rows.size() == 1);
     const auto* expected_meta =
@@ -228,7 +228,7 @@ TEST_CASE("unit: json_streaming_lexer parse payload with missing results", "[uni
     lexer.feed(chunk);
     REQUIRE_FALSE(on_row_handler_executed);
     REQUIRE(on_complete_handler_excecuted);
-    REQUIRE_FALSE(result.ec);
+    REQUIRE_SUCCESS(result.ec);
     REQUIRE(result.number_of_rows == 0);
     REQUIRE(result.rows.empty());
     REQUIRE(result.meta == chunk);


### PR DESCRIPTION
Before:
```
  REQUIRE_FALSE(!(ctx.ec()))
with expansion:
  !couchbase.key_value:113
```

After:
```
  REQUIRE_FALSE(!(ctx.ec()))
with expansion:
  !couchbase.key_value:113
with message:
  path_not_found (113)
```