### PR TITLE
CXXCBC-243 and CXXCBC-244: Expose kv transactions as public api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,8 @@ set(couchbase_cxx_client_FILES
     core/impl/subdoc/replace.cxx
     core/impl/subdoc/upsert.cxx
     core/impl/touch.cxx
+    core/impl/transaction_error_category.cxx
+    core/impl/transaction_op_error_category.cxx
     core/impl/upsert.cxx
     core/impl/view_error_category.cxx
     core/transactions/atr_cleanup_entry.cxx

--- a/core/impl/transaction_error_category.cxx
+++ b/core/impl/transaction_error_category.cxx
@@ -1,0 +1,54 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/error_codes.hxx>
+
+#include <string>
+namespace couchbase::core::impl
+{
+
+struct transaction_error_category : std::error_category {
+    [[nodiscard]] const char* name() const noexcept override
+    {
+        return "couchbase.transaction";
+    }
+
+    [[nodiscard]] std::string message(int ev) const noexcept override
+    {
+        switch (static_cast<errc::transaction>(ev)) {
+            case errc::transaction::failed:
+                return "transaction failed (1200)";
+            case errc::transaction::expired:
+                return "transaction expired (1201)";
+            case errc::transaction::failed_post_commit:
+                return "transaction failed post-commit (1202)";
+            case errc::transaction::ambiguous:
+                return "transaction commit ambiguous (1203)";
+        }
+        return "FIXME: unknown error code (recompile with newer library): couchbase.transaction." + std::to_string(ev);
+    }
+};
+
+const inline static transaction_error_category transaction_category_instance;
+
+const std::error_category&
+transaction_category() noexcept
+{
+    return transaction_category_instance;
+}
+
+} // namespace couchbase::core::impl

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -24,7 +24,7 @@ namespace couchbase::core::impl
 struct transaction_op_error_category : std::error_category {
     [[nodiscard]] const char* name() const noexcept override
     {
-        return "couchbase.transaction";
+        return "couchbase.transaction_op";
     }
 
     [[nodiscard]] std::string message(int ev) const noexcept override
@@ -75,7 +75,7 @@ struct transaction_op_error_category : std::error_category {
             case errc::transaction_op::transaction_already_committed:
                 return "transaction already committed (1321)";
         }
-        return "FIXME: unknown error code (recompile with newer library): couchbase.transaction." + std::to_string(ev);
+        return "FIXME: unknown error code (recompile with newer library): couchbase.transaction_op." + std::to_string(ev);
     }
 };
 

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -1,0 +1,116 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/error_codes.hxx>
+
+#include <string>
+namespace couchbase::core::impl
+{
+/*
+enum class transaction_op {
+    unknown = 1300,
+    active_transaction_record_entry_not_found = 1301,
+    active_transaction_record_full = 1302,
+    active_transaction_record_not_found = 1303,
+    document_already_in_transaction = 1304,
+    document_exists_exception = 1305,
+    document_not_found_exception = 1306,
+    not_set = 1307,
+    feature_not_available_exception = 1308,
+    transaction_aborted_externally = 1309,
+    previous_operation_failed = 1310,
+    forward_compatibility_failure = 1311,
+    parsing_failure = 1312,
+    illegal_state_exception = 1313,
+    couchbase_exception = 1314,
+    service_not_available_exception = 1315,
+    request_canceled_exception = 1316,
+    concurrent_operations_detected_on_same_document = 1317,
+    commit_not_permitted = 1318,
+    rollback_not_permitted = 1319,
+    transaction_already_aborted =1320,
+    transaction_already_committed = 1321,
+};
+ *
+ */
+struct transaction_op_error_category : std::error_category {
+    [[nodiscard]] const char* name() const noexcept override
+    {
+        return "couchbase.transaction";
+    }
+
+    [[nodiscard]] std::string message(int ev) const noexcept override
+    {
+        switch (static_cast<errc::transaction_op>(ev)) {
+            case errc::transaction_op::unknown:
+                return "unknown error (1300)";
+            case errc::transaction_op::active_transaction_record_entry_not_found:
+                return "active transaction record entry not found (1301)";
+            case errc::transaction_op::active_transaction_record_full:
+                return "active transaction record full (1302)";
+            case errc::transaction_op::active_transaction_record_not_found:
+                return "active transaction record not found (1303)";
+            case errc::transaction_op::document_already_in_transaction:
+                return "document already in transaction (1304)";
+            case errc::transaction_op::document_exists_exception:
+                return "document exists (1305)";
+            case errc::transaction_op::document_not_found_exception:
+                return "document not found (1306)";
+            case errc::transaction_op::not_set:
+                return "error not set (1307)";
+            case errc::transaction_op::feature_not_available_exception:
+                return "feature not available (1308)";
+            case errc::transaction_op::transaction_aborted_externally:
+                return "transaction aborted externally (1309)";
+            case errc::transaction_op::previous_operation_failed:
+                return "previous operation failed (1310)";
+            case errc::transaction_op::forward_compatibility_failure:
+                return "forward compatible failure (1311)";
+            case errc::transaction_op::parsing_failure:
+                return "parsing failure (1312)";
+            case errc::transaction_op::illegal_state_exception:
+                return "illegal state (1313)";
+            case errc::transaction_op::couchbase_exception:
+                return "couchbase exception (1314)";
+            case errc::transaction_op::service_not_available_exception:
+                return "service not available (1315)";
+            case errc::transaction_op::request_canceled_exception:
+                return "request canceled (1316)";
+            case errc::transaction_op::concurrent_operations_detected_on_same_document:
+                return "concurrent operations detected on same document (1317)";
+            case errc::transaction_op::commit_not_permitted:
+                return "commit not permitted (1318)";
+            case errc::transaction_op::rollback_not_permitted:
+                return "rollback not permitted (1319)";
+            case errc::transaction_op::transaction_already_aborted:
+                return "transaction already aborted (1320)";
+            case errc::transaction_op::transaction_already_committed:
+                return "transaction already committed (1321)";
+        }
+        return "FIXME: unknown error code (recompile with newer library): couchbase.transaction." + std::to_string(ev);
+    }
+};
+
+const inline static transaction_op_error_category transaction_op_category_instance;
+
+const std::error_category&
+transaction_op_category() noexcept
+{
+    return transaction_op_category_instance;
+}
+
+} // namespace couchbase::core::impl

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -20,33 +20,7 @@
 #include <string>
 namespace couchbase::core::impl
 {
-/*
-enum class transaction_op {
-    unknown = 1300,
-    active_transaction_record_entry_not_found = 1301,
-    active_transaction_record_full = 1302,
-    active_transaction_record_not_found = 1303,
-    document_already_in_transaction = 1304,
-    document_exists_exception = 1305,
-    document_not_found_exception = 1306,
-    not_set = 1307,
-    feature_not_available_exception = 1308,
-    transaction_aborted_externally = 1309,
-    previous_operation_failed = 1310,
-    forward_compatibility_failure = 1311,
-    parsing_failure = 1312,
-    illegal_state_exception = 1313,
-    couchbase_exception = 1314,
-    service_not_available_exception = 1315,
-    request_canceled_exception = 1316,
-    concurrent_operations_detected_on_same_document = 1317,
-    commit_not_permitted = 1318,
-    rollback_not_permitted = 1319,
-    transaction_already_aborted =1320,
-    transaction_already_committed = 1321,
-};
- *
- */
+
 struct transaction_op_error_category : std::error_category {
     [[nodiscard]] const char* name() const noexcept override
     {

--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -188,6 +188,9 @@ class transactions : public couchbase::transactions::transactions
 
     void run(const couchbase::transactions::per_transaction_config& config, async_logic&& code, txn_complete_callback&& cb);
 
+    void run(couchbase::transactions::async_txn_logic&& code,
+             couchbase::transactions::async_txn_complete_logic&& complete_cb,
+             const couchbase::transactions::per_transaction_config& cfg = {}) override;
     /**
      * @internal
      * called internally - will likely move

--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -1428,7 +1428,7 @@ attempt_context_impl::commit()
 {
     debug("waiting on ops to finish...");
     op_list_.wait_and_block_ops();
-    existing_error();
+    existing_error(false);
     debug("commit {}", id());
     if (op_list_.get_mode().is_query()) {
         auto barrier = std::make_shared<std::promise<void>>();

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -74,13 +74,9 @@ class attempt_context_impl
                                                                    const std::string& id,
                                                                    std::vector<std::byte> content) override
     {
-        try {
-            auto res = insert_raw({ coll->bucket_name(), coll->scope_name(), coll->name(), id }, content);
-            auto retval = std::make_shared<transaction_get_result>(res);
-            return retval;
-        } catch (const transaction_operation_failed&) {
-            return {};
-        }
+        return wrap_call_for_public_api([this, coll, &id, &content]() -> transaction_get_result {
+            return insert_raw({ coll->bucket_name(), coll->scope_name(), coll->name(), id }, content);
+        });
     }
     transaction_get_result insert_raw(const core::document_id& id, const std::vector<std::byte>& content) override;
 
@@ -90,11 +86,8 @@ class attempt_context_impl
     couchbase::transactions::transaction_get_result_ptr replace_raw(const couchbase::transactions::transaction_get_result_ptr doc,
                                                                     std::vector<std::byte> content) override
     {
-        try {
-            return std::make_shared<transaction_get_result>(replace_raw(dynamic_cast<transaction_get_result&>(*doc), content));
-        } catch (const transaction_operation_failed&) {
-            return {};
-        }
+        return wrap_call_for_public_api(
+          [this, doc, &content]() -> transaction_get_result { return replace_raw(dynamic_cast<transaction_get_result&>(*doc), content); });
     }
     void replace_raw(const transaction_get_result& document, const std::vector<std::byte>& content, Callback&& cb) override;
 
@@ -311,7 +304,9 @@ class attempt_context_impl
     transaction_get_result get(const core::document_id& id) override;
     couchbase::transactions::transaction_get_result_ptr get(std::shared_ptr<couchbase::collection> coll, const std::string& id) override
     {
-        return std::make_shared<transaction_get_result>(get({ coll->bucket_name(), coll->scope_name(), coll->name(), id }));
+        return wrap_call_for_public_api([this, coll, id]() mutable {
+            return get({ coll->bucket_name(), coll->scope_name(), coll->name(), id });
+        });
     }
     void get(const core::document_id& id, Callback&& cb) override;
 
@@ -321,13 +316,7 @@ class attempt_context_impl
     void remove(const transaction_get_result& document) override;
     couchbase::transactions::transaction_get_result_ptr remove(couchbase::transactions::transaction_get_result_ptr doc) override
     {
-        try {
-            remove(dynamic_cast<transaction_get_result&>(*doc));
-            return doc;
-        } catch (const transaction_operation_failed&) {
-            // TODO: here is where we pop the error in
-            return doc;
-        } // TODO: handle other exceptions
+        return wrap_void_call_for_public_api([this, doc]() { remove(dynamic_cast<transaction_get_result&>(*doc)); });
     }
     void remove(const transaction_get_result& document, VoidCallback&& cb) override;
 
@@ -459,5 +448,30 @@ class attempt_context_impl
                                             Handler&& cb,
                                             error_class ec,
                                             const std::string& message);
+
+    couchbase::transactions::transaction_get_result_ptr wrap_call_for_public_api(std::function<transaction_get_result()>&& handler)
+    {
+        try {
+            return std::make_shared<transaction_get_result>(handler());
+        } catch (const transaction_operation_failed& e) {
+            return std::make_shared<transaction_get_result>(e.get_error_ctx());
+        } catch (...) {
+            // the handler should catch everything else, but just in case...
+            return std::make_shared<transaction_get_result>(transaction_op_error_context(errc::transaction_op::unknown));
+        }
+    }
+
+    couchbase::transactions::transaction_get_result_ptr wrap_void_call_for_public_api(std::function<void()>&& handler)
+    {
+        try {
+            handler();
+            return std::make_shared<transaction_get_result>();
+        } catch (const transaction_operation_failed& e) {
+            return std::make_shared<transaction_get_result>(e.get_error_ctx());
+        } catch (...) {
+            // the handler should catch everything else, but just in case...
+            return std::make_shared<transaction_get_result>(transaction_op_error_context(errc::transaction_op::unknown));
+        }
+    }
 };
 } // namespace couchbase::core::transactions

--- a/core/transactions/exceptions.cxx
+++ b/core/transactions/exceptions.cxx
@@ -84,10 +84,65 @@ transaction_exception::transaction_exception(const std::runtime_error& cause, co
   , result_(context.get_transaction_result())
   , cause_(UNKNOWN)
   , type_(type)
+  , txn_id_(context.transaction_id())
 {
     auto txn_op = dynamic_cast<const transaction_operation_failed*>(&cause);
     if (nullptr != txn_op) {
         cause_ = txn_op->cause();
     }
+    result_.ctx = error_context();
 }
+
+errc::transaction_op
+transaction_op_errc_from_external_exception(external_exception e)
+{
+    switch (e) {
+        case external_exception::UNKNOWN:
+            return errc::transaction_op::unknown;
+        case external_exception::ACTIVE_TRANSACTION_RECORD_ENTRY_NOT_FOUND:
+            return errc::transaction_op::active_transaction_record_entry_not_found;
+        case external_exception::ACTIVE_TRANSACTION_RECORD_FULL:
+            return errc::transaction_op::active_transaction_record_full;
+        case external_exception::COMMIT_NOT_PERMITTED:
+            return errc::transaction_op::commit_not_permitted;
+        case external_exception::ACTIVE_TRANSACTION_RECORD_NOT_FOUND:
+            return errc::transaction_op::active_transaction_record_not_found;
+        case external_exception::CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT:
+            return errc::transaction_op::concurrent_operations_detected_on_same_document;
+        case external_exception::COUCHBASE_EXCEPTION:
+            return errc::transaction_op::couchbase_exception;
+        case external_exception::DOCUMENT_ALREADY_IN_TRANSACTION:
+            return errc::transaction_op::document_already_in_transaction;
+        case external_exception::DOCUMENT_EXISTS_EXCEPTION:
+            return errc::transaction_op::document_exists_exception;
+        case external_exception::DOCUMENT_NOT_FOUND_EXCEPTION:
+            return errc::transaction_op::document_not_found_exception;
+        case external_exception::FEATURE_NOT_AVAILABLE_EXCEPTION:
+            return errc::transaction_op::feature_not_available_exception;
+        case external_exception::FORWARD_COMPATIBILITY_FAILURE:
+            return errc::transaction_op::forward_compatibility_failure;
+        case external_exception::ILLEGAL_STATE_EXCEPTION:
+            return errc::transaction_op::illegal_state_exception;
+        case external_exception::PARSING_FAILURE:
+            return errc::transaction_op::parsing_failure;
+        case external_exception::NOT_SET:
+            return errc::transaction_op::not_set;
+        case external_exception::PREVIOUS_OPERATION_FAILED:
+            return errc::transaction_op::previous_operation_failed;
+        case external_exception::REQUEST_CANCELED_EXCEPTION:
+            return errc::transaction_op::request_canceled_exception;
+        case external_exception::ROLLBACK_NOT_PERMITTED:
+            return errc::transaction_op::rollback_not_permitted;
+        case external_exception::SERVICE_NOT_AVAILABLE_EXCEPTION:
+            return errc::transaction_op::service_not_available_exception;
+        case external_exception::TRANSACTION_ABORTED_EXTERNALLY:
+            return errc::transaction_op::transaction_aborted_externally;
+        case external_exception::TRANSACTION_ALREADY_ABORTED:
+            return errc::transaction_op::transaction_already_aborted;
+        case external_exception::TRANSACTION_ALREADY_COMMITTED:
+            return errc::transaction_op::transaction_already_committed;
+    }
+    return errc::transaction_op::unknown;
+}
+
 } // namespace couchbase::core::transactions

--- a/core/transactions/internal/transaction_context.hxx
+++ b/core/transactions/internal/transaction_context.hxx
@@ -124,7 +124,7 @@ class transaction_context
 
     [[nodiscard]] ::couchbase::transactions::transaction_result get_transaction_result() const
     {
-        return couchbase::transactions::transaction_result{ transaction_id(), current_attempt().state == attempt_state::COMPLETED };
+        return couchbase::transactions::transaction_result{ transaction_id(), current_attempt().state == attempt_state::COMPLETED, {} };
     }
     void new_attempt_context()
     {
@@ -162,7 +162,7 @@ class transaction_context
 
     void finalize(txn_complete_callback&& cb);
 
-    void existing_error();
+    void existing_error(bool previous_op_failed = true);
 
     void handle_error(std::exception_ptr err, txn_complete_callback&& cb);
 

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -176,10 +176,10 @@ transaction_context::rollback(async_attempt_context::VoidCallback&& cb)
 }
 
 void
-transaction_context::existing_error()
+transaction_context::existing_error(bool previous_op_failed)
 {
     if (current_attempt_context_) {
-        return current_attempt_context_->existing_error();
+        return current_attempt_context_->existing_error(previous_op_failed);
     }
     throw transaction_operation_failed(FAIL_OTHER, "no current attempt context").no_rollback();
 }
@@ -264,7 +264,7 @@ transaction_context::finalize(txn_complete_callback&& cb)
 {
 
     try {
-        existing_error();
+        existing_error(false);
         if (current_attempt_context_->is_done()) {
             return cb(std::nullopt, get_transaction_result());
         }

--- a/core/transactions/transaction_get_result.hxx
+++ b/core/transactions/transaction_get_result.hxx
@@ -56,6 +56,12 @@ class transaction_get_result : public couchbase::transactions::transaction_get_r
     transaction_get_result(transaction_get_result&& doc) = default;
 
     /** @internal */
+    transaction_get_result(const transaction_op_error_context& ctx)
+      : couchbase::transactions::transaction_get_result(ctx)
+    {
+    }
+
+    /** @internal */
     template<typename Content>
     transaction_get_result(core::document_id id,
                            Content content,
@@ -204,6 +210,11 @@ class transaction_get_result : public couchbase::transactions::transaction_get_r
     [[nodiscard]] couchbase::cas cas() const override
     {
         return cas_;
+    }
+
+    void ctx(transaction_op_error_context ctx)
+    {
+        ctx_ = std::move(ctx);
     }
 
     /** @internal */

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -127,7 +127,12 @@ transactions::run(const couchbase::transactions::per_transaction_config& config,
 couchbase::transactions::transaction_result
 transactions::run(couchbase::transactions::txn_logic&& code, const couchbase::transactions::per_transaction_config& config)
 {
-    return wrap_run(*this, config, max_attempts_, std::move(code));
+    try {
+        return wrap_run(*this, config, max_attempts_, std::move(code));
+    } catch (const transaction_exception& e) {
+        // get transaction_error_context from e and return it in the transaction_result
+        return e.get_transaction_result();
+    }
 }
 
 void

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -138,12 +138,28 @@ transactions::run(couchbase::transactions::txn_logic&& code, const couchbase::tr
 void
 transactions::run(const couchbase::transactions::per_transaction_config& config, async_logic&& code, txn_complete_callback&& cb)
 {
+    // TODO: use underlying asio instead!!
     std::thread([this, config, code = std::move(code), cb = std::move(cb)]() {
         try {
             auto result = wrap_run(*this, config, max_attempts_, std::move(code));
             return cb({}, result);
         } catch (const transaction_exception& e) {
             return cb(e, std::nullopt);
+        }
+    }).detach();
+}
+void
+transactions::run(couchbase::transactions::async_txn_logic&& code,
+                  couchbase::transactions::async_txn_complete_logic&& cb,
+                  const couchbase::transactions::per_transaction_config& config)
+{
+    // TODO: use underlying asio instead!!
+    std::thread([this, config, code = std::move(code), cb = std::move(cb)]() {
+        try {
+            auto result = wrap_run(*this, config, max_attempts_, std::move(code));
+            return cb(result);
+        } catch (const transaction_exception& e) {
+            return cb(e.get_transaction_result());
         }
     }).detach();
 }

--- a/couchbase/error_codes.hxx
+++ b/couchbase/error_codes.hxx
@@ -53,6 +53,13 @@ network_category() noexcept;
 
 const std::error_category&
 streaming_json_lexer_category() noexcept;
+
+const std::error_category&
+transaction_category() noexcept;
+
+const std::error_category&
+transaction_op_category() noexcept;
+
 } // namespace core::impl
 #endif
 
@@ -997,6 +1004,50 @@ enum class streaming_json_lexer {
     root_does_not_match_json_pointer = 1128,
 };
 
+/**
+ * Errors related to a failed transaction
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+enum class transaction {
+    failed = 1200,
+    expired = 1201,
+    failed_post_commit = 1202,
+    ambiguous = 1203,
+};
+
+/**
+ * Errors related to a failed transaction operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+enum class transaction_op {
+    unknown = 1300,
+    active_transaction_record_entry_not_found = 1301,
+    active_transaction_record_full = 1302,
+    active_transaction_record_not_found = 1303,
+    document_already_in_transaction = 1304,
+    document_exists_exception = 1305,
+    document_not_found_exception = 1306,
+    not_set = 1307,
+    feature_not_available_exception = 1308,
+    transaction_aborted_externally = 1309,
+    previous_operation_failed = 1310,
+    forward_compatibility_failure = 1311,
+    parsing_failure = 1312,
+    illegal_state_exception = 1313,
+    couchbase_exception = 1314,
+    service_not_available_exception = 1315,
+    request_canceled_exception = 1316,
+    concurrent_operations_detected_on_same_document = 1317,
+    commit_not_permitted = 1318,
+    rollback_not_permitted = 1319,
+    transaction_already_aborted = 1320,
+    transaction_already_committed = 1321,
+};
+
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
 inline std::error_code
 make_error_code(common e) noexcept
@@ -1057,6 +1108,19 @@ make_error_code(streaming_json_lexer e)
 {
     return { static_cast<int>(e), core::impl::streaming_json_lexer_category() };
 }
+
+inline std::error_code
+make_error_code(transaction e)
+{
+    return { static_cast<int>(e), core::impl::transaction_category() };
+}
+
+inline std::error_code
+make_error_code(transaction_op e)
+{
+    return { static_cast<int>(e), core::impl::transaction_op_category() };
+}
+
 #endif
 } // namespace errc
 } // namespace couchbase
@@ -1101,4 +1165,13 @@ struct std::is_error_code_enum<couchbase::errc::network> : std::true_type {
 template<>
 struct std::is_error_code_enum<couchbase::errc::streaming_json_lexer> : std::true_type {
 };
+
+template<>
+struct std::is_error_code_enum<couchbase::errc::transaction> : std::true_type {
+};
+
+template<>
+struct std::is_error_code_enum<couchbase::errc::transaction_op> : std::true_type {
+};
+
 #endif

--- a/couchbase/transaction_error_context.hxx
+++ b/couchbase/transaction_error_context.hxx
@@ -1,0 +1,49 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/error_context.hxx>
+#include <couchbase/transaction_op_error_context.hxx>
+
+namespace couchbase
+{
+class transaction_error_context
+{
+  public:
+    transaction_error_context() = default;
+    transaction_error_context(std::error_code ec, std::error_code cause)
+      : ec_(ec)
+      , cause_(cause)
+    {
+    }
+
+    [[nodiscard]] std::error_code ec() const
+    {
+        return ec_;
+    }
+
+    [[nodiscard]] std::error_code cause() const
+    {
+        return cause_;
+    }
+
+  private:
+    std::error_code ec_{};    // a transaction error_code
+    std::error_code cause_{}; // a transaction_op error_code
+};
+} // namespace couchbase

--- a/couchbase/transaction_op_error_context.hxx
+++ b/couchbase/transaction_op_error_context.hxx
@@ -42,7 +42,7 @@ class transaction_op_error_context
     }
 
   private:
-    std::error_code ec_{};    // a transaction_op error_code
+    std::error_code ec_{}; // a transaction_op error_code
     // TODO: perhaps a variant later to house a kv or query error_context,
     //       or maybe they both have a common base, etc...
     couchbase::error_context cause_{};

--- a/couchbase/transaction_op_error_context.hxx
+++ b/couchbase/transaction_op_error_context.hxx
@@ -1,0 +1,50 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/error_context.hxx>
+
+namespace couchbase
+{
+class transaction_op_error_context
+{
+  public:
+    transaction_op_error_context() = default;
+
+    transaction_op_error_context(std::error_code ec, couchbase::error_context cause = {})
+      : ec_(std::move(ec))
+      , cause_(std::move(cause))
+    {
+    }
+    [[nodiscard]] std::error_code ec() const
+    {
+        return ec_;
+    }
+
+    [[nodiscard]] couchbase::error_context cause() const
+    {
+        return cause_;
+    }
+
+  private:
+    std::error_code ec_{};    // a transaction_op error_code
+    // TODO: perhaps a variant later to house a kv or query error_context,
+    //       or maybe they both have a common base, etc...
+    couchbase::error_context cause_{};
+};
+} // namespace couchbase

--- a/couchbase/transactions.hxx
+++ b/couchbase/transactions.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <couchbase/transactions/async_attempt_context.hxx>
 #include <couchbase/transactions/attempt_context.hxx>
 #include <couchbase/transactions/per_transaction_config.hxx>
 #include <couchbase/transactions/transaction_result.hxx>
@@ -26,11 +27,16 @@
 namespace couchbase::transactions
 {
 using txn_logic = std::function<void(attempt_context&)>;
+using async_txn_logic = std::function<void(async_attempt_context&)>;
+using async_txn_complete_logic = std::function<void(transaction_result)>;
 
 class transactions
 {
   public:
     virtual ~transactions() = default;
     virtual transaction_result run(txn_logic&& logic, const per_transaction_config& cfg = per_transaction_config()) = 0;
+    virtual void run(async_txn_logic&& logic,
+                     async_txn_complete_logic&& complete_callback,
+                     const per_transaction_config& cfg = per_transaction_config()) = 0;
 };
 } // namespace couchbase::transactions

--- a/couchbase/transactions/async_attempt_context.hxx
+++ b/couchbase/transactions/async_attempt_context.hxx
@@ -15,21 +15,12 @@
  */
 #pragma once
 
-#include <couchbase/transaction_error_context.hxx>
-#include <string>
+#include <couchbase/transactions/transaction_get_result.hxx>
 
 namespace couchbase::transactions
 {
-/**
- * Results of a transaction
- * @volatile
- *
- * Contains internal information on a transaction,
- * returned by @ref core::transactions::run()
- */
-struct transaction_result {
-    std::string transaction_id;
-    bool unstaging_complete;
-    transaction_error_context ctx;
+class async_attempt_context
+{
+  public:
 };
 } // namespace couchbase::transactions

--- a/couchbase/transactions/attempt_context.hxx
+++ b/couchbase/transactions/attempt_context.hxx
@@ -44,10 +44,11 @@ class attempt_context
         }
     }
 
-    virtual transaction_get_result_ptr remove(transaction_get_result_ptr doc) = 0;
+    virtual transaction_op_error_context remove(transaction_get_result_ptr doc) = 0;
 
     // TODO: when public api has query, we will be able to use non-core options to create the transaction_query_options.
-    // virtual void query(const std::string& statement, const transaction_query_options& options, QueryCallback&& cb) = 0;
+    // virtual transaction_op_error_context query(const std::string& statement, const transaction_query_options& options, QueryCallback&&
+    // cb) = 0;
 
     virtual ~attempt_context() = default;
 

--- a/couchbase/transactions/transaction_get_result.hxx
+++ b/couchbase/transactions/transaction_get_result.hxx
@@ -21,6 +21,7 @@
 #include <couchbase/cas.hxx>
 #include <couchbase/codec/json_transcoder.hxx>
 #include <couchbase/collection.hxx>
+#include <couchbase/transaction_op_error_context.hxx>
 
 namespace couchbase::transactions
 {
@@ -29,10 +30,16 @@ class transaction_get_result
 {
   protected:
     std::vector<std::byte> value_{};
+    transaction_op_error_context ctx_{};
 
     transaction_get_result() = default;
     transaction_get_result(std::vector<std::byte> content)
       : value_(content)
+    {
+    }
+
+    transaction_get_result(const transaction_op_error_context& ctx)
+      : ctx_(ctx)
     {
     }
 
@@ -60,9 +67,15 @@ class transaction_get_result
         return value_;
     }
 
+    // TODO: move to core
     void content(const std::vector<std::byte>& content)
     {
         value_ = content;
+    }
+
+    [[nodiscard]] const transaction_op_error_context& ctx() const
+    {
+        return ctx_;
     }
 
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ transaction_test(transaction_context)
 transaction_test(transaction_simple)
 transaction_test(transaction_simple_async)
 transaction_test(transaction_public_blocking_api)
+transaction_test(transaction_public_async_api)
 
 unit_test(transaction_logging)
 unit_test(transaction_utils)

--- a/test/test_transaction_transaction_public_async_api.cxx
+++ b/test/test_transaction_transaction_public_async_api.cxx
@@ -1,0 +1,251 @@
+/*
+ *     Copyright 2022 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+#include "utils/transactions_env.h"
+
+static const tao::json::value async_content{ { "some_number", 0 } };
+
+TEST_CASE("can async get", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [id, coll](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [id](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK_FALSE(res->ctx().ec());
+              CHECK(res->key() == id.key());
+              CHECK(res->bucket() == id.bucket());
+              CHECK(res->scope() == id.scope());
+              CHECK(res->content<tao::json::value>() == async_content);
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.ctx.ec());
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK_FALSE(res.unstaging_complete);
+          barrier->set_value();
+      });
+    f.get();
+}
+
+TEST_CASE("can get fail as expected", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [id, coll](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [id](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK(res->ctx().ec());
+              CHECK(res->ctx().ec() == couchbase::errc::transaction_op::document_not_found_exception);
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.ctx.ec());
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK_FALSE(res.unstaging_complete);
+          barrier->set_value();
+      });
+    f.get();
+}
+TEST_CASE("can async remove", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [coll, id](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [&ctx](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK_FALSE(res->ctx().ec());
+              ctx.remove(res, [](couchbase::transaction_op_error_context err) { CHECK_FALSE(err.ec()); });
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK(res.unstaging_complete);
+          CHECK_FALSE(res.ctx.ec());
+          barrier->set_value();
+      });
+    f.get();
+}
+
+TEST_CASE("async remove with bad cas fails as expected", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [coll, id](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [&ctx](couchbase::transactions::transaction_get_result_ptr res) {
+              std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(res)->cas(100);
+              ctx.remove(res, [](couchbase::transaction_op_error_context err) { CHECK(err.ec()); });
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK_FALSE(res.unstaging_complete);
+          CHECK(res.ctx.ec() == couchbase::errc::transaction::expired);
+          barrier->set_value();
+      });
+    f.get();
+}
+TEST_CASE("can async insert", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [id, coll](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.insert(coll, id.key(), async_content, [coll, id](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK_FALSE(res->ctx().ec());
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK(res.unstaging_complete);
+          CHECK_FALSE(res.ctx.ec());
+          barrier->set_value();
+      });
+    f.get();
+}
+
+TEST_CASE("async insert fails when doc already exists", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    c.transactions()->run(
+      [id, coll](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.insert(coll, id.key(), async_content, [coll, id](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK(res->ctx().ec() == couchbase::errc::transaction_op::document_exists_exception);
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK_FALSE(res.transaction_id.empty());
+          CHECK_FALSE(res.unstaging_complete);
+          CHECK(res.ctx.ec() == couchbase::errc::transaction::failed);
+          CHECK(res.ctx.cause() == couchbase::errc::transaction_op::document_exists_exception);
+          barrier->set_value();
+      });
+    f.get();
+}
+
+TEST_CASE("can async replace", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    tao::json::value new_content = { { "Iam", "new content" } };
+    c.transactions()->run(
+      [id, coll, new_content](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [new_content, &ctx](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK_FALSE(res->ctx().ec());
+              ctx.replace(res, new_content, [](couchbase::transactions::transaction_get_result_ptr replace_res) {
+                  CHECK_FALSE(replace_res->ctx().ec());
+              });
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result tx_result) {
+          CHECK_FALSE(tx_result.transaction_id.empty());
+          CHECK(tx_result.unstaging_complete);
+          CHECK_FALSE(tx_result.ctx.ec());
+          barrier->set_value();
+      });
+    f.get();
+}
+TEST_CASE("async replace fails as expected with bad cas", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    tao::json::value new_content = { { "Iam", "new content" } };
+    c.transactions()->run(
+      [id, coll, new_content](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [new_content, &ctx](couchbase::transactions::transaction_get_result_ptr res) {
+              std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(res)->cas(100);
+              ctx.replace(
+                res, new_content, [](couchbase::transactions::transaction_get_result_ptr replace_res) { CHECK(replace_res->ctx().ec()); });
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result tx_result) {
+          CHECK_FALSE(tx_result.transaction_id.empty());
+          CHECK_FALSE(tx_result.unstaging_complete);
+          CHECK(tx_result.ctx.ec() == couchbase::errc::transaction::expired);
+          barrier->set_value();
+      });
+    f.get();
+}
+
+TEST_CASE("uncaught exception will rollback", "[transactions]")
+{
+    auto id = TransactionsTestEnvironment::get_document_id();
+    REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
+    auto core_cluster = TransactionsTestEnvironment::get_cluster();
+    couchbase::cluster c(core_cluster);
+    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto f = barrier->get_future();
+    tao::json::value new_content = { { "Iam", "new content" } };
+    c.transactions()->run(
+      [id, coll, new_content](couchbase::transactions::async_attempt_context& ctx) {
+          ctx.get(coll, id.key(), [new_content, &ctx](couchbase::transactions::transaction_get_result_ptr res) {
+              CHECK_FALSE(res->ctx().ec());
+              ctx.replace(res, new_content, [](couchbase::transactions::transaction_get_result_ptr res) {
+                  CHECK_FALSE(res->ctx().ec());
+                  throw std::runtime_error("I wanna rollback");
+              });
+          });
+      },
+      [barrier](couchbase::transactions::transaction_result res) {
+          CHECK(res.ctx.ec() == couchbase::errc::transaction::failed);
+          CHECK_FALSE(res.unstaging_complete);
+          CHECK_FALSE(res.transaction_id.empty());
+          barrier->set_value();
+      });
+    f.get();
+}

--- a/test/test_transaction_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_transaction_public_blocking_api.cxx
@@ -19,7 +19,7 @@
 
 static const tao::json::value content{ { "some_number", 0 } };
 
-TEST_CASE("can get", "[public_transactions_api]")
+TEST_CASE("can get", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, content));
@@ -36,7 +36,7 @@ TEST_CASE("can get", "[public_transactions_api]")
     CHECK_FALSE(result.ctx.ec());
 }
 
-TEST_CASE("get fails as expected when doc doesn't exist", "[public_transactions_api]")
+TEST_CASE("get fails as expected when doc doesn't exist", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
@@ -53,7 +53,7 @@ TEST_CASE("get fails as expected when doc doesn't exist", "[public_transactions_
     CHECK(result.ctx.cause() == couchbase::errc::transaction_op::document_not_found_exception);
 }
 
-TEST_CASE("can insert", "[public_transactions_api]")
+TEST_CASE("can insert", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
@@ -73,7 +73,7 @@ TEST_CASE("can insert", "[public_transactions_api]")
     CHECK(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("insert fails as expected when doc already exists", "[public_transactions_api]")
+TEST_CASE("insert fails as expected when doc already exists", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     tao::json::value new_content{ { "something", "else" } };
@@ -95,7 +95,7 @@ TEST_CASE("insert fails as expected when doc already exists", "[public_transacti
     CHECK(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("can replace", "[public_transactions_api]")
+TEST_CASE("can replace", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, content));
@@ -119,7 +119,7 @@ TEST_CASE("can replace", "[public_transactions_api]")
     CHECK(final_doc.content_as<tao::json::value>() == new_content);
 }
 
-TEST_CASE("replace fails as expected with bad cas", "[public_transactions_api]")
+TEST_CASE("replace fails as expected with bad cas", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, content));
@@ -141,7 +141,7 @@ TEST_CASE("replace fails as expected with bad cas", "[public_transactions_api]")
     REQUIRE(doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("can remove", "[public_transactions_api]")
+TEST_CASE("can remove", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, content));
@@ -162,7 +162,7 @@ TEST_CASE("can remove", "[public_transactions_api]")
         REQUIRE(e.res()->ec == couchbase::errc::key_value::document_not_found);
     }
 }
-TEST_CASE("remove fails as expected with bad cas", "[public_transactions_api]")
+TEST_CASE("remove fails as expected with bad cas", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, content));
@@ -182,7 +182,7 @@ TEST_CASE("remove fails as expected with bad cas", "[public_transactions_api]")
     CHECK(result.ctx.ec() == couchbase::errc::transaction::expired);
 }
 
-TEST_CASE("remove fails as expected with missing doc", "[public_transactions_api]")
+TEST_CASE("remove fails as expected with missing doc", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
@@ -203,7 +203,7 @@ TEST_CASE("remove fails as expected with missing doc", "[public_transactions_api
     CHECK(result.ctx.cause() == couchbase::errc::transaction_op::document_not_found_exception);
 }
 
-TEST_CASE("uncaught exception in lambda will rollback without retry", "[public_transactions_api]")
+TEST_CASE("uncaught exception in lambda will rollback without retry", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();


### PR DESCRIPTION
Initial exposure of public api for transactions.   Will need to add transaction configs when we have a public api for creating the cluster (so there can be a transactions_config, etc...).   Also need queries exposed - felt they needed public query api first, but I'll look again, to be sure.   