### PR TITLE
logger: extract level.hxx to reduce coupling

### DIFF
--- a/core/logger/configuration.hxx
+++ b/core/logger/configuration.hxx
@@ -10,7 +10,10 @@
  */
 #pragma once
 
+#include "level.hxx"
+
 #include <spdlog/common.h>
+
 #include <string>
 
 namespace couchbase::core::logger

--- a/core/logger/level.hxx
+++ b/core/logger/level.hxx
@@ -1,0 +1,21 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *     Copyright 2018-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+#pragma once
+
+namespace couchbase::core::logger
+{
+
+/**
+ * the various severity levels we can log at
+ */
+enum class level { trace, debug, info, warn, err, critical, off };
+
+} // namespace couchbase::core::logger

--- a/core/logger/logger.hxx
+++ b/core/logger/logger.hxx
@@ -25,20 +25,18 @@
 
 #pragma once
 
+#include "level.hxx"
+
 #include <fmt/core.h>
+#include <spdlog/fwd.h>
+
 #include <memory>
 #include <optional>
-#include <spdlog/fwd.h>
 #include <string>
 
 namespace couchbase::core::logger
 {
 struct configuration;
-
-/**
- * the various severity levels we can log at
- */
-enum class level { trace, debug, info, warn, err, critical, off };
 
 level
 level_from_str(const std::string& str);


### PR DESCRIPTION
The `logger.hxx` does not include `configuration.hxx`, because it is
often not needed (default logger is being used), but `configuration.hxx`
itself depends on the log level. So to workaround this dependency for
cases, where only `configuration.hxx` included, we extract logger level
into its own header file.
