### PR TITLE
Eliminate looping transform in mcbp_parser::next

### DIFF
--- a/core/io/mcbp_parser.cxx
+++ b/core/io/mcbp_parser.cxx
@@ -61,7 +61,7 @@ mcbp_parser::next(mcbp_message& msg)
         if (snappy::Uncompress(reinterpret_cast<const char*>(buf.data() + offset), body_size - prefix_size, &uncompressed)) {
             msg.body.insert(msg.body.end(),
                             reinterpret_cast<std::byte*>(&uncompressed.data()[0]),
-                            reinterpret_cast<std::byte*>(&uncompressed.data()[uncompressed.size() - 1]));
+                            reinterpret_cast<std::byte*>(&uncompressed.data()[uncompressed.size()]));
             use_raw_value = false;
             // patch header with new body size
             msg.header.bodylen = utils::byte_swap(static_cast<std::uint32_t>(prefix_size + uncompressed.size()));

--- a/core/io/mcbp_parser.hxx
+++ b/core/io/mcbp_parser.hxx
@@ -30,7 +30,7 @@ struct mcbp_parser {
     void feed(Iterator begin, Iterator end)
     {
         buf.reserve(buf.size() + static_cast<std::size_t>(std::distance(begin, end)));
-        std::copy(begin, end, std::back_insert_iterator(buf));
+        buf.insert(buf.end(), begin, end);
     }
 
     void reset()

--- a/core/utils/json.cxx
+++ b/core/utils/json.cxx
@@ -96,13 +96,13 @@ class to_byte_vector
     void write(tao::binary_view data)
     {
         buffer_.reserve(buffer_.size() + data.size());
-        std::copy(data.begin(), data.end(), std::back_inserter(buffer_));
+        buffer_.insert(buffer_.end(), data.begin(), data.end());
     }
 
     void write(std::string_view data)
     {
         buffer_.reserve(buffer_.size() + data.size());
-        std::transform(data.begin(), data.end(), std::back_inserter(buffer_), [](auto ch) { return static_cast<std::byte>(ch); });
+        buffer_.insert(buffer_.end(), reinterpret_cast<const std::byte*>(&data[0]), reinterpret_cast<const std::byte*>(&data[data.size()]));
     }
 
     inline void escape(const std::string_view s)


### PR DESCRIPTION
I found that in mcbp_session_impl::do_read, 39% of the time was in mcbp::parser::next, with the vast majority of that in the std::transform
call after uncompressing the data.   By using vector::insert instead,
that dropped to only 11% of the time in do:read.

Probably the upshot here is to look for everywhere we are filling containers with a back_inserter and considering a way to modify that to not loop and instead copy in blocks.

before: 
![image](https://user-images.githubusercontent.com/1072532/215151421-76a47bde-8022-474a-88ea-773649718d65.png)
after:
![image](https://user-images.githubusercontent.com/1072532/215151562-a42c045e-4c39-48b2-9153-4c2d8f065ec8.png)
 