### PR TITLE
CXXCBC-226: ensure that moving from movable_function will clear the source

### DIFF
--- a/core/utils/movable_function.hxx
+++ b/core/utils/movable_function.hxx
@@ -88,8 +88,18 @@ class movable_function : public std::function<Signature>
     {
     }
 
-    movable_function(movable_function&& /* other */) noexcept = default;
-    movable_function& operator=(movable_function&& /* other */) noexcept = default;
+    movable_function(movable_function&& other) noexcept
+      : base(std::move(static_cast<base&&>(other)))
+    {
+        other = nullptr;
+    }
+
+    movable_function& operator=(movable_function&& other) noexcept
+    {
+        base::operator=(std::move(static_cast<base&&>(other)));
+        other = nullptr;
+        return *this;
+    }
 
     movable_function& operator=(std::nullptr_t /* other */)
     {
@@ -104,6 +114,7 @@ class movable_function : public std::function<Signature>
         return *this;
     }
 
+    using base::operator bool;
     using base::operator();
 };
 


### PR DESCRIPTION
Right now we just delegate move assignment and constructor to std::function, which does not clean the source, which in turn lets "operator bool()" return true after the function has been moved.