### PR TITLE
CXXCBC-172: refresh DNS SRV when cluster uncontactable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set(couchbase_cxx_client_FILES
     core/utils/split_string.cxx
     core/utils/url_codec.cxx
     core/impl/analytics_error_category.cxx
+    core/impl/dns_srv_tracker.cxx
     core/impl/append.cxx
     core/impl/build_deferred_query_indexes.cxx
     core/impl/common_error_category.cxx

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -99,7 +99,8 @@ class cluster : public std::enable_shared_from_this<cluster>
         session_manager_->set_tracer(tracer_);
         if (origin_.options().enable_dns_srv) {
             auto [hostname, _] = origin_.next_address();
-            dns_srv_tracker_ = std::make_shared<impl::dns_srv_tracker>(ctx_, hostname, origin_.options().enable_tls);
+            dns_srv_tracker_ =
+              std::make_shared<impl::dns_srv_tracker>(ctx_, hostname, origin_.options().dns_config, origin_.options().enable_tls);
             return asio::post(asio::bind_executor(
               ctx_, [self = shared_from_this(), hostname = std::move(hostname), handler = std::forward<Handler>(handler)]() mutable {
                   return self->dns_srv_tracker_->get_srv_nodes(

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -19,7 +19,6 @@
 
 #include "bucket.hxx"
 #include "capella_ca.hxx"
-#include "core/io/dns_client.hxx"
 #include "core/io/http_command.hxx"
 #include "core/io/http_session_manager.hxx"
 #include "core/io/mcbp_command.hxx"
@@ -31,6 +30,7 @@
 #include "core/tracing/threshold_logging_tracer.hxx"
 #include "core/utils/join_strings.hxx"
 #include "diagnostics.hxx"
+#include "impl/dns_srv_tracker.hxx"
 #include "operations.hxx"
 #include "origin.hxx"
 
@@ -98,9 +98,25 @@ class cluster : public std::enable_shared_from_this<cluster>
         }
         session_manager_->set_tracer(tracer_);
         if (origin_.options().enable_dns_srv) {
-            return asio::post(asio::bind_executor(ctx_, [self = shared_from_this(), handler = std::forward<Handler>(handler)]() mutable {
-                return self->do_dns_srv(std::forward<Handler>(handler));
-            }));
+            auto [hostname, _] = origin_.next_address();
+            dns_srv_tracker_ = std::make_shared<impl::dns_srv_tracker>(ctx_, hostname, origin_.options().enable_tls);
+            return asio::post(asio::bind_executor(
+              ctx_, [self = shared_from_this(), hostname = std::move(hostname), handler = std::forward<Handler>(handler)]() mutable {
+                  return self->dns_srv_tracker_->get_srv_nodes(
+                    [self, hostname = std::move(hostname), handler = std::forward<Handler>(handler)](origin::node_list nodes,
+                                                                                                     std::error_code ec) mutable {
+                        if (ec) {
+                            return handler(ec);
+                        }
+                        if (!nodes.empty()) {
+                            self->origin_.set_nodes(std::move(nodes));
+                            LOG_INFO("replace list of bootstrap nodes with addresses from DNS SRV of \"{}\": [{}]",
+                                     hostname,
+                                     utils::join_strings(self->origin_.get_nodes(), ", "));
+                        }
+                        return self->do_open(std::forward<Handler>(handler));
+                    });
+              }));
         }
         do_open(std::forward<Handler>(handler));
     }
@@ -140,7 +156,7 @@ class cluster : public std::enable_shared_from_this<cluster>
                 if (session_ && session_->has_config()) {
                     known_features = session_->supported_features();
                 }
-                b = std::make_shared<bucket>(id_, ctx_, tls_, tracer_, meter_, bucket_name, origin_, known_features);
+                b = std::make_shared<bucket>(id_, ctx_, tls_, tracer_, meter_, bucket_name, origin_, known_features, dns_srv_tracker_);
                 buckets_.try_emplace(bucket_name, b);
             }
         }
@@ -158,9 +174,7 @@ class cluster : public std::enable_shared_from_this<cluster>
             }
             handler(ec);
         });
-        b->on_configuration_update([self = shared_from_this()](topology::configuration new_config) {
-            self->session_manager_->update_configuration(std::move(new_config));
-        });
+        b->on_configuration_update(session_manager_);
     }
 
     template<typename Handler>
@@ -267,7 +281,6 @@ class cluster : public std::enable_shared_from_this<cluster>
       : ctx_(ctx)
       , work_(asio::make_work_guard(ctx_))
       , session_manager_(std::make_shared<io::http_session_manager>(id_, ctx_, tls_))
-      , dns_client_(ctx_)
     {
     }
 
@@ -292,42 +305,6 @@ class cluster : public std::enable_shared_from_this<cluster>
         for (auto bucket : buckets) {
             handler(bucket);
         }
-    }
-
-    template<typename Handler>
-    void do_dns_srv(Handler&& handler)
-    {
-        std::string hostname;
-        std::string service;
-        std::tie(hostname, service) = origin_.next_address();
-        service = origin_.options().enable_tls ? "_couchbases" : "_couchbase";
-        dns_client_.query_srv(
-          hostname,
-          service,
-          [hostname, self = shared_from_this(), handler = std::forward<Handler>(handler)](
-            couchbase::core::io::dns::dns_client::dns_srv_response&& resp) mutable {
-              if (resp.ec) {
-                  LOG_WARNING("failed to fetch DNS SRV records for \"{}\" ({}), assuming that cluster is listening this address",
-                              hostname,
-                              resp.ec.message());
-              } else if (resp.targets.empty()) {
-                  LOG_WARNING("DNS SRV query returned 0 records for \"{}\", assuming that cluster is listening this address", hostname);
-              } else {
-                  origin::node_list nodes;
-                  nodes.reserve(resp.targets.size());
-                  for (const auto& address : resp.targets) {
-                      origin::node_entry node;
-                      node.first = address.hostname;
-                      node.second = std::to_string(address.port);
-                      nodes.emplace_back(node);
-                  }
-                  self->origin_.set_nodes(nodes);
-                  LOG_INFO("replace list of bootstrap nodes with addresses from DNS SRV of \"{}\": [{}]",
-                           hostname,
-                           utils::join_strings(self->origin_.get_nodes(), ", "));
-              }
-              return self->do_open(std::forward<Handler>(handler));
-          });
     }
 
     template<typename Handler>
@@ -418,9 +395,9 @@ class cluster : public std::enable_shared_from_this<cluster>
                     return handler(ec);
                 }
             }
-            session_ = std::make_shared<io::mcbp_session>(id_, ctx_, tls_, origin_);
+            session_ = std::make_shared<io::mcbp_session>(id_, ctx_, tls_, origin_, dns_srv_tracker_);
         } else {
-            session_ = std::make_shared<io::mcbp_session>(id_, ctx_, origin_);
+            session_ = std::make_shared<io::mcbp_session>(id_, ctx_, origin_, dns_srv_tracker_);
         }
         session_->bootstrap([self = shared_from_this(),
                              handler = std::forward<Handler>(handler)](std::error_code ec, const topology::configuration& config) mutable {
@@ -453,9 +430,7 @@ class cluster : public std::enable_shared_from_this<cluster>
                              utils::join_strings(self->origin_.get_nodes(), ","));
                 }
                 self->session_manager_->set_configuration(config, self->origin_.options());
-                self->session_->on_configuration_update([manager = self->session_manager_](topology::configuration new_config) {
-                    manager->update_configuration(std::move(new_config));
-                });
+                self->session_->on_configuration_update(self->session_manager_);
                 self->session_->on_stop([self](retry_reason) { self->session_.reset(); });
             }
             handler(ec);
@@ -467,9 +442,8 @@ class cluster : public std::enable_shared_from_this<cluster>
     asio::executor_work_guard<asio::io_context::executor_type> work_;
     asio::ssl::context tls_{ asio::ssl::context::tls_client };
     std::shared_ptr<io::http_session_manager> session_manager_;
-    io::dns::dns_config& dns_config_{ io::dns::dns_config::get() };
-    couchbase::core::io::dns::dns_client dns_client_;
     std::shared_ptr<io::mcbp_session> session_{};
+    std::shared_ptr<impl::dns_srv_tracker> dns_srv_tracker_{};
     std::mutex buckets_mutex_{};
     std::map<std::string, std::shared_ptr<bucket>> buckets_{};
     couchbase::core::origin origin_{};

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "core/io/dns_config.hxx"
 #include "core/io/ip_protocol.hxx"
 #include "core/metrics/logging_meter_options.hxx"
 #include "core/metrics/meter.hxx"
@@ -55,6 +56,7 @@ struct cluster_options {
     bool enable_tcp_keep_alive{ true };
     io::ip_protocol use_ip_protocol{ io::ip_protocol::any };
     bool enable_dns_srv{ true };
+    io::dns::dns_config dns_config{ io::dns::dns_config::system_config() };
     bool show_queries{ false };
     bool enable_unordered_execution{ true };
     bool enable_clustermap_notification{ false };

--- a/core/config_listener.hxx
+++ b/core/config_listener.hxx
@@ -1,0 +1,31 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "topology/configuration.hxx"
+
+namespace couchbase::core
+{
+class config_listener
+{
+  public:
+    virtual ~config_listener() = default;
+
+    virtual void update_config(topology::configuration config) = 0;
+};
+} // namespace couchbase::core

--- a/core/impl/bootstrap_state_listener.hxx
+++ b/core/impl/bootstrap_state_listener.hxx
@@ -1,0 +1,38 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/config_listener.hxx"
+
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace couchbase::core::impl
+{
+class bootstrap_state_listener
+{
+  public:
+    virtual ~bootstrap_state_listener() = default;
+    virtual void report_bootstrap_error(const std::string& endpoint, std::error_code ec) = 0;
+    virtual void report_bootstrap_success(const std::vector<std::string>& endpoints) = 0;
+
+    virtual void register_config_listener(std::shared_ptr<config_listener> listener) = 0;
+    virtual void unregister_config_listener(std::shared_ptr<config_listener> listener) = 0;
+};
+} // namespace couchbase::core::impl

--- a/core/impl/dns_srv_tracker.cxx
+++ b/core/impl/dns_srv_tracker.cxx
@@ -1,0 +1,133 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "dns_srv_tracker.hxx"
+#include "../logger/logger.hxx"
+#include "../topology/configuration.hxx"
+
+#include <asio/bind_executor.hpp>
+#include <asio/io_context.hpp>
+
+#include <memory>
+
+namespace couchbase::core::impl
+{
+dns_srv_tracker::dns_srv_tracker(asio::io_context& ctx, std::string address, bool use_tls)
+  : ctx_{ ctx }
+  , dns_client_{ ctx_ }
+  , address_{ std::move(address) }
+  , use_tls_{ use_tls }
+  , service_{ use_tls_ ? "_couchbases" : "_couchbase" }
+{
+}
+
+void
+dns_srv_tracker::get_srv_nodes(utils::movable_function<void(origin::node_list, std::error_code)> callback)
+{
+    dns_client_.query_srv(
+      address_,
+      service_,
+      [self = shared_from_this(), callback = std::move(callback)](couchbase::core::io::dns::dns_client::dns_srv_response&& resp) mutable {
+          origin::node_list nodes;
+          if (resp.ec) {
+              LOG_WARNING("failed to fetch DNS SRV records for \"{}\" ({}), assuming that cluster is listening this address",
+                          self->address_,
+                          resp.ec.message());
+          } else if (resp.targets.empty()) {
+              LOG_WARNING("DNS SRV query returned 0 records for \"{}\", assuming that cluster is listening this address", self->address_);
+          } else {
+              nodes.reserve(resp.targets.size());
+              for (const auto& address : resp.targets) {
+                  origin::node_entry node;
+                  node.first = address.hostname;
+                  node.second = std::to_string(address.port);
+                  nodes.emplace_back(node);
+              }
+          }
+          return callback(nodes, {});
+      });
+}
+
+void
+dns_srv_tracker::report_bootstrap_error(const std::string& endpoint, std::error_code ec)
+{
+    bool trigger_dns_srv_refresh = false;
+
+    if (ec && ec != errc::common::request_canceled) {
+        std::scoped_lock lock(known_endpoints_mutex_);
+        known_endpoints_.erase(endpoint);
+        if (known_endpoints_.empty()) {
+            trigger_dns_srv_refresh = true;
+        }
+    } else {
+        return;
+    }
+
+    if (trigger_dns_srv_refresh) {
+        LOG_DEBUG("all nodes failed to bootstrap, triggering DNS-SRV refresh");
+        return asio::post(asio::bind_executor(ctx_, [self = shared_from_this()]() mutable {
+            return self->get_srv_nodes([self](origin::node_list nodes, std::error_code dns_ec) mutable {
+                if (dns_ec || nodes.empty()) {
+                    LOG_WARNING("unable to perform DNS-SRV refresh: {}", dns_ec.message());
+                    return;
+                }
+                std::set<std::shared_ptr<config_listener>> listeners;
+                {
+                    std::scoped_lock lock(self->config_listeners_mutex_);
+                    listeners = self->config_listeners_;
+                }
+
+                if (!listeners.empty()) {
+                    auto config = topology::make_blank_configuration(nodes, self->use_tls_);
+                    std::vector<std::string> endpoints;
+                    endpoints.reserve(nodes.size());
+                    for (const auto& [host, port] : nodes) {
+                        endpoints.emplace_back(fmt::format("\"{}:{}\"", host, port));
+                    }
+                    LOG_INFO(
+                      "generated configuration from DNS-SRV response \"{}\": [{}]", self->address_, utils::join_strings(endpoints, ", "));
+                    for (const auto& listener : listeners) {
+                        listener->update_config(config);
+                    }
+                }
+            });
+        }));
+    }
+}
+
+void
+dns_srv_tracker::report_bootstrap_success(const std::vector<std::string>& endpoints)
+{
+    std::set<std::string, std::less<>> known_endpoints{ endpoints.begin(), endpoints.end() };
+    std::scoped_lock lock(known_endpoints_mutex_);
+    std::swap(known_endpoints_, known_endpoints);
+}
+
+void
+dns_srv_tracker::register_config_listener(std::shared_ptr<config_listener> listener)
+{
+    std::scoped_lock lock(config_listeners_mutex_);
+    config_listeners_.insert(listener);
+}
+
+void
+dns_srv_tracker::unregister_config_listener(std::shared_ptr<config_listener> listener)
+{
+    std::scoped_lock lock(config_listeners_mutex_);
+    config_listeners_.erase(listener);
+}
+} // namespace couchbase::core::impl

--- a/core/impl/dns_srv_tracker.cxx
+++ b/core/impl/dns_srv_tracker.cxx
@@ -26,10 +26,11 @@
 
 namespace couchbase::core::impl
 {
-dns_srv_tracker::dns_srv_tracker(asio::io_context& ctx, std::string address, bool use_tls)
+dns_srv_tracker::dns_srv_tracker(asio::io_context& ctx, std::string address, const io::dns::dns_config& config, bool use_tls)
   : ctx_{ ctx }
   , dns_client_{ ctx_ }
   , address_{ std::move(address) }
+  , config_{ config }
   , use_tls_{ use_tls }
   , service_{ use_tls_ ? "_couchbases" : "_couchbase" }
 {
@@ -41,6 +42,7 @@ dns_srv_tracker::get_srv_nodes(utils::movable_function<void(origin::node_list, s
     dns_client_.query_srv(
       address_,
       service_,
+      config_,
       [self = shared_from_this(), callback = std::move(callback)](couchbase::core::io::dns::dns_client::dns_srv_response&& resp) mutable {
           origin::node_list nodes;
           if (resp.ec) {

--- a/core/impl/dns_srv_tracker.hxx
+++ b/core/impl/dns_srv_tracker.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "../io/dns_client.hxx"
+#include "../origin.hxx"
+#include "bootstrap_state_listener.hxx"
+#include "core/utils/movable_function.hxx"
+
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace asio
+{
+class io_context;
+} // namespace asio
+
+namespace couchbase::core::impl
+{
+class dns_srv_tracker
+  : public std::enable_shared_from_this<dns_srv_tracker>
+  , public bootstrap_state_listener
+{
+  public:
+    dns_srv_tracker(asio::io_context& ctx, std::string address, bool use_tls);
+    void get_srv_nodes(utils::movable_function<void(origin::node_list nodes, std::error_code ec)> callback);
+
+    void report_bootstrap_error(const std::string& endpoint, std::error_code ec) override;
+    void report_bootstrap_success(const std::vector<std::string>& endpoints) override;
+
+    void register_config_listener(std::shared_ptr<config_listener> listener) override;
+    void unregister_config_listener(std::shared_ptr<config_listener> listener) override;
+
+  private:
+    asio::io_context& ctx_;
+    io::dns::dns_client dns_client_;
+    std::string address_;
+    bool use_tls_;
+    std::string service_;
+    std::set<std::string, std::less<>> known_endpoints_{};
+    std::mutex known_endpoints_mutex_;
+
+    std::set<std::shared_ptr<config_listener>> config_listeners_{};
+    std::mutex config_listeners_mutex_;
+};
+} // namespace couchbase::core::impl

--- a/core/impl/dns_srv_tracker.hxx
+++ b/core/impl/dns_srv_tracker.hxx
@@ -39,7 +39,7 @@ class dns_srv_tracker
   , public bootstrap_state_listener
 {
   public:
-    dns_srv_tracker(asio::io_context& ctx, std::string address, bool use_tls);
+    dns_srv_tracker(asio::io_context& ctx, std::string address, const io::dns::dns_config& config, bool use_tls);
     void get_srv_nodes(utils::movable_function<void(origin::node_list nodes, std::error_code ec)> callback);
 
     void report_bootstrap_error(const std::string& endpoint, std::error_code ec) override;
@@ -52,6 +52,7 @@ class dns_srv_tracker
     asio::io_context& ctx_;
     io::dns::dns_client dns_client_;
     std::string address_;
+    io::dns::dns_config config_;
     bool use_tls_;
     std::string service_;
     std::set<std::string, std::less<>> known_endpoints_{};

--- a/core/impl/dns_srv_tracker.hxx
+++ b/core/impl/dns_srv_tracker.hxx
@@ -49,6 +49,8 @@ class dns_srv_tracker
     void unregister_config_listener(std::shared_ptr<config_listener> listener) override;
 
   private:
+    void do_dns_refresh();
+
     asio::io_context& ctx_;
     io::dns::dns_client dns_client_;
     std::string address_;
@@ -60,5 +62,7 @@ class dns_srv_tracker
 
     std::set<std::shared_ptr<config_listener>> config_listeners_{};
     std::mutex config_listeners_mutex_;
+
+    std::atomic_bool refresh_in_progress_{ false };
 };
 } // namespace couchbase::core::impl

--- a/core/io/CMakeLists.txt
+++ b/core/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(couchbase_io STATIC mcbp_message.cxx mcbp_parser.cxx http_parser.cxx)
+add_library(couchbase_io STATIC mcbp_message.cxx mcbp_parser.cxx http_parser.cxx dns_config.cxx)
 set_target_properties(couchbase_io PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_dependencies(couchbase_io http_parser)
 target_link_libraries(

--- a/core/io/dns_client.hxx
+++ b/core/io/dns_client.hxx
@@ -25,6 +25,8 @@
 
 #include <asio/ip/tcp.hpp>
 #include <asio/read.hpp>
+#include <asio/write.hpp>
+
 #include <memory>
 #include <sstream>
 

--- a/core/io/dns_client.hxx
+++ b/core/io/dns_client.hxx
@@ -208,10 +208,14 @@ class dns_client
     }
 
     template<class Handler>
-    void query_srv(const std::string& name, const std::string& service, Handler&& handler)
+    void query_srv(const std::string& name, const std::string& service, const dns_config& config, Handler&& handler)
     {
-        const dns_config& config = dns_config::get();
-        auto cmd = std::make_shared<dns_srv_command>(ctx_, name, service, config.address(), config.port());
+        std::error_code ec;
+        auto address = asio::ip::address::from_string(config.nameserver(), ec);
+        if (ec) {
+            return handler({ ec });
+        }
+        auto cmd = std::make_shared<dns_srv_command>(ctx_, name, service, address, config.port());
         cmd->execute(config.timeout(), std::forward<Handler>(handler));
     }
 

--- a/core/io/dns_codec.hxx
+++ b/core/io/dns_codec.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "core/utils/byteswap.hxx"
 #include "dns_message.hxx"
 
 #include <asio/ip/udp.hpp>

--- a/core/io/dns_config.cxx
+++ b/core/io/dns_config.cxx
@@ -1,0 +1,78 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "dns_config.hxx"
+
+#include <mutex>
+
+namespace couchbase::core::io::dns
+{
+static constexpr auto default_resolv_conf_path = "/etc/resolv.conf";
+
+std::string
+load_resolv_conf(const char* conf_path)
+{
+    if (std::error_code ec{}; std::filesystem::exists(conf_path, ec) && !ec) {
+        std::ifstream conf(conf_path);
+        while (conf.good()) {
+            std::string line;
+            std::getline(conf, line);
+            if (line.empty()) {
+                continue;
+            }
+            std::size_t offset = 0;
+            while (line[offset] == ' ') {
+                ++offset;
+            }
+            if (line[offset] == '#') {
+                continue;
+            }
+            std::size_t space = line.find(' ', offset);
+            if (space == std::string::npos || space == offset || line.size() < space + 2) {
+                continue;
+            }
+            if (std::string keyword = line.substr(offset, space); keyword != "nameserver") {
+                continue;
+            }
+            offset = space + 1;
+            space = line.find(' ', offset);
+            return line.substr(offset, space);
+        }
+    }
+    return {};
+}
+
+static std::once_flag system_config_initialized_flag;
+
+const dns_config&
+dns_config::system_config()
+{
+    static dns_config instance{};
+
+    std::call_once(system_config_initialized_flag, []() {
+        auto nameserver = load_resolv_conf(default_resolv_conf_path);
+        std::error_code ec;
+        asio::ip::address::from_string(nameserver, ec);
+        if (ec) {
+            nameserver = default_nameserver;
+        }
+        instance.nameserver_ = nameserver;
+    });
+
+    return instance;
+}
+} // namespace couchbase::core::io::dns

--- a/core/io/dns_config.hxx
+++ b/core/io/dns_config.hxx
@@ -31,13 +31,16 @@ namespace couchbase::core::io::dns
 class dns_config
 {
   public:
-    static constexpr auto default_resolv_conf_path = "/etc/resolv.conf";
-    static constexpr auto default_host = "8.8.8.8";
+    static constexpr auto default_nameserver = "8.8.8.8";
     static constexpr std::uint16_t default_port = 53;
 
-    [[nodiscard]] const asio::ip::address& address() const
+    dns_config() = default;
+
+    dns_config(const std::string& nameserver, std::uint16_t port, std::chrono::milliseconds timeout = timeout_defaults::dns_srv_timeout)
+      : nameserver_{ nameserver }
+      , port_{ port }
+      , timeout_{ timeout }
     {
-        return address_;
     }
 
     [[nodiscard]] std::uint16_t port() const
@@ -45,70 +48,20 @@ class dns_config
         return port_;
     }
 
+    [[nodiscard]] const std::string& nameserver() const
+    {
+        return nameserver_;
+    }
+
     [[nodiscard]] std::chrono::milliseconds timeout() const
     {
         return timeout_;
     }
 
-    static dns_config& get()
-    {
-        static dns_config instance{};
-
-        instance.initialize();
-
-        return instance;
-    }
+    static const dns_config& system_config();
 
   private:
-    void initialize()
-    {
-        if (!initialized_) {
-            load_resolv_conf(default_resolv_conf_path);
-            std::error_code ec;
-            address_ = asio::ip::address::from_string(host_, ec);
-            if (ec) {
-                host_ = default_host;
-                address_ = asio::ip::address::from_string(host_, ec);
-            }
-            initialized_ = true;
-        }
-    }
-
-    void load_resolv_conf(const char* conf_path)
-    {
-        if (std::error_code ec{}; std::filesystem::exists(conf_path, ec) && !ec) {
-            std::ifstream conf(conf_path);
-            while (conf.good()) {
-                std::string line;
-                std::getline(conf, line);
-                if (line.empty()) {
-                    continue;
-                }
-                std::size_t offset = 0;
-                while (line[offset] == ' ') {
-                    ++offset;
-                }
-                if (line[offset] == '#') {
-                    continue;
-                }
-                std::size_t space = line.find(' ', offset);
-                if (space == std::string::npos || space == offset || line.size() < space + 2) {
-                    continue;
-                }
-                if (std::string keyword = line.substr(offset, space); keyword != "nameserver") {
-                    continue;
-                }
-                offset = space + 1;
-                space = line.find(' ', offset);
-                host_ = line.substr(offset, space);
-                break;
-            }
-        }
-    }
-
-    std::atomic_bool initialized_{ false };
-    std::string host_{ default_host };
-    asio::ip::address address_{};
+    std::string nameserver_{ default_nameserver };
     std::uint16_t port_{ default_port };
     std::chrono::milliseconds timeout_{ timeout_defaults::dns_srv_timeout };
 };

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "core/config_listener.hxx"
 #include "core/metrics/meter.hxx"
 #include "core/operations/http_noop.hxx"
 #include "core/service_type.hxx"
@@ -31,7 +32,9 @@
 namespace couchbase::core::io
 {
 
-class http_session_manager : public std::enable_shared_from_this<http_session_manager>
+class http_session_manager
+  : public std::enable_shared_from_this<http_session_manager>
+  , public config_listener
 {
   public:
     http_session_manager(std::string client_id, asio::io_context& ctx, asio::ssl::context& tls)
@@ -51,7 +54,7 @@ class http_session_manager : public std::enable_shared_from_this<http_session_ma
         meter_ = std::move(meter);
     }
 
-    void update_configuration(topology::configuration config)
+    void update_config(topology::configuration config) override
     {
         std::scoped_lock config_lock(config_mutex_, sessions_mutex_);
         config_ = std::move(config);

--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -209,7 +209,7 @@ std::pair<std::uint16_t, std::int16_t>
 configuration::map_key(const std::string& key, std::size_t index)
 {
     if (!vbmap.has_value()) {
-        throw std::runtime_error("cannot map key: partition map is not available");
+        return { 0, -1 };
     }
     std::uint32_t crc = utils::hash_crc32(key.data(), key.size());
     auto vbucket = std::uint16_t(crc % vbmap->size());
@@ -232,9 +232,10 @@ make_blank_configuration(const std::string& hostname, std::uint16_t plain_port, 
 }
 
 configuration
-make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints, bool use_tls)
+make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints, bool use_tls, bool force)
 {
     configuration result;
+    result.force = force;
     result.id = couchbase::core::uuid::random();
     result.epoch = 0;
     result.rev = 0;

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -88,6 +88,7 @@ struct configuration {
     std::set<bucket_capability> bucket_capabilities{};
     std::set<cluster_capability> cluster_capabilities{};
     node_locator_type node_locator{ node_locator_type::unknown };
+    bool force{ false };
 
     bool operator==(const configuration& other) const
     {
@@ -128,5 +129,5 @@ configuration
 make_blank_configuration(const std::string& hostname, std::uint16_t plain_port, std::uint16_t tls_port);
 
 configuration
-make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints, bool use_tls);
+make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints, bool use_tls, bool force = false);
 } // namespace couchbase::core::topology

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -68,6 +68,8 @@ struct configuration {
         [[nodiscard]] std::uint16_t port_or(const std::string& network, service_type type, bool is_tls, std::uint16_t default_value) const;
 
         [[nodiscard]] const std::string& hostname_for(const std::string& network) const;
+
+        [[nodiscard]] std::optional<std::string> endpoint(const std::string& network, service_type type, bool is_tls) const;
     };
 
     [[nodiscard]] std::string select_network(const std::string& bootstrap_hostname) const;
@@ -124,4 +126,7 @@ struct configuration {
 
 configuration
 make_blank_configuration(const std::string& hostname, std::uint16_t plain_port, std::uint16_t tls_port);
+
+configuration
+make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints, bool use_tls);
 } // namespace couchbase::core::topology

--- a/test/tools/tool_kv_loader.cxx
+++ b/test/tools/tool_kv_loader.cxx
@@ -101,6 +101,12 @@ main()
     asio::io_context io(static_cast<int>(number_of_io_threads));
 
     auto origin = couchbase::core::origin(auth, connstr);
+    if (ctx.dns_nameserver || ctx.dns_port) {
+        origin.options().dns_config = couchbase::core::io::dns::dns_config{
+            ctx.dns_nameserver.value_or(couchbase::core::io::dns::dns_config::default_nameserver),
+            ctx.dns_port.value_or(couchbase::core::io::dns::dns_config::default_port),
+        };
+    }
     auto cluster = couchbase::core::cluster::create(io);
 
     std::vector<std::thread> io_pool{};

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -38,6 +38,12 @@ integration_test_guard::integration_test_guard()
     }
     io_thread = std::thread([this]() { io.run(); });
     origin = couchbase::core::origin(auth, connstr);
+    if (ctx.dns_nameserver || ctx.dns_port) {
+        origin.options().dns_config = couchbase::core::io::dns::dns_config{
+            ctx.dns_nameserver.value_or(couchbase::core::io::dns::dns_config::default_nameserver),
+            ctx.dns_port.value_or(couchbase::core::io::dns::dns_config::default_port),
+        };
+    }
     open_cluster(cluster, origin);
 }
 

--- a/test/utils/test_context.cxx
+++ b/test/utils/test_context.cxx
@@ -52,6 +52,14 @@ test_context::load_from_environment()
         ctx.bucket = var;
     }
 
+    if (auto var = spdlog::details::os::getenv("TEST_DNS_NAMESERVER"); !var.empty()) {
+        ctx.dns_nameserver = var;
+    }
+
+    if (auto var = spdlog::details::os::getenv("TEST_DNS_PORT"); !var.empty()) {
+        ctx.dns_port = std::stol(var);
+    }
+
     if (auto var = spdlog::details::os::getenv("TEST_DEPLOYMENT_TYPE"); !var.empty()) {
         if (var == "on_prem") {
             ctx.deployment = deployment_type::on_prem;

--- a/test/utils/test_context.hxx
+++ b/test/utils/test_context.hxx
@@ -35,6 +35,8 @@ struct test_context {
     server_version version{ 6, 6, 0 };
     deployment_type deployment{ deployment_type::on_prem };
     server_config_profile profile{ server_config_profile::unknown };
+    std::optional<std::string> dns_nameserver{};
+    std::optional<std::uint16_t> dns_port{};
 
     [[nodiscard]] couchbase::core::cluster_credentials build_auth() const
     {


### PR DESCRIPTION
When DNS SRV records are used to connect to the SDK it's possible for the underlying addresses to change, i.e. the cluster to move. We need to detect this happening and react accordingly so that the SDK can continue to work correctly.