### PR TITLE
CXXCBC-290: add header with feature macros

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -1,0 +1,31 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2022-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+/*
+ * This header defines macros for the various features to help
+ * users adopt early features or use conditional compilation to avoid
+ * unnecessary or untested code.
+ *
+ * Feel free to update this header with more macros.
+ */
+
+/**
+ * couchbase::core::meta::sdk_version() function is available
+ */
+#define COUCHBASE_CXX_CLIENT_HAS_SDK_SEMVER 1

--- a/core/meta/version.hxx
+++ b/core/meta/version.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2020-Present Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 
 #include <map>
 #include <string>
+
+#include "features.hxx"
 
 namespace couchbase::core::meta
 {

--- a/test/test_unit_utils.cxx
+++ b/test/test_unit_utils.cxx
@@ -226,4 +226,6 @@ TEST_CASE("unit: semantic version string", "[unit]")
     REQUIRE(couchbase::core::meta::parse_git_describe_output("unknown") == "");
     REQUIRE(couchbase::core::meta::parse_git_describe_output("invalid") == "");
     REQUIRE(couchbase::core::meta::parse_git_describe_output("1.0.0.0.0") == "");
+    REQUIRE(couchbase::core::meta::parse_git_describe_output("1.0.0-beta.4-0-gfbc9922") == "1.0.0-beta.4");
+    REQUIRE(couchbase::core::meta::parse_git_describe_output("1.0.0-beta.4") == "1.0.0-beta.4");
 }


### PR DESCRIPTION
also covers special case for tagged releases in sdk_semver() function