### PR TITLE
CXXCBC-259 Transactions public api expects bucket already open

### DIFF
--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -52,14 +52,14 @@ namespace transactions
 class transactions_cleanup;
 
 /** @brief Transaction logic should be contained in a lambda of this form */
-using logic = utils::movable_function<void(attempt_context&)>;
+using logic = std::function<void(attempt_context&)>;
 
 /** @brief AsyncTransaction logic should be contained in a lambda of this form */
-using async_logic = utils::movable_function<void(async_attempt_context&)>;
+using async_logic = std::function<void(async_attempt_context&)>;
 
 /** @brief AsyncTransaction callback when transaction has completed */
 using txn_complete_callback =
-  utils::movable_function<void(std::optional<transaction_exception>, std::optional<::couchbase::transactions::transaction_result>)>;
+  std::function<void(std::optional<transaction_exception>, std::optional<::couchbase::transactions::transaction_result>)>;
 
 /**
  * @brief set log level for transactions

--- a/core/transactions/async_attempt_context.hxx
+++ b/core/transactions/async_attempt_context.hxx
@@ -22,7 +22,6 @@
 #include "transaction_get_result.hxx"
 
 #include "core/operations/document_query.hxx"
-#include "core/utils/movable_function.hxx"
 #include <future>
 #include <optional>
 #include <string>
@@ -39,8 +38,8 @@ class transaction_operation_failed;
 class async_attempt_context
 {
   public:
-    using Callback = utils::movable_function<void(std::exception_ptr, std::optional<transaction_get_result>)>;
-    using VoidCallback = utils::movable_function<void(std::exception_ptr)>;
+    using Callback = std::function<void(std::exception_ptr, std::optional<transaction_get_result>)>;
+    using VoidCallback = std::function<void(std::exception_ptr)>;
     using QueryCallback = std::function<void(std::exception_ptr, std::optional<core::operations::query_response>)>;
     virtual ~async_attempt_context() = default;
     /**

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <core/cluster.hxx>
 #include <couchbase/transactions/async_attempt_context.hxx>
 #include <couchbase/transactions/attempt_context.hxx>
 #include <couchbase/transactions/transaction_query_options.hxx>
@@ -137,7 +138,7 @@ class attempt_context_impl
     void commit_with_query(VoidCallback&& cb);
     void rollback_with_query(VoidCallback&& cb);
 
-    void query_begin_work(utils::movable_function<void(std::exception_ptr)>&& cb);
+    void query_begin_work(std::function<void(std::exception_ptr)>&& cb);
 
     void do_query(const std::string& statement, const couchbase::transactions::transaction_query_options& opts, QueryCallback&& cb);
     std::exception_ptr handle_query_error(const core::operations::query_response& resp);
@@ -147,7 +148,7 @@ class attempt_context_impl
                     const tao::json::value& txdata,
                     const std::string& hook_point,
                     bool check_expiry,
-                    utils::movable_function<void(std::exception_ptr, core::operations::query_response)>&& cb);
+                    std::function<void(std::exception_ptr, core::operations::query_response)>&& cb);
 
     void handle_err_from_callback(std::exception_ptr e)
     {
@@ -285,7 +286,7 @@ class attempt_context_impl
     }
 
     template<typename Handler>
-    void cache_error_async(Handler&& cb, std::function<void()> func)
+    void cache_error_async(Handler cb, std::function<void()> func)
     {
         try {
             op_list_.increment_ops();
@@ -507,15 +508,13 @@ class attempt_context_impl
 
     void atr_rollback_complete();
 
-    void select_atr_if_needed_unlocked(const core::document_id id,
-                                       utils::movable_function<void(std::optional<transaction_operation_failed>)>&& cb);
+    void select_atr_if_needed_unlocked(const core::document_id id, std::function<void(std::optional<transaction_operation_failed>)>&& cb);
 
     template<typename Handler>
     void do_get(const core::document_id& id, const std::optional<std::string> resolving_missing_atr_entry, Handler&& cb);
 
-    void get_doc(
-      const core::document_id& id,
-      utils::movable_function<void(std::optional<error_class>, std::optional<std::string>, std::optional<transaction_get_result>)>&& cb);
+    void get_doc(const core::document_id& id,
+                 std::function<void(std::optional<error_class>, std::optional<std::string>, std::optional<transaction_get_result>)>&& cb);
 
     core::operations::mutate_in_request create_staging_request(const core::document_id& in,
                                                                const transaction_get_result* document,
@@ -601,6 +600,11 @@ class attempt_context_impl
             }
         }
         return cb({});
+    }
+
+    void ensure_open_bucket(std::string bucket_name, std::function<void(std::error_code)>&& handler)
+    {
+        cluster_ref()->open_bucket(bucket_name, [handler = std::move(handler)](std::error_code ec) { handler(ec); });
     }
 };
 

--- a/test/test_transaction_transaction_public_async_api.cxx
+++ b/test/test_transaction_transaction_public_async_api.cxx
@@ -158,7 +158,7 @@ TEST_CASE("can async insert", "[transactions]")
     f.get();
 }
 
-TEST_CASE("async insert fails when doc already exists", "[transactions]")
+TEST_CASE("async insert fails when doc already exists, but doesn't rollback", "[transactions]")
 {
     auto id = TransactionsTestEnvironment::get_document_id();
     REQUIRE(TransactionsTestEnvironment::upsert_doc(id, async_content));
@@ -175,9 +175,8 @@ TEST_CASE("async insert fails when doc already exists", "[transactions]")
       },
       [barrier](couchbase::transactions::transaction_result res) {
           CHECK_FALSE(res.transaction_id.empty());
-          CHECK_FALSE(res.unstaging_complete);
-          CHECK(res.ctx.ec() == couchbase::errc::transaction::failed);
-          CHECK(res.ctx.cause() == couchbase::errc::transaction_op::document_exists_exception);
+          CHECK(res.unstaging_complete);
+          CHECK_FALSE(res.ctx.ec());
           barrier->set_value();
       },
       async_options());


### PR DESCRIPTION
That's inconvienent - since you have to perform a kv op on it before the transaction.  So - added a function to insure it is open, on the public api calls.

While there, noticed an issue with cache_error_async, where we move the callback yet use it in the function as well.  For now, not using movable_function, allowing a copy, until I rework that function.