### PR TITLE
TXNCXX-260 - ExtBinaryMetadata bug

### DIFF
--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -1890,7 +1890,7 @@ attempt_context_impl::set_atr_pending_locked(const core::document_id& id, std::u
                     .create_path(),
                   // subdoc::opcode::set_doc used in replace w/ empty path
                   // ExtBinaryMetadata
-                  couchbase::mutate_in_specs::replace({}, std::string({ 0x00 })),
+                  couchbase::mutate_in_specs::replace_raw({}, std::vector<std::byte>{ std::byte{ 0x00 } }),
               }
                 .specs();
             req.store_semantics = couchbase::store_semantics::upsert;

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -248,7 +248,7 @@ transactions_cleanup::create_client_record(const couchbase::transactions::transa
               couchbase::mutate_in_specs::insert(FIELD_CLIENTS, tao::json::empty_object).xattr().create_path(),
               // subdoc::opcode::set_doc used in replace w/ empty path
               // ExtBinaryMetadata
-              couchbase::mutate_in_specs::replace({}, std::string({ 0x00 })),
+              couchbase::mutate_in_specs::replace_raw({}, std::vector<std::byte>{ std::byte{ 0x00 } }),
           }
             .specs();
         wrap_durable_request(req, config_);


### PR DESCRIPTION
The atrs and client-records had `"u0000"` as the body, instead of a single `0` byte.   Thus they would be indexed by the index service, and other problematic things.

Simple fix, and added a test to catch any regressions in the future.