### PR TITLE
CXXCBC-197: Add support for ExtInsertExisting

### DIFF
--- a/core/transactions/exceptions.cxx
+++ b/core/transactions/exceptions.cxx
@@ -33,6 +33,19 @@ external_exception_from_error_class(error_class ec)
     }
 }
 
+couchbase::core::transactions::error_class
+error_class_from_external_exception(external_exception e)
+{
+    switch (e) {
+        case DOCUMENT_NOT_FOUND_EXCEPTION:
+            return FAIL_DOC_NOT_FOUND;
+        case DOCUMENT_EXISTS_EXCEPTION:
+            return FAIL_DOC_ALREADY_EXISTS;
+        default:
+            return FAIL_OTHER;
+    }
+}
+
 error_class
 error_class_from_result(const result& res)
 {

--- a/core/transactions/forward_compat.hxx
+++ b/core/transactions/forward_compat.hxx
@@ -123,7 +123,7 @@ struct forward_compat_supported {
     uint32_t protocol_major = 2;
     uint32_t protocol_minor = 0;
     std::list<std::string> extensions{ "TI", "MO", "BM", "QU",     "SD", "BF3787", "BF3705", "BF3838",
-                                       "RC", "UA", "CO", "BF3791", "CM", "SI",     "QC" };
+                                       "RC", "UA", "CO", "BF3791", "CM", "SI",     "QC",     "IX" };
 };
 
 struct forward_compat_requirement {

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -201,7 +201,7 @@ transaction_context::handle_error(std::exception_ptr err, txn_complete_callback&
     try {
         try {
             std::rethrow_exception(err);
-        } catch (const query_exception& e) {
+        } catch (const op_exception& e) {
             // turn this into a transaction_operation_failed
             throw transaction_operation_failed(FAIL_OTHER, e.what()).cause(e.cause());
         }

--- a/test/test_transaction_transaction_context.cxx
+++ b/test/test_transaction_transaction_context.cxx
@@ -374,7 +374,7 @@ TEST_CASE("transactions: can see some query errors but no transactions failed", 
     tx.query("jkjkjl;kjlk;  jfjjffjfj",
              opts,
              [&barrier](std::exception_ptr err, std::optional<couchbase::core::operations::query_response> payload) {
-                 // this should result in a query_exception since the query isn't parseable.
+                 // this should result in a op_exception since the query isn't parseable.
                  CHECK(err);
                  CHECK_FALSE(payload);
                  if (err) {
@@ -386,12 +386,12 @@ TEST_CASE("transactions: can see some query errors but no transactions failed", 
     try {
         f.get();
         FAIL("expected future to throw exception");
-    } catch (const query_exception&) {
+    } catch (const op_exception&) {
 
     } catch (...) {
         auto e = std::current_exception();
         std::cout << "got " << typeid(e).name() << std::endl;
-        FAIL("expected query_exception to be thrown from the future");
+        FAIL("expected op_exception to be thrown from the future");
     }
     REQUIRE_NOTHROW(tx.existing_error());
 }


### PR DESCRIPTION
Updates transactions to give an ignorable exception (in the core api) when a transactional insert discovers the document already exists (as long as it isn't in a transaction itself).  The public api just returns an error, and in either case that error doesn't stop the transaction.