### PR TITLE
CXXCBC-271: fix get_all_replicas behaviour

### DIFF
--- a/core/impl/get_all_replicas.cxx
+++ b/core/impl/get_all_replicas.cxx
@@ -102,6 +102,9 @@ initiate_get_all_replicas_operation(std::shared_ptr<cluster> core,
                       }
                   }
                   if (local_handler) {
+                      if (!ctx->result_.empty()) {
+                          resp.ctx.override_ec({});
+                      }
                       return local_handler(std::move(resp.ctx), std::move(ctx->result_));
                   }
               });
@@ -131,6 +134,9 @@ initiate_get_all_replicas_operation(std::shared_ptr<cluster> core,
                   }
               }
               if (local_handler) {
+                  if (!ctx->result_.empty()) {
+                      resp.ctx.override_ec({});
+                  }
                   return local_handler(std::move(resp.ctx), std::move(ctx->result_));
               }
           });


### PR DESCRIPTION
Do not propagate error if result set is not empty, but the last response has failed.