### PR TITLE
remove \n at EOF of Capella certificate

### DIFF
--- a/core/capella_ca.hxx
+++ b/core/capella_ca.hxx
@@ -38,6 +38,6 @@ static const char* capellaCaCert = "-----BEGIN CERTIFICATE-----\n"
                                    "Js7HEHKVms5tZTgKIw1fbmgR2XHleah1AcANB+MAPBCcTgqurqr5G7W2aPSBLLGA\n"
                                    "fRIiVzm7VFLc7kWbp7ENH39HVG6TZzKnfl9zJYeiklo5vQQhGSMhzBsO70z4RRzi\n"
                                    "DPFAN/4qZAgD5q3AFNIq2WWADFQGSwVJhg==\n"
-                                   "-----END CERTIFICATE-----\n";
+                                   "-----END CERTIFICATE-----";
 
 } // namespace couchbase::core::default_ca


### PR DESCRIPTION
to avoid PEM_R_NO_START_LINE "no start line" from parser