### PR TITLE
Check for expiry in begin work

### DIFF
--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -40,7 +40,7 @@ cluster::close() -> void
 {
     if (transactions_) {
         // blocks until cleanup is finished
-        static_cast<core::transactions::transactions&>(*transactions_).close();
+        transactions_->close();
     }
     transactions_.reset();
     return core::impl::initiate_cluster_close(core_);

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -35,6 +35,17 @@ cluster::transactions() -> std::shared_ptr<couchbase::transactions::transactions
     return transactions_;
 }
 
+auto
+cluster::close() -> void
+{
+    if (transactions_) {
+        // blocks until cleanup is finished
+        static_cast<core::transactions::transactions&>(*transactions_).close();
+    }
+    transactions_.reset();
+    return core::impl::initiate_cluster_close(core_);
+}
+
 namespace core::impl
 {
 

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -94,11 +94,7 @@ class cluster
     auto operator=(const cluster& other) -> cluster& = default;
     auto operator=(cluster&& other) -> cluster& = default;
 
-    void close()
-    {
-        transactions_.reset();
-        return core::impl::initiate_cluster_close(core_);
-    }
+    void close();
 
     /**
      * Wraps low-level implementation of the SDK to provide common API.


### PR DESCRIPTION
While there, lets see if blocking cluster.close until the transactions have finished stopping will help the crash at close seen on fit.