### PR TITLE
CXXCBC-221: Support for configuration profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_subdirectory(core/metrics)
 set(couchbase_cxx_client_FILES
     core/cluster.cxx
     core/cluster_options.cxx
+    core/config_profile.cxx
     core/document_id.cxx
     core/error_context/key_value.cxx
     core/management/analytics_link_azure_blob_external.cxx

--- a/core/cluster_options.cxx
+++ b/core/cluster_options.cxx
@@ -16,7 +16,7 @@
  */
 
 #include "cluster_options.hxx"
-
+#include "config_profile.hxx"
 #include <stdexcept>
 
 namespace couchbase::core
@@ -41,5 +41,10 @@ cluster_options::default_timeout_for(service_type type) const
             return management_timeout;
     }
     throw std::runtime_error("unexpected service type");
+}
+void
+cluster_options::apply_profile(std::string profile_name)
+{
+    couchbase::core::known_profiles().apply(profile_name, *this);
 }
 } // namespace couchbase::core

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -26,6 +26,7 @@
 #include "timeout_defaults.hxx"
 
 #include <chrono>
+#include <list>
 #include <string>
 
 namespace couchbase::core
@@ -77,6 +78,7 @@ struct cluster_options {
     std::string user_agent_extra{};
 
     [[nodiscard]] std::chrono::milliseconds default_timeout_for(service_type type) const;
+    void apply_profile(std::string profile_name);
 };
 
 } // namespace couchbase::core

--- a/core/config_profile.cxx
+++ b/core/config_profile.cxx
@@ -20,7 +20,6 @@
 couchbase::core::config_profiles&
 couchbase::core::known_profiles()
 {
-    // NOTE: this is definitely not threadsafe.
     static couchbase::core::config_profiles profiles{};
     return profiles;
 }

--- a/core/config_profile.cxx
+++ b/core/config_profile.cxx
@@ -1,0 +1,26 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "config_profile.hxx"
+
+couchbase::core::config_profiles&
+couchbase::core::known_profiles()
+{
+    // NOTE: this is definitely not threadsafe.
+    static couchbase::core::config_profiles profiles{};
+    return profiles;
+}

--- a/core/config_profile.hxx
+++ b/core/config_profile.hxx
@@ -20,9 +20,9 @@
 #include <chrono>
 #include <fmt/core.h>
 #include <map>
+#include <mutex>
 #include <stdexcept>
 #include <string>
-#include <thread>
 
 namespace couchbase::core
 {

--- a/core/config_profile.hxx
+++ b/core/config_profile.hxx
@@ -1,0 +1,82 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#pragma once
+
+#include "cluster_options.hxx"
+#include <chrono>
+#include <fmt/core.h>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+namespace couchbase::core
+{
+class config_profile
+{
+  public:
+    virtual ~config_profile() = default;
+    virtual void apply(cluster_options&) = 0;
+};
+
+class development_profile : public config_profile
+{
+  public:
+    void apply(couchbase::core::cluster_options& opts) override
+    {
+        opts.key_value_timeout = std::chrono::milliseconds(20000); // 20 sec kv timeout.
+        opts.connect_timeout = std::chrono::milliseconds(5000);    // 5 sec connect timeout.
+    }
+};
+
+// this class just registers the known profiles defined above, and allows access to them.
+class config_profiles
+{
+  private:
+    std::map<std::string, std::shared_ptr<couchbase::core::config_profile>> profiles_;
+
+  public:
+    config_profiles() noexcept
+    {
+        // add all known profiles (above) to the map
+        profiles_.emplace(std::make_pair(std::string("wan_development"), std::make_shared<development_profile>()));
+    }
+
+    void apply(const std::string& profile_name, couchbase::core::cluster_options& opts)
+    {
+        auto it = profiles_.find(profile_name);
+        if (it != profiles_.end()) {
+            it->second->apply(opts);
+        } else {
+            throw std::invalid_argument(fmt::format("unknown profile '{}'", profile_name));
+        }
+    }
+
+    template<typename T>
+    void register_profile(const std::string& name)
+    {
+        // This will just add it, doesn't look to see if it is overwriting an existing profile.
+        // TODO: perhaps add a template Args param?
+        // TODO: should we make this thread-safe?   Easy enough here, but we'd need to make the
+        //   singleton thread-safe too.
+        profiles_.emplace(std::make_pair(name, std::make_shared<T>()));
+    }
+};
+
+config_profiles&
+known_profiles();
+
+} // namespace couchbase::core

--- a/core/config_profile.hxx
+++ b/core/config_profile.hxx
@@ -22,6 +22,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 namespace couchbase::core
 {
@@ -47,16 +48,18 @@ class config_profiles
 {
   private:
     std::map<std::string, std::shared_ptr<couchbase::core::config_profile>> profiles_;
+    std::mutex mut_;
 
   public:
     config_profiles() noexcept
     {
         // add all known profiles (above) to the map
-        profiles_.emplace(std::make_pair(std::string("wan_development"), std::make_shared<development_profile>()));
+        register_profile<development_profile>("wan_development");
     }
 
     void apply(const std::string& profile_name, couchbase::core::cluster_options& opts)
     {
+        std::lock_guard<std::mutex> lock(mut_);
         auto it = profiles_.find(profile_name);
         if (it != profiles_.end()) {
             it->second->apply(opts);
@@ -65,14 +68,15 @@ class config_profiles
         }
     }
 
-    template<typename T>
-    void register_profile(const std::string& name)
+    template<typename T, typename... Args>
+    void register_profile(const std::string& name, Args... args)
     {
         // This will just add it, doesn't look to see if it is overwriting an existing profile.
         // TODO: perhaps add a template Args param?
         // TODO: should we make this thread-safe?   Easy enough here, but we'd need to make the
         //   singleton thread-safe too.
-        profiles_.emplace(std::make_pair(name, std::make_shared<T>()));
+        std::lock_guard<std::mutex> lock(mut_);
+        profiles_.emplace(std::make_pair(name, std::make_shared<T>(args...)));
     }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ unit_test(utils)
 unit_test(json_transcoder)
 unit_test(json_streaming_lexer)
 unit_test(jsonsl)
+unit_test(config_profiles)
 target_link_libraries(test_unit_jsonsl jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_config_profiles.cxx
+++ b/test/test_unit_config_profiles.cxx
@@ -1,0 +1,104 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/cluster_options.hxx"
+#include "core/config_profile.hxx"
+#include <stdexcept>
+
+class test_profile : public couchbase::core::config_profile
+{
+  public:
+    void apply(couchbase::core::cluster_options& opts) override
+    {
+        opts.key_value_timeout = std::chrono::milliseconds(10);
+    }
+};
+
+TEST_CASE("unit: can apply wan_development profile", "[unit]")
+{
+    couchbase::core::cluster_options opts{};
+    opts.apply_profile("wan_development");
+    CHECK(opts.key_value_timeout.count() == 20000);
+    CHECK(opts.connect_timeout.count() == 5000);
+}
+TEST_CASE("unit: all other options remain unchanged", "[unit]")
+{
+    couchbase::core::cluster_options default_opts{};
+    couchbase::core::cluster_options opts{};
+    opts.apply_profile("wan_development");
+    // other than key_value_timeout and connect_timeout,
+    // we'd expect default_opts to be equal to opts:
+    CHECK(opts.key_value_durable_timeout == default_opts.key_value_durable_timeout);
+    CHECK(opts.tracer == default_opts.tracer);
+    CHECK(opts.meter == default_opts.meter);
+    CHECK(opts.analytics_timeout == default_opts.analytics_timeout);
+    CHECK(opts.bootstrap_timeout == default_opts.bootstrap_timeout);
+    CHECK(opts.config_idle_redial_timeout == default_opts.config_idle_redial_timeout);
+    CHECK(opts.config_poll_floor == default_opts.config_poll_floor);
+    CHECK(opts.config_poll_interval == default_opts.config_poll_interval);
+    CHECK(opts.dns_srv_timeout == default_opts.dns_srv_timeout);
+    CHECK(opts.enable_clustermap_notification == opts.enable_clustermap_notification);
+    CHECK(opts.enable_compression == default_opts.enable_compression);
+    CHECK(opts.enable_dns_srv == default_opts.enable_dns_srv);
+    CHECK(opts.enable_metrics == default_opts.enable_metrics);
+    CHECK(opts.enable_mutation_tokens == default_opts.enable_mutation_tokens);
+    CHECK(opts.enable_tcp_keep_alive == default_opts.enable_tcp_keep_alive);
+    CHECK(opts.enable_tls == default_opts.enable_tls);
+    CHECK(opts.enable_tracing == default_opts.enable_tracing);
+    CHECK(opts.enable_unordered_execution == default_opts.enable_unordered_execution);
+    CHECK(opts.idle_http_connection_timeout == default_opts.idle_http_connection_timeout);
+    CHECK(opts.management_timeout == default_opts.management_timeout);
+    CHECK(opts.max_http_connections == default_opts.max_http_connections);
+    CHECK(opts.network == default_opts.network);
+    CHECK(opts.query_timeout == default_opts.query_timeout);
+    CHECK(opts.resolve_timeout == default_opts.resolve_timeout);
+    CHECK(opts.search_timeout == default_opts.search_timeout);
+    CHECK(opts.show_queries == default_opts.show_queries);
+    CHECK(opts.tcp_keep_alive_interval == default_opts.tcp_keep_alive_interval);
+    CHECK(opts.tls_verify == default_opts.tls_verify);
+    CHECK(opts.trust_certificate == default_opts.trust_certificate);
+    CHECK(opts.use_ip_protocol == default_opts.use_ip_protocol);
+    CHECK(opts.user_agent_extra == default_opts.user_agent_extra);
+    CHECK(opts.view_timeout == default_opts.view_timeout);
+}
+
+TEST_CASE("unit: can register and use new profile", "[unit]")
+{
+    couchbase::core::cluster_options opts{};
+    couchbase::core::known_profiles().register_profile<test_profile>("test");
+    opts.apply_profile("test");
+    CHECK(opts.key_value_timeout.count() == 10);
+}
+TEST_CASE("unit: unknown profile name raises exception", "[unit]")
+{
+    couchbase::core::cluster_options opts{};
+    REQUIRE_THROWS_AS(opts.apply_profile("i don't exist"), std::invalid_argument);
+}
+
+TEST_CASE("unit: can apply multiple profiles", "[unit]")
+{
+    couchbase::core::cluster_options opts{};
+    couchbase::core::known_profiles().register_profile<test_profile>("test");
+    opts.apply_profile("wan_development");
+    opts.apply_profile("test");
+    // set only in wan_development
+    CHECK(opts.connect_timeout.count() == 5000);
+    // set in both, so should be overwritten by "test"
+    CHECK(opts.key_value_timeout.count() == 10);
+}


### PR DESCRIPTION
Motivation
==========
Allow users can apply a named profile, rather than set several configuration options when making a cluster.

Modification
============
Added a config_profile class, which applies some changes to a
cluster_options object which is passed in.   Then created a
development_profile which applies some specific options.

Added a config_profiles class, accessed via a singleton static call (known_profiles) which allows a user to add new config_profile derived classes to the known_profiles.

Results
=======
Added unit tests, which all pass.