### PR TITLE
TXNCXX-268 ASAN issue in fit tests

### DIFF
--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -283,7 +283,7 @@ transactions_cleanup::get_active_clients(const couchbase::transactions::transact
         min_retry = config_.cleanup_config.cleanup_window;
     }
     return retry_op_exponential_backoff_timeout<client_record_details>(
-      min_retry, std::chrono::seconds(1), config_.cleanup_config.cleanup_window, [&]() -> client_record_details {
+      min_retry, std::chrono::seconds(1), config_.cleanup_config.cleanup_window, [this, keyspace, uuid]() -> client_record_details {
           client_record_details details;
           // Write our client record, return details.
           try {
@@ -415,7 +415,7 @@ transactions_cleanup::remove_client_record_from_all_buckets(const std::string& u
     for (const auto& keyspace : collections_) {
         try {
             retry_op_exponential_backoff_timeout<void>(
-              std::chrono::milliseconds(10), std::chrono::milliseconds(250), std::chrono::milliseconds(500), [&]() {
+              std::chrono::milliseconds(10), std::chrono::milliseconds(250), std::chrono::milliseconds(500), [this, keyspace, uuid]() {
                   try {
                       // insure a client record document exists...
                       create_client_record(keyspace);


### PR DESCRIPTION
After the previous commit for this ticket, I noticed another complaint from ASAN.  Small fix to just copy variables into the retry lambda rather than capture by reference.  Generally, though, I notice sometimes the API takes a const reference and copies, other times it takes an
object and moves.   Ideally the txn api should be a bit more consistent
on that - will make a ticket for that as well.