### PR TITLE
set build timeouts for github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           key: ${{ github.job }}
       - name: Build tests
+        timeout-minutes: 40
         env:
           CB_TEST_SUITE: ${{ matrix.suite }}
         run: ./bin/build-tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,9 @@ jobs:
           key: ${{ github.job }}-${{ matrix.os }}
           variant: sccache
       - name: Build tests
+        timeout-minutes: 40
         env:
           CB_CACHE_OPTION: sccache
+          CB_CMAKE_BUILD_TYPE: Release
+          CB_NUMBER_OF_JOBS: 2
         run: ruby ./bin/build-tests.rb

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -102,5 +102,6 @@ Dir.chdir(BUILD_DIR) do
   run(CB_CMAKE,
       "--build", BUILD_DIR,
       "--parallel", CB_NUMBER_OF_JOBS,
+      "--config", CB_CMAKE_BUILD_TYPE,
       "--verbose")
 end


### PR DESCRIPTION
* set timeout to be safe, and not to waste to much time
* increase number of parallel jobs for cmake to 2 (works for now, but if it will be a problem, we can go back to 1)
* use Release build time as it consumes less space during build and less likely hit the disk limit on github actions.