### PR TITLE
Move away from reinterpret_pointer_cast<> for mac build issue

### DIFF
--- a/test/test_transaction_transaction_public_async_api.cxx
+++ b/test/test_transaction_transaction_public_async_api.cxx
@@ -107,7 +107,7 @@ TEST_CASE("async remove with bad cas fails as expected", "[transactions]")
     c.transactions()->run(
       [coll, id](couchbase::transactions::async_attempt_context& ctx) {
           ctx.get(coll, id.key(), [&ctx](couchbase::transactions::transaction_get_result_ptr res) {
-              std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(res)->cas(100);
+              reinterpret_cast<couchbase::core::transactions::transaction_get_result&>(*res).cas(100);
               ctx.remove(res, [](couchbase::transaction_op_error_context err) { CHECK(err.ec()); });
           });
       },
@@ -207,7 +207,7 @@ TEST_CASE("async replace fails as expected with bad cas", "[transactions]")
     c.transactions()->run(
       [id, coll, new_content](couchbase::transactions::async_attempt_context& ctx) {
           ctx.get(coll, id.key(), [new_content, &ctx](couchbase::transactions::transaction_get_result_ptr res) {
-              std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(res)->cas(100);
+              reinterpret_cast<couchbase::core::transactions::transaction_get_result&>(*res).cas(100);
               ctx.replace(
                 res, new_content, [](couchbase::transactions::transaction_get_result_ptr replace_res) { CHECK(replace_res->ctx().ec()); });
           });

--- a/test/test_transaction_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_transaction_public_blocking_api.cxx
@@ -128,7 +128,7 @@ TEST_CASE("replace fails as expected with bad cas", "[transactions]")
     auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
     auto result = c.transactions()->run([id, coll, new_content](couchbase::transactions::attempt_context& ctx) {
         auto doc = ctx.get(coll, id.key());
-        std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(doc)->cas(100);
+        reinterpret_cast<couchbase::core::transactions::transaction_get_result&>(*doc).cas(100);
         auto replaced_doc = ctx.replace(doc, new_content);
     });
     CHECK_FALSE(result.transaction_id.empty());
@@ -171,7 +171,7 @@ TEST_CASE("remove fails as expected with bad cas", "[transactions]")
     auto result = c.transactions()->run([id, coll](couchbase::transactions::attempt_context& ctx) {
         auto doc = ctx.get(coll, id.key());
         // change cas, so remove will fail and retry
-        std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(doc)->cas(100);
+        reinterpret_cast<couchbase::core::transactions::transaction_get_result&>(*doc).cas(100);
         auto err = ctx.remove(doc);
         CHECK(err.ec());
     });
@@ -233,7 +233,7 @@ TEST_CASE("can pass per-transaction configs", "[transactions]")
     auto result = c.transactions()->run(
       [id, coll](couchbase::transactions::attempt_context& ctx) {
           auto doc = ctx.get(coll, id.key());
-          std::reinterpret_pointer_cast<couchbase::core::transactions::transaction_get_result>(doc)->cas(100);
+          reinterpret_cast<couchbase::core::transactions::transaction_get_result&>(*doc).cas(100);
           auto err = ctx.remove(doc);
           CHECK(err.ec());
       },

--- a/test/test_transaction_transaction_simple.cxx
+++ b/test/test_transaction_transaction_simple.cxx
@@ -16,15 +16,9 @@
 
 #include "simple_object.hxx"
 #include "test_helper.hxx"
-
 #include "utils/transactions_env.h"
 
-#include "core/transactions.hxx"
-#include <couchbase/error_codes.hxx>
-
 #include <spdlog/spdlog.h>
-
-#include <couchbase/cluster.hxx>
 #include <stdexcept>
 
 using namespace couchbase::core::transactions;

--- a/test/test_transaction_transaction_simple_async.cxx
+++ b/test/test_transaction_transaction_simple_async.cxx
@@ -18,12 +18,9 @@
 #include "test_helper.hxx"
 
 #include "core/transactions/attempt_context_impl.hxx"
-#include "core/transactions/attempt_context_testing_hooks.hxx"
 
 #include "utils/transactions_env.h"
 
-#include "core/transactions.hxx"
-#include <couchbase/error_codes.hxx>
 #include <spdlog/spdlog.h>
 
 #include <future>


### PR DESCRIPTION
Since adding <memory> header didn't seem to help on Jenkins, we don't really need to do it.   A reinterpret_cast to a reference is fine, since we are just calling a method and not saving that pointer anyways.