### PR TITLE
fix tracer and meter ref-counting

### DIFF
--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -169,7 +169,7 @@ initiate_cluster_connect(asio::io_service& io,
         auto c = couchbase::cluster(core);
         // create txns as we want to start cleanup immediately if configured with metadata_collection
         [[maybe_unused]] std::shared_ptr<couchbase::transactions::transactions> t = c.transactions();
-        handler(c, {});
+        handler(std::move(c), {});
     });
 }
 

--- a/core/meta/CMakeLists.txt
+++ b/core/meta/CMakeLists.txt
@@ -7,8 +7,10 @@ target_link_libraries(
           snappy
           fmt::fmt
           spdlog::spdlog)
-target_include_directories(couchbase_meta PRIVATE ${PROJECT_BINARY_DIR}/generated ../..
-        ../../third_party/http_parser)
+target_include_directories(couchbase_meta PRIVATE
+        ${PROJECT_BINARY_DIR}/generated
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/third_party/http_parser)
 
 if(NOT COUCHBASE_CXX_CLIENT_POST_LINKED_OPENSSL)
   target_link_libraries(couchbase_meta PUBLIC OpenSSL::SSL OpenSSL::Crypto)

--- a/core/metrics/CMakeLists.txt
+++ b/core/metrics/CMakeLists.txt
@@ -7,4 +7,7 @@ target_link_libraries(
           hdr_histogram_static
           fmt::fmt
           spdlog::spdlog)
-target_include_directories(couchbase_metrics PRIVATE ../.. ../../third_party/hdr_histogram_c/src)
+target_include_directories(couchbase_metrics PRIVATE
+        ${PROJECT_BINARY_DIR}/generated
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/third_party/hdr_histogram_c/src)

--- a/core/metrics/logging_meter.cxx
+++ b/core/metrics/logging_meter.cxx
@@ -17,12 +17,16 @@
 
 #include "logging_meter.hxx"
 
+#include "couchbase/build_info.hxx"
+
 #include "core/logger/logger.hxx"
 #include "core/utils/json.hxx"
 #include "noop_meter.hxx"
 
-#include "third_party/hdr_histogram_c/src/hdr_histogram.h"
+#include <hdr_histogram.h>
+
 #include <gsl/assert>
+
 #include <memory>
 #include <utility>
 
@@ -142,7 +146,7 @@ logging_meter::log_report() const
           {
 
             { "emit_interval_s", std::chrono::duration_cast<std::chrono::seconds>(options_.emit_interval).count() },
-#if BACKEND_DEBUG_BUILD
+#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
             { "emit_interval_ms", options_.emit_interval.count() },
 #endif
           },

--- a/core/tracing/CMakeLists.txt
+++ b/core/tracing/CMakeLists.txt
@@ -6,4 +6,6 @@ target_link_libraries(
           project_warnings
           fmt::fmt
           spdlog::spdlog)
-target_include_directories(couchbase_tracing PRIVATE ../..)
+target_include_directories(couchbase_tracing PRIVATE
+        ${PROJECT_BINARY_DIR}/generated
+        ${PROJECT_SOURCE_DIR})

--- a/core/tracing/threshold_logging_tracer.hxx
+++ b/core/tracing/threshold_logging_tracer.hxx
@@ -38,11 +38,11 @@ class threshold_logging_tracer
   public:
     threshold_logging_tracer(asio::io_context& ctx, threshold_logging_options options);
 
-    void start();
-
     std::shared_ptr<couchbase::tracing::request_span> start_span(std::string name,
                                                                  std::shared_ptr<couchbase::tracing::request_span> parent) override;
     void report(std::shared_ptr<threshold_logging_span> span);
+    void start() override;
+    void stop() override;
 
   private:
     threshold_logging_options options_;

--- a/couchbase/metrics/meter.hxx
+++ b/couchbase/metrics/meter.hxx
@@ -46,6 +46,22 @@ class meter
     meter& operator=(meter&& other) = default;
     virtual ~meter() = default;
 
+    /**
+     * SDK invokes this method when cluster is ready to emit metrics. Override it as NO-OP if no action is necessary.
+     */
+    virtual void start()
+    {
+        /* do nothing */
+    }
+
+    /**
+     * SDK invokes this method when cluster is closed. Override it as NO-OP if no action is necessary.
+     */
+    virtual void stop()
+    {
+        /* do nothing */
+    }
+
     virtual std::shared_ptr<value_recorder> get_value_recorder(const std::string& name, const std::map<std::string, std::string>& tags) = 0;
 };
 

--- a/couchbase/tracing/request_tracer.hxx
+++ b/couchbase/tracing/request_tracer.hxx
@@ -72,6 +72,22 @@ class request_tracer
     request_tracer& operator=(request_tracer&& other) = default;
     virtual ~request_tracer() = default;
 
+    /**
+     * SDK invokes this method when cluster is ready to trace. Override it as NO-OP if no action is necessary.
+     */
+    virtual void start()
+    {
+        /* do nothing */
+    }
+
+    /**
+     * SDK invokes this method when cluster is closed. Override it as NO-OP if no action is necessary.
+     */
+    virtual void stop()
+    {
+        /* do nothing */
+    }
+
     virtual std::shared_ptr<request_span> start_span(std::string name, std::shared_ptr<request_span> parent = {}) = 0;
 };
 

--- a/examples/minimal.cxx
+++ b/examples/minimal.cxx
@@ -44,7 +44,9 @@ main()
     auto options = couchbase::cluster_options(username, password);
     options.apply_profile("wan_development");
     auto [cluster, ec] = couchbase::cluster::connect(io, connection_string, options).get();
-    {
+    if (ec) {
+        std::cout << "Unable to connect to the cluster. ec: " << ec.message() << "\n";
+    } else {
         auto collection = cluster.bucket(bucket_name).scope(scope_name).collection(collection_name);
 
         const std::string document_id{ "minimal_example" };

--- a/test/utils/wait_until.cxx
+++ b/test/utils/wait_until.cxx
@@ -80,11 +80,11 @@ wait_until_cluster_connected(const std::string& username, const std::string& pas
         asio::io_context io;
         auto guard = asio::make_work_guard(io);
         std::thread io_thread([&io]() { io.run(); });
-        auto resp = couchbase::cluster::connect(io, connection_string, cluster_options).get();
-        resp.first.close();
+        auto [cluster, ec] = couchbase::cluster::connect(io, connection_string, cluster_options).get();
+        cluster.close();
         guard.reset();
         io_thread.join();
-        return resp.second.value() == 0;
+        return ec.value() == 0;
     });
     if (connected) {
         std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
After this change, the library got issues with stopping cluster properly: https://github.com/couchbaselabs/couchbase-cxx-client/pull/359/files#diff-d57958cc60b900a216af3a607194ccac57e75457e69eddfa953cca5b33f2cc78R59.

So I dig it a bit and found several issues:
* meter uses raw pointer to capture itself in the periodic timer (which causes leak and potential use-after-free)
* we should really try to signal timers in tracer and meter before relying on destructors, because some references might be still hold by IO threads
* when error occurs during core::cluster::open(), we should ensure that the cluster in closed state, in particular meter/tracer should be also stopped.