### PR TITLE
CXXCBC-261 Query error handling issues

### DIFF
--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -44,7 +44,7 @@ namespace couchbase::core::impl
 {
 
 couchbase::transactions::transaction_query_result
-build_transaction_query_result(operations::query_response resp);
+build_transaction_query_result(operations::query_response resp, std::error_code ec = {});
 
 core::operations::query_request
 build_transaction_query_request(couchbase::query_options::built opts);

--- a/core/transactions/durability_level.hxx
+++ b/core/transactions/durability_level.hxx
@@ -46,7 +46,7 @@ durability_level_to_string_for_query(durability_level level)
         case durability_level::majority:
             return "majority";
         case durability_level::majority_and_persist_to_active:
-            return "majorityAndPersistToActive";
+            return "majorityAndPersistActive";
         case durability_level::persist_to_majority:
             return "persistToMajority";
     }

--- a/couchbase/transactions/transaction_keyspace.hxx
+++ b/couchbase/transactions/transaction_keyspace.hxx
@@ -68,7 +68,7 @@ struct transaction_keyspace {
 
     bool valid()
     {
-        return !(bucket.empty() || scope.empty() || collection.empty());
+        return !bucket.empty() && !scope.empty() && !collection.empty();
     }
 
     template<typename OStream>


### PR DESCRIPTION
Though some issues were fixed in previous commits, this addresses the remaining ones.  Now we will return the expected errors from kv operations done through query.

While there, corrected a typo in transactions durability levels, a small issue in transaction_keyspace.  Also, added an error_code to override
what build_transaction_query_result would otherwise decide upon.   This
will be useful as we transition away from exceptions in txn core.