### PR TITLE
CXXCBC-254 Update txn example

### DIFF
--- a/couchbase/cluster_options.hxx
+++ b/couchbase/cluster_options.hxx
@@ -210,6 +210,19 @@ class cluster_options
         return behavior_;
     }
 
+    /**
+     * Returns the transactions options which effect the transactions behavior.
+     *
+     * @return  transactions configuration.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto transactions() -> transactions::transactions_config&
+    {
+        return transactions_;
+    }
+
     struct built {
         std::string username;
         std::string password;

--- a/couchbase/transactions/async_attempt_context.hxx
+++ b/couchbase/transactions/async_attempt_context.hxx
@@ -28,11 +28,11 @@ class async_attempt_context
 {
 
   public:
-    virtual void get(std::shared_ptr<collection> coll, std::string id, async_result_handler&& handler) = 0;
+    virtual void get(const collection& coll, std::string id, async_result_handler&& handler) = 0;
     virtual void remove(transaction_get_result_ptr doc, async_err_handler&& handler) = 0;
 
     template<typename Content>
-    void insert(std::shared_ptr<collection> coll, std::string id, Content&& content, async_result_handler&& handler)
+    void insert(const collection& coll, std::string id, Content&& content, async_result_handler&& handler)
     {
         if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
             return insert_raw(content, id, content, std::move(handler));
@@ -59,10 +59,7 @@ class async_attempt_context
     virtual ~async_attempt_context() = default;
 
   protected:
-    virtual void insert_raw(std::shared_ptr<collection> coll,
-                            std::string id,
-                            std::vector<std::byte> content,
-                            async_result_handler&& handler) = 0;
+    virtual void insert_raw(const collection& coll, std::string id, std::vector<std::byte> content, async_result_handler&& handler) = 0;
     virtual void replace_raw(transaction_get_result_ptr doc, std::vector<std::byte> content, async_result_handler&& handler) = 0;
 };
 } // namespace couchbase::transactions

--- a/couchbase/transactions/attempt_context.hxx
+++ b/couchbase/transactions/attempt_context.hxx
@@ -24,10 +24,10 @@ namespace couchbase::transactions
 class attempt_context
 {
   public:
-    virtual transaction_get_result_ptr get(std::shared_ptr<couchbase::collection> coll, const std::string& id) = 0;
+    virtual transaction_get_result_ptr get(const couchbase::collection& coll, const std::string& id) = 0;
 
     template<typename Content>
-    transaction_get_result_ptr insert(std::shared_ptr<couchbase::collection> coll, const std::string& id, const Content& content)
+    transaction_get_result_ptr insert(const couchbase::collection& coll, const std::string& id, const Content& content)
     {
         if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
             return insert_raw(content, id, content);
@@ -57,7 +57,7 @@ class attempt_context
 
   protected:
     virtual transaction_get_result_ptr replace_raw(const transaction_get_result_ptr doc, std::vector<std::byte> content) = 0;
-    virtual transaction_get_result_ptr insert_raw(std::shared_ptr<couchbase::collection> coll,
+    virtual transaction_get_result_ptr insert_raw(const couchbase::collection& coll,
                                                   const std::string& id,
                                                   std::vector<std::byte> content) = 0;
     virtual transaction_query_result_ptr do_public_query(const std::string& statement, const transaction_query_options& options) = 0;

--- a/test/test_transaction_transaction_public_async_api.cxx
+++ b/test/test_transaction_transaction_public_async_api.cxx
@@ -36,7 +36,7 @@ TEST_CASE("can async get", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -64,7 +64,7 @@ TEST_CASE("can get fail as expected", "[transactions]")
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -89,7 +89,7 @@ TEST_CASE("can async remove", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -115,7 +115,7 @@ TEST_CASE("async remove with bad cas fails as expected", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -139,7 +139,7 @@ TEST_CASE("can async insert", "[transactions]")
     auto id = TransactionsTestEnvironment::get_document_id();
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -164,7 +164,7 @@ TEST_CASE("async insert fails when doc already exists", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -190,7 +190,7 @@ TEST_CASE("can async replace", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     tao::json::value new_content = { { "Iam", "new content" } };
@@ -218,7 +218,7 @@ TEST_CASE("async replace fails as expected with bad cas", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     tao::json::value new_content = { { "Iam", "new content" } };
@@ -246,7 +246,7 @@ TEST_CASE("uncaught exception will rollback", "[transactions]")
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     tao::json::value new_content = { { "Iam", "new content" } };
@@ -277,7 +277,7 @@ TEST_CASE("can set transaction options", "[transactions]")
     auto core_cluster = TransactionsTestEnvironment::get_cluster();
     couchbase::cluster c(core_cluster);
     auto cfg = couchbase::transactions::transaction_options().expiration_time(std::chrono::seconds(2));
-    auto coll = std::make_shared<couchbase::collection>(c.bucket("default").default_collection());
+    auto coll = c.bucket(id.bucket()).scope(id.scope()).collection(id.collection());
     auto begin = std::chrono::steady_clock::now();
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();


### PR DESCRIPTION
Using public api.   While at it, noticed the public api is more
convenient to use with `collection&` (rather than `shared_ptr<collection>`), so I
changed that as well.