### PR TITLE
CXXCBC-257 Support for FIT testing of kv range scan

### DIFF
--- a/core/collections_component.cxx
+++ b/core/collections_component.cxx
@@ -335,7 +335,7 @@ collection_id_cache_entry_impl::refresh_collection_id(std::shared_ptr<mcbp::queu
         return ec;
     }
 
-    CB_LOG_DEBUG("refreshing collection ID for %s.%s", req->scope_name_, req->collection_name_);
+    CB_LOG_DEBUG("refreshing collection ID for \"{}.{}\"", req->scope_name_, req->collection_name_);
     auto op = manager_->get_collection_id(
       req->scope_name_,
       req->collection_name_,

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -189,6 +189,19 @@ class cluster
 
     [[nodiscard]] auto transactions() -> std::shared_ptr<couchbase::transactions::transactions>;
 
+    /**
+     * Provide access to core cluster object
+     *
+     * This is used internally, during testing, and may be removed as the API evolves.
+     *
+     * @return pointer to core cluster
+     * @volatile
+     */
+    [[nodiscard]] auto core() -> std::shared_ptr<couchbase::core::cluster>
+    {
+        return core_;
+    }
+
   private:
     std::shared_ptr<couchbase::core::cluster> core_{};
     std::shared_ptr<couchbase::core::transactions::transactions> transactions_{};


### PR DESCRIPTION
Since FIT uses the public api, we need (at least for now) a way to get the core cluster object from the public cluster object, to use kv range
scan.   Added an accessor for that, for now.

Also added a check to apply the limit on a sampling scan, so next() stops when the limit is reached.

And a small logging change so we can see the collection being refreshed.