### PR TITLE
CXXCBC-235: load system CAs when the trust certificate is not provided

### DIFF
--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -361,9 +361,13 @@ class cluster : public std::enable_shared_from_this<cluster>
                     return handler(ec);
                 }
             } else {
-                // add the cappela Root CA if no other CA was specified.
-                std::error_code ec{};
                 LOG_DEBUG(R"([{}]: use default CA for TLS verify)", id_);
+                std::error_code ec{};
+                tls_.set_default_verify_paths(ec);
+                if (ec) {
+                    LOG_WARNING(R"([{}]: failed to load system CAs: {})", id_, ec.message());
+                }
+                // add the capella Root CA if no other CA was specified.
                 tls_.add_certificate_authority(
                   asio::const_buffer(couchbase::core::default_ca::capellaCaCert, strlen(couchbase::core::default_ca::capellaCaCert)), ec);
                 if (ec) {

--- a/core/meta/version.cxx
+++ b/core/meta/version.cxx
@@ -26,6 +26,7 @@
 #include <fmt/core.h>
 #include <http_parser.h>
 #include <openssl/crypto.h>
+#include <openssl/x509.h>
 #include <snappy-stubs-public.h>
 #include <spdlog/version.h>
 
@@ -89,6 +90,8 @@ sdk_build_info()
 #elif defined(SSLEAY_VERSION)
     info["openssl_runtime"] = SSLeay_version(SSLEAY_VERSION);
 #endif
+    info["openssl_default_cert_dir"] = X509_get_default_cert_dir();
+    info["openssl_default_cert_file"] = X509_get_default_cert_file();
     info["__cplusplus"] = fmt::format("{}", __cplusplus);
 #if defined(_MSC_VER)
     info["_MSC_VER"] = fmt::format("{}", _MSC_VER);


### PR DESCRIPTION
When the user has not set any root ca provider but is using TLS then we should trust both the system store and the Capella root CA.