### PR TITLE
CXXCBC-285: write to sockets from IO threads

### DIFF
--- a/core/io/http_session.hxx
+++ b/core/io/http_session.hxx
@@ -293,7 +293,7 @@ class http_session : public std::enable_shared_from_this<http_session>
         if (stopped_) {
             return;
         }
-        do_write();
+        asio::post(asio::bind_executor(ctx_, [self = shared_from_this()]() { self->do_write(); }));
     }
 
     template<typename Handler>

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -851,7 +851,7 @@ class mcbp_session_impl
         if (stopped_) {
             return;
         }
-        do_write();
+        asio::post(asio::bind_executor(ctx_, [self = shared_from_this()]() { self->do_write(); }));
     }
 
     void write_and_flush(std::vector<std::byte>&& buf)
@@ -1397,8 +1397,10 @@ class mcbp_session_impl
                 std::scoped_lock inner_lock(self->writing_buffer_mutex_);
                 self->writing_buffer_.clear();
             }
-            self->do_write();
-            self->do_read();
+            asio::post(asio::bind_executor(self->ctx_, [self]() {
+                self->do_write();
+                self->do_read();
+            }));
         });
     }
 


### PR DESCRIPTION
The writing procedure should be invoked from the IO thread and bound to IO executor. Otherwise when main thread invokes ASIO write directly, the OpenSSL structures are not guaranteed to be thread-safe.