### PR TITLE
CXXCBC-256 Async transactions example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,5 +5,6 @@ macro(define_example name)
 endmacro()
 
 define_example(game_server)
+define_example(async_game_server)
 define_example(minimal)
 define_example(distributed_mutex)


### PR DESCRIPTION
Added async_game_server - follows the existing game_server, but the update of the player and removal of the monster are in parallel.