### PR TITLE
CXXCBC-246: convert not_store code to document_exists

### DIFF
--- a/core/operations/document_mutate_in.cxx
+++ b/core/operations/document_mutate_in.cxx
@@ -103,7 +103,8 @@ mutate_in_request::make_response(key_value_error_context&& ctx, const encoded_re
             response_token = couchbase::utils::build_mutation_token(encoded.body().token(), partition, ctx.bucket());
         }
         std::sort(fields.begin(), fields.end(), [](const auto& lhs, const auto& rhs) { return lhs.original_index < rhs.original_index; });
-    } else if (store_semantics == couchbase::store_semantics::insert && ctx.ec() == errc::common::cas_mismatch) {
+    } else if (store_semantics == couchbase::store_semantics::insert &&
+               (ctx.ec() == errc::common::cas_mismatch || ctx.status_code() == key_value_status_code::not_stored)) {
         ec = errc::key_value::document_exists;
     }
     return mutate_in_response{

--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -43,7 +43,12 @@ map_status_code(protocol::client_opcode opcode, std::uint16_t status)
             return {};
 
         case key_value_status_code::not_found:
+            return errc::key_value::document_not_found;
+
         case key_value_status_code::not_stored:
+            if (opcode == protocol::client_opcode::insert) {
+                return errc::key_value::document_exists;
+            }
             return errc::key_value::document_not_found;
 
         case key_value_status_code::exists:


### PR DESCRIPTION
The server can return either NOT_STORED or EXISTS error when inserting an existing document (MB-50742).