### PR TITLE
CXXCBC-275 Update query_context handling in query management calls

### DIFF
--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -137,11 +137,14 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
     if (check_scan_wait && scan_wait) {
         body["scan_wait"] = fmt::format("{}ms", scan_wait.value().count());
     }
+
     if (scope_qualifier) {
         body["query_context"] = scope_qualifier;
-    } else if (scope_name) {
-        if (bucket_name) {
+    } else if (bucket_name) {
+        if (scope_name) {
             body["query_context"] = fmt::format("default:`{}`.`{}`", *bucket_name, *scope_name);
+        } else {
+            body["query_context"] = fmt::format("default:`{}`", *bucket_name);
         }
     }
     for (const auto& [name, value] : raw) {

--- a/core/operations/management/query_index_build.cxx
+++ b/core/operations/management/query_index_build.cxx
@@ -55,7 +55,7 @@ query_index_build_request::encode_to(encoded_request_type& encoded, http_context
         query_context += ".`" + scope_name + "`";
     } else {
         statement = fmt::format(R"(BUILD INDEX ON {} ({}))", query_context, quote_and_join_strings(index_names, ","));
-        query_context += ".`_default`";
+        query_context += fmt::format(".`{}`", couchbase::scope::default_name);
     }
     encoded.headers["content-type"] = "application/json";
     tao::json::value body{ { "statement", statement },

--- a/core/operations/management/query_index_build.cxx
+++ b/core/operations/management/query_index_build.cxx
@@ -54,14 +54,13 @@ query_index_build_request::encode_to(encoded_request_type& encoded, http_context
           R"(BUILD INDEX ON `{}`.`{}`.`{}` ({}))", bucket_name, scope_name, collection_name, quote_and_join_strings(index_names, ","));
         query_context += ".`" + scope_name + "`";
     } else {
-        statement = fmt::format(R"(BUILD INDEX ON `{}` ({}))", bucket_name, quote_and_join_strings(index_names, ","));
+        statement = fmt::format(R"(BUILD INDEX ON {} ({}))", query_context, quote_and_join_strings(index_names, ","));
         query_context += ".`_default`";
     }
     encoded.headers["content-type"] = "application/json";
-    tao::json::value body{ { "statement", statement }, { "client_context_id", encoded.client_context_id } };
-    if (!scope_name.empty() || !collection_name.empty()) {
-        body["query_context"] = query_context;
-    }
+    tao::json::value body{ { "statement", statement },
+                           { "client_context_id", encoded.client_context_id },
+                           { "query_context", query_context } };
     encoded.method = "POST";
     encoded.path = "/query/service";
     encoded.body = utils::json::generate(body);

--- a/core/operations/management/query_index_create.cxx
+++ b/core/operations/management/query_index_create.cxx
@@ -46,14 +46,13 @@ query_index_create_request::encode_to(encoded_request_type& encoded, http_contex
         with_clause = fmt::format("WITH {}", utils::json::generate(with));
     }
     std::string keyspace = fmt::format("{}:`{}`", namespace_id, bucket_name);
-    std::string query_context = keyspace;
+    auto query_context = keyspace;
     if (!scope_name.empty()) {
         keyspace += ".`" + scope_name + "`";
         query_context += ".`" + scope_name + "`";
     } else {
         query_context += ".`_default`";
     }
-
     if (!collection_name.empty()) {
         keyspace += ".`" + collection_name + "`";
     }
@@ -68,10 +67,8 @@ query_index_create_request::encode_to(encoded_request_type& encoded, http_contex
                                                       utils::join_strings(fields, ", "),
                                                       where_clause,
                                                       with_clause) },
-                           { "client_context_id", encoded.client_context_id } };
-    if (!scope_name.empty() || !collection_name.empty()) {
-        body["query_context"] = query_context;
-    }
+                           { "client_context_id", encoded.client_context_id },
+                           { "query_context", query_context } };
     encoded.method = "POST";
     encoded.path = "/query/service";
     encoded.body = utils::json::generate(body);

--- a/core/operations/management/query_index_create.cxx
+++ b/core/operations/management/query_index_create.cxx
@@ -51,7 +51,7 @@ query_index_create_request::encode_to(encoded_request_type& encoded, http_contex
         keyspace += ".`" + scope_name + "`";
         query_context += ".`" + scope_name + "`";
     } else {
-        query_context += ".`_default`";
+        query_context += fmt::format(".`{}`", couchbase::scope::default_name);
     }
     if (!collection_name.empty()) {
         keyspace += ".`" + collection_name + "`";

--- a/core/operations/management/query_index_drop.cxx
+++ b/core/operations/management/query_index_drop.cxx
@@ -29,31 +29,27 @@ query_index_drop_request::encode_to(encoded_request_type& encoded, http_context&
         return errc::common::invalid_argument;
     }
     encoded.headers["content-type"] = "application/json";
-    std::string keyspace = fmt::format("`{}`", bucket_name);
-    std::string query_context = keyspace;
+    std::string query_context = fmt::format("default:{}", bucket_name);
+    auto keyspace = query_context;
     if (!scope_name.empty()) {
-        keyspace += ".`" + scope_name + "`";
         query_context += ".`" + scope_name + "`";
+        keyspace += ".`" + scope_name + "`";
     } else {
         query_context += ".`_default`";
     }
     if (!collection_name.empty()) {
         keyspace += ".`" + collection_name + "`";
     }
-
     std::string drop_index_stmt;
     if (is_primary && index_name.empty()) {
         drop_index_stmt = fmt::format(R"(DROP PRIMARY INDEX ON {} USING GSI)", keyspace);
-    } else if (!scope_name.empty() || !collection_name.empty()) {
-        drop_index_stmt = fmt::format(R"(DROP INDEX `{}` ON {} USING GSI)", index_name, keyspace);
     } else {
-        drop_index_stmt = fmt::format(R"(DROP INDEX {}.`{}` USING GSI)", keyspace, index_name);
+        drop_index_stmt = fmt::format(R"(DROP INDEX `{}` ON {} USING GSI)", index_name, keyspace);
     }
 
-    tao::json::value body{ { "statement", drop_index_stmt }, { "client_context_id", encoded.client_context_id } };
-    if (!scope_name.empty() || !collection_name.empty()) {
-        body["query_context"] = query_context;
-    }
+    tao::json::value body{ { "statement", drop_index_stmt },
+                           { "client_context_id", encoded.client_context_id },
+                           { "query_context", query_context } };
     encoded.method = "POST";
     encoded.path = "/query/service";
     encoded.body = utils::json::generate(body);

--- a/core/operations/management/query_index_drop.cxx
+++ b/core/operations/management/query_index_drop.cxx
@@ -29,13 +29,13 @@ query_index_drop_request::encode_to(encoded_request_type& encoded, http_context&
         return errc::common::invalid_argument;
     }
     encoded.headers["content-type"] = "application/json";
-    std::string query_context = fmt::format("default:{}", bucket_name);
+    std::string query_context = fmt::format("{}:`{}`", namespace_id, bucket_name);
     auto keyspace = query_context;
     if (!scope_name.empty()) {
         query_context += ".`" + scope_name + "`";
         keyspace += ".`" + scope_name + "`";
     } else {
-        query_context += ".`_default`";
+        query_context += fmt::format(".`{}`", couchbase::scope::default_name);
     }
     if (!collection_name.empty()) {
         keyspace += ".`" + collection_name + "`";

--- a/core/operations/management/query_index_get_all.cxx
+++ b/core/operations/management/query_index_get_all.cxx
@@ -42,7 +42,7 @@ query_index_get_all_request::encode_to(encoded_request_type& encoded, couchbase:
     if (!scope_name.empty()) {
         query_context += ".`" + scope_name + "`";
     } else {
-        query_context += ".`_default`";
+        query_context += fmt::format(".`{}`", couchbase::scope::default_name);
     }
 
     if (collection_name == "_default" || collection_name.empty()) {

--- a/core/operations/management/query_index_get_all.cxx
+++ b/core/operations/management/query_index_get_all.cxx
@@ -39,10 +39,10 @@ query_index_get_all_request::encode_to(encoded_request_type& encoded, couchbase:
     }
 
     std::string query_context = fmt::format("{}:`{}`", namespace_id, bucket_name);
-    if (scope_name.empty()) {
-        query_context += ".`_default`";
-    } else {
+    if (!scope_name.empty()) {
         query_context += ".`" + scope_name + "`";
+    } else {
+        query_context += ".`_default`";
     }
 
     if (collection_name == "_default" || collection_name.empty()) {
@@ -61,10 +61,8 @@ query_index_get_all_request::encode_to(encoded_request_type& encoded, couchbase:
                            { "client_context_id", encoded.client_context_id },
                            { "$bucket_name", bucket_name },
                            { "$scope_name", scope_name },
-                           { "$collection_name", collection_name } };
-    if (!scope_name.empty() || !collection_name.empty()) {
-        body["query_context"] = query_context;
-    }
+                           { "$collection_name", collection_name },
+                           { "query_context", query_context } };
     encoded.method = "POST";
     encoded.path = "/query/service";
     encoded.body = utils::json::generate(body);

--- a/core/operations/management/query_index_get_all_deferred.cxx
+++ b/core/operations/management/query_index_get_all_deferred.cxx
@@ -36,7 +36,7 @@ query_index_get_all_deferred_request::encode_to(encoded_request_type& encoded, c
     if (!scope_name.empty()) {
         query_context += ".`" + scope_name + "`";
     } else {
-        query_context += ".`_default`";
+        query_context += fmt::format(".`{}`", couchbase::scope::default_name);
     }
 
     std::string statement = "SELECT RAW name FROM system:indexes"

--- a/core/operations/management/query_index_get_all_deferred.cxx
+++ b/core/operations/management/query_index_get_all_deferred.cxx
@@ -33,10 +33,10 @@ query_index_get_all_deferred_request::encode_to(encoded_request_type& encoded, c
     }
 
     std::string query_context = fmt::format("{}:`{}`", namespace_id, bucket_name);
-    if (scope_name.empty()) {
-        query_context += ".`_default`";
-    } else {
+    if (!scope_name.empty()) {
         query_context += ".`" + scope_name + "`";
+    } else {
+        query_context += ".`_default`";
     }
 
     std::string statement = "SELECT RAW name FROM system:indexes"
@@ -50,10 +50,8 @@ query_index_get_all_deferred_request::encode_to(encoded_request_type& encoded, c
                            { "client_context_id", encoded.client_context_id },
                            { "$bucket_name", bucket_name },
                            { "$scope_name", scope_name },
-                           { "$collection_name", collection_name } };
-    if (!scope_name.empty() || !collection_name.empty()) {
-        body["query_context"] = query_context;
-    }
+                           { "$collection_name", collection_name },
+                           { "query_context", query_context } };
     encoded.method = "POST";
     encoded.path = "/query/service";
     encoded.body = utils::json::generate(body);

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -967,7 +967,7 @@ TEST_CASE("integration: query index management", "[integration]")
 {
     test::utils::integration_test_guard integration;
 
-    if (!integration.cluster_version().supports_query_index_management()) {
+    if (!integration.cluster_version().supports_collections()) {
         return;
     }
 
@@ -1176,10 +1176,6 @@ TEST_CASE("integration: query index management", "[integration]")
 TEST_CASE("integration: collections query index management", "[integration]")
 {
     test::utils::integration_test_guard integration;
-
-    if (!integration.cluster_version().supports_query_index_management()) {
-        return;
-    }
 
     if (!integration.cluster_version().supports_collections()) {
         return;


### PR DESCRIPTION
The decision we have made is to always send a `query_context`, and live with the errors we see from 6.x and earlier for the management calls.  We could follow up with an option that allowed to user to specify this isn't put in the calls, if really needed.