### PR TITLE
TXNCXX-268 Segfault in jenkins fit tests

### DIFF
--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -80,8 +80,11 @@ void
 transaction_context::retry_delay()
 {
     // when we retry an operation, we typically call that function recursively.  So, we need to
-    // limit total number of times we do it.  Later we can be more sophisticated, perhaps.
-    auto delay = config_.expiration_time / 50; // the 50 is arbitrary
+    // limit total number of times we do it.  CXXCBC-263 will address this, and no longer make the
+    // recursive calls that lead to hacks like this. No way to know how many calls will blow up the
+    // stack, so using 50 in hopes that makes jenkins happy till we do this better.
+    constexpr auto arbitrary_factor = 50;
+    auto delay = config_.expiration_time / arbitrary_factor;
     txn_log->trace("about to sleep for {} ms", std::chrono::duration_cast<std::chrono::milliseconds>(delay).count());
     std::this_thread::sleep_for(delay);
 }

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -81,7 +81,7 @@ transaction_context::retry_delay()
 {
     // when we retry an operation, we typically call that function recursively.  So, we need to
     // limit total number of times we do it.  Later we can be more sophisticated, perhaps.
-    auto delay = config_.expiration_time / 100; // the 100 is arbitrary
+    auto delay = config_.expiration_time / 50; // the 50 is arbitrary
     txn_log->trace("about to sleep for {} ms", std::chrono::duration_cast<std::chrono::milliseconds>(delay).count());
     std::this_thread::sleep_for(delay);
 }


### PR DESCRIPTION
Here lets just lower the max retries for calls that use `retry_delay` to `50` from `100`.  That should (probably) allow jenkins testing to proceed without overflowing the stack.

There is another ticket (CXXCBC-263) to track the proper fix for this issue.  Here, we just want to get the fit tests running.