### PR TITLE
CXXCBC-253 query_options not setting scope_qualifier

### DIFF
--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -351,7 +351,7 @@ struct query_options : public common_options<query_options> {
      */
     auto scope_qualifier(std::string scope_qualifier) -> query_options&
     {
-        client_context_id_ = std::move(scope_qualifier);
+        scope_qualifier_ = std::move(scope_qualifier);
         return self();
     }
 


### PR DESCRIPTION
The setter seems to have had a cut/paste issue.   Simple fix.