### PR TITLE
update API reference generation

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           submodules: recursive
       - name: Initialize couchbase
+        env:
+          CB_TRAVEL_SAMPLE: yes
         run: ./bin/init-cluster
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -71,6 +73,8 @@ jobs:
         with:
           submodules: recursive
       - name: Initialize couchbase
+        env:
+          CB_TRAVEL_SAMPLE: yes
         run: ./bin/init-cluster
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -114,6 +118,8 @@ jobs:
         with:
           submodules: recursive
       - name: Initialize couchbase
+        env:
+          CB_TRAVEL_SAMPLE: yes
         run: ./bin/init-cluster
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -157,6 +163,8 @@ jobs:
         with:
           submodules: recursive
       - name: Initialize couchbase
+        env:
+          CB_TRAVEL_SAMPLE: yes
         run: ./bin/init-cluster
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,8 @@ jobs:
         run: ./bin/init-cluster
       - name: Initialize couchbase for non-transactions testing
         if: ${{ matrix.suite != 'transaction' }}
+        env:
+          CB_TRAVEL_SAMPLE: yes
         run: ./bin/init-cluster
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/cmake/Documentation.cmake
+++ b/cmake/Documentation.cmake
@@ -11,7 +11,7 @@ if(DOXYGEN_FOUND AND DOT)
   file(
     GLOB_RECURSE
     COUCHBASE_CXX_CLIENT_PUBLIC_HEADERS
-    ${PROJECT_SOURCE_DIR}/couchbase/*.hxx
+    ${PROJECT_SOURCE_DIR}/couchbase/**/*.hxx
     ${PROJECT_SOURCE_DIR}/docs/*.hxx
     ${PROJECT_SOURCE_DIR}/docs/*.md)
 

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -161,7 +161,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto get(std::string document_id, const get_options& options) const
+    [[nodiscard]] auto get(std::string document_id, const get_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_result>>>();
@@ -220,7 +220,9 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto get_and_touch(std::string document_id, std::chrono::seconds duration, const get_and_touch_options& options) const
+    [[nodiscard]] auto get_and_touch(std::string document_id,
+                                     std::chrono::seconds duration,
+                                     const get_and_touch_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_result>>>();
@@ -281,7 +283,7 @@ class collection
      */
     [[nodiscard]] auto get_and_touch(std::string document_id,
                                      std::chrono::system_clock::time_point time_point,
-                                     const get_and_touch_options& options) const
+                                     const get_and_touch_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_result>>>();
@@ -337,7 +339,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto touch(std::string document_id, std::chrono::seconds duration, const touch_options& options) const
+    [[nodiscard]] auto touch(std::string document_id, std::chrono::seconds duration, const touch_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, result>>>();
@@ -396,8 +398,9 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto touch(std::string document_id, std::chrono::system_clock::time_point time_point, const touch_options& options) const
-      -> std::future<std::pair<key_value_error_context, result>>
+    [[nodiscard]] auto touch(std::string document_id,
+                             std::chrono::system_clock::time_point time_point,
+                             const touch_options& options = {}) const -> std::future<std::pair<key_value_error_context, result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, result>>>();
         auto future = barrier->get_future();
@@ -450,7 +453,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto get_any_replica(std::string document_id, const get_any_replica_options& options) const
+    [[nodiscard]] auto get_any_replica(std::string document_id, const get_any_replica_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_replica_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_replica_result>>>();
@@ -502,7 +505,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto get_all_replicas(std::string document_id, const get_all_replicas_options& options) const
+    [[nodiscard]] auto get_all_replicas(std::string document_id, const get_all_replicas_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_all_replicas_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_all_replicas_result>>>();
@@ -562,7 +565,7 @@ class collection
      * @committed
      */
     template<typename Transcoder = codec::default_json_transcoder, typename Document>
-    [[nodiscard]] auto upsert(std::string document_id, const Document& document, const upsert_options& options) const
+    [[nodiscard]] auto upsert(std::string document_id, const Document& document, const upsert_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, mutation_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutation_result>>>();
@@ -624,7 +627,7 @@ class collection
      * @committed
      */
     template<typename Transcoder = codec::default_json_transcoder, typename Document>
-    [[nodiscard]] auto insert(std::string document_id, const Document& document, const insert_options& options) const
+    [[nodiscard]] auto insert(std::string document_id, const Document& document, const insert_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, mutation_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutation_result>>>();
@@ -688,7 +691,7 @@ class collection
      * @committed
      */
     template<typename Transcoder = codec::default_json_transcoder, typename Document>
-    [[nodiscard]] auto replace(std::string document_id, const Document& document, const replace_options& options) const
+    [[nodiscard]] auto replace(std::string document_id, const Document& document, const replace_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, mutation_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutation_result>>>();
@@ -738,7 +741,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto remove(std::string document_id, const remove_options& options) const
+    [[nodiscard]] auto remove(std::string document_id, const remove_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, mutation_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutation_result>>>();
@@ -792,7 +795,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto mutate_in(std::string document_id, mutate_in_specs specs, const mutate_in_options& options) const
+    [[nodiscard]] auto mutate_in(std::string document_id, mutate_in_specs specs, const mutate_in_options& options = {}) const
       -> std::future<std::pair<subdocument_error_context, mutate_in_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<subdocument_error_context, mutate_in_result>>>();
@@ -842,7 +845,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto lookup_in(std::string document_id, lookup_in_specs specs, const lookup_in_options& options) const
+    [[nodiscard]] auto lookup_in(std::string document_id, lookup_in_specs specs, const lookup_in_options& options = {}) const
       -> std::future<std::pair<subdocument_error_context, lookup_in_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<subdocument_error_context, lookup_in_result>>>();
@@ -887,7 +890,9 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto get_and_lock(std::string document_id, std::chrono::seconds lock_duration, const get_and_lock_options& options) const
+    [[nodiscard]] auto get_and_lock(std::string document_id,
+                                    std::chrono::seconds lock_duration,
+                                    const get_and_lock_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, get_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, get_result>>>();
@@ -939,7 +944,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto unlock(std::string document_id, couchbase::cas cas, const unlock_options& options) const
+    [[nodiscard]] auto unlock(std::string document_id, couchbase::cas cas, const unlock_options& options = {}) const
       -> std::future<key_value_error_context>
     {
         auto barrier = std::make_shared<std::promise<key_value_error_context>>();
@@ -983,7 +988,7 @@ class collection
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto exists(std::string document_id, const exists_options& options) const
+    [[nodiscard]] auto exists(std::string document_id, const exists_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, exists_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, exists_result>>>();

--- a/couchbase/fmt/cas.hxx
+++ b/couchbase/fmt/cas.hxx
@@ -21,6 +21,18 @@
 
 #include <fmt/core.h>
 
+#ifdef COUCHBASE_CXX_CLIENT_DOXYGEN
+namespace fmt
+{
+}
+#endif
+
+/**
+ * Helper for fmtlib to format @ref couchbase::cas objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::cas> {
     template<typename ParseContext>

--- a/couchbase/fmt/durability_level.hxx
+++ b/couchbase/fmt/durability_level.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::durability_level objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::durability_level> {
     template<typename ParseContext>

--- a/couchbase/fmt/key_value_extended_error_info.hxx
+++ b/couchbase/fmt/key_value_extended_error_info.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::key_value_extended_error_info objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::key_value_extended_error_info> {
     template<typename ParseContext>

--- a/couchbase/fmt/key_value_status_code.hxx
+++ b/couchbase/fmt/key_value_status_code.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::key_value_status_code objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::key_value_status_code> {
     template<typename ParseContext>

--- a/couchbase/fmt/mutation_token.hxx
+++ b/couchbase/fmt/mutation_token.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::mutation_token objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::mutation_token> {
     template<typename ParseContext>

--- a/couchbase/fmt/query_scan_consistency.hxx
+++ b/couchbase/fmt/query_scan_consistency.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::query_scan_consistency objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::query_scan_consistency> {
     template<typename ParseContext>

--- a/couchbase/fmt/query_status.hxx
+++ b/couchbase/fmt/query_status.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::query_status objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::query_status> {
     template<typename ParseContext>

--- a/couchbase/fmt/retry_reason.hxx
+++ b/couchbase/fmt/retry_reason.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::retry_reason objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::retry_reason> {
     template<typename ParseContext>

--- a/couchbase/fmt/tls_verify_mode.hxx
+++ b/couchbase/fmt/tls_verify_mode.hxx
@@ -21,6 +21,12 @@
 
 #include <fmt/core.h>
 
+/**
+ * Helper for fmtlib to format @ref couchbase::tls_verify_mode objects.
+ *
+ * @since 1.0.0
+ * @committed
+ */
 template<>
 struct fmt::formatter<couchbase::tls_verify_mode> {
     template<typename ParseContext>

--- a/couchbase/scope.hxx
+++ b/couchbase/scope.hxx
@@ -121,7 +121,7 @@ class scope
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto query(std::string statement, const query_options& options) const
+    [[nodiscard]] auto query(std::string statement, const query_options& options = {}) const
       -> std::future<std::pair<query_error_context, query_result>>
     {
         auto barrier = std::make_shared<std::promise<std::pair<query_error_context, query_result>>>();

--- a/couchbase/subdoc/array_add_unique.hxx
+++ b/couchbase/subdoc/array_add_unique.hxx
@@ -71,7 +71,9 @@ class array_add_unique
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     array_add_unique(std::string path, std::vector<std::byte> value)
       : path_(std::move(path))

--- a/couchbase/subdoc/array_append.hxx
+++ b/couchbase/subdoc/array_append.hxx
@@ -70,7 +70,9 @@ class array_append
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     array_append(std::string path, std::vector<std::vector<std::byte>> values)
       : path_(std::move(path))

--- a/couchbase/subdoc/array_insert.hxx
+++ b/couchbase/subdoc/array_insert.hxx
@@ -71,7 +71,9 @@ class array_insert
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     array_insert(std::string path, std::vector<std::vector<std::byte>> values)
       : path_(std::move(path))

--- a/couchbase/subdoc/array_prepend.hxx
+++ b/couchbase/subdoc/array_prepend.hxx
@@ -71,7 +71,9 @@ class array_prepend
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     array_prepend(std::string path, std::vector<std::vector<std::byte>> values)
       : path_(std::move(path))

--- a/couchbase/subdoc/count.hxx
+++ b/couchbase/subdoc/count.hxx
@@ -54,7 +54,9 @@ class count
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::lookup_in_specs;
+#endif
 
     explicit count(std::string path)
       : path_(std::move(path))

--- a/couchbase/subdoc/counter.hxx
+++ b/couchbase/subdoc/counter.hxx
@@ -69,7 +69,9 @@ class counter
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     counter(std::string path, std::int64_t value)
       : path_(std::move(path))

--- a/couchbase/subdoc/exists.hxx
+++ b/couchbase/subdoc/exists.hxx
@@ -54,7 +54,9 @@ class exists
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::lookup_in_specs;
+#endif
 
     explicit exists(std::string path)
       : path_(std::move(path))

--- a/couchbase/subdoc/get.hxx
+++ b/couchbase/subdoc/get.hxx
@@ -56,7 +56,9 @@ class get
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::lookup_in_specs;
+#endif
 
     explicit get(std::string path)
       : path_(std::move(path))

--- a/couchbase/subdoc/insert.hxx
+++ b/couchbase/subdoc/insert.hxx
@@ -71,7 +71,9 @@ class insert
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     insert(std::string path, std::vector<std::byte> value)
       : path_(std::move(path))

--- a/couchbase/subdoc/remove.hxx
+++ b/couchbase/subdoc/remove.hxx
@@ -54,7 +54,9 @@ class remove
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     explicit remove(std::string path)
       : path_(std::move(path))

--- a/couchbase/subdoc/replace.hxx
+++ b/couchbase/subdoc/replace.hxx
@@ -56,7 +56,9 @@ class replace
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     replace(std::string path, std::vector<std::byte> value)
       : path_(std::move(path))

--- a/couchbase/subdoc/upsert.hxx
+++ b/couchbase/subdoc/upsert.hxx
@@ -71,7 +71,9 @@ class upsert
     }
 
   private:
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
     friend couchbase::mutate_in_specs;
+#endif
 
     upsert(std::string path, std::vector<std::byte> value)
       : path_(std::move(path))

--- a/couchbase/transactions/transactions_config.hxx
+++ b/couchbase/transactions/transactions_config.hxx
@@ -115,7 +115,7 @@ class transactions_config
     /**
      * @brief Set the expiration time for transactions.
      *
-     * @param duration desired expiration for transactions. see @expiration_time().
+     * @param duration desired expiration for transactions. see @ref expiration_time().
      * @return reference to this, so calls can be chained.
      */
     template<typename T>

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1034,7 +1034,7 @@ FILE_PATTERNS          = *.c \
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/docs/mainpage.hxx
+++ b/docs/mainpage.hxx
@@ -22,6 +22,15 @@
  *
  * @note You may read about related Couchbase software at https://docs.couchbase.com/
  *
- * This is API reference for C++ library for connecting to a Couchbase Server and performing data operations and queries.
+ * ### Start Using
  *
+ * The following example shows the most basic usage of the library. It performs the following operations:
+ * * connect to local cluster (location and credentials given in program arguments),
+ * * in lines <a href="#l00071">70-78</a>, persists document to the collection using @ref couchbase::collection#upsert(),
+ * * in lines <a href="#l00081">80-89</a>, retrieves document back with @ref couchbase::collection#get(), extracts content as generic JSON
+ * value, and prints one of the fields,
+ * * in lines <a href="#l00092">91-102</a>, performs N1QL query with @ref couchbase::scope#query() and prints the result.
+ * * close the cluster and deallocate resources
+ *
+ * @snippetlineno test_integration_examples.cxx start-using
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,3 +39,5 @@ transaction_test(transaction_public_async_api)
 unit_test(transaction_logging)
 unit_test(transaction_utils)
 unit_test(waitable_op_list)
+
+integration_test(examples)

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -1,0 +1,141 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/fmt/cas.hxx>
+#include <couchbase/fmt/mutation_token.hxx>
+
+#include <tao/json.hpp>
+
+namespace start_using
+{
+//! [start-using]
+#include <couchbase/cluster.hxx>
+#include <couchbase/fmt/cas.hxx>
+#include <couchbase/fmt/mutation_token.hxx>
+
+#include <tao/json.hpp>
+
+int
+main(int argc, const char* argv[])
+{
+    if (argc != 4) {
+        fmt::print("USAGE: ./start_using couchbase://127.0.0.1 Administrator password\n");
+        return 1;
+    }
+
+    std::string connection_string{ argv[1] };
+    std::string username{ argv[2] };
+    std::string password{ argv[3] };
+    std::string bucket_name{ "travel-sample" };
+
+    // run IO context on separate thread
+    asio::io_context io;
+    auto guard = asio::make_work_guard(io);
+    std::thread io_thread([&io]() { io.run(); });
+
+    auto options = couchbase::cluster_options(username, password);
+    // customize through the 'options'.
+    // For example, optimize timeouts for WAN
+    options.apply_profile("wan_development");
+
+    auto [cluster, ec] = couchbase::cluster::connect(io, connection_string, options).get();
+    if (ec) {
+        fmt::print("unable to connect to the cluster: {}\n", ec.message());
+        return 1;
+    }
+
+    // get a bucket reference
+    auto bucket = cluster.bucket(bucket_name);
+
+    // get a user-defined collection reference
+    auto scope = bucket.scope("tenant_agent_00");
+    auto collection = scope.collection("users");
+
+    {
+        // upsert document
+        auto [ctx, upsert_result] = collection.upsert("my-document", tao::json::value{ { "name", "mike" } }).get();
+        if (ctx.ec()) {
+            fmt::print("unable to upsert the document \"{}\": {}\n", ctx.id(), ctx.ec().message());
+            return 1;
+        }
+        fmt::print("saved document \"{}\", cas={}, token={}\n", ctx.id(), upsert_result.cas(), upsert_result.mutation_token().value());
+    }
+
+    {
+        // get document
+        auto [ctx, get_result] = collection.get("my-document").get();
+        if (ctx.ec()) {
+            fmt::print("unable to get the document \"{}\": {}\n", ctx.id(), ctx.ec().message());
+            return 1;
+        }
+        auto name = get_result.content_as<tao::json::value>()["name"].get_string();
+        fmt::print("retrieved document \"{}\", name=\"{}\"\n", ctx.id(), name);
+    }
+
+    {
+        // N1QL query
+        auto inventory_scope = bucket.scope("inventory");
+        auto [ctx, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
+        if (ctx.ec()) {
+            fmt::print("unable to perform query: {}, ({}, {})\n", ctx.ec().message(), ctx.first_error_code(), ctx.first_error_message());
+            return 1;
+        }
+        for (const auto& row : query_result.rows_as_json()) {
+            fmt::print("row: {}\n", tao::json::to_string(row));
+        }
+    }
+
+    // close cluster connection
+    cluster.close();
+    guard.reset();
+
+    io_thread.join();
+    return 0;
+}
+
+/*
+
+$ ./start_using couchbase://127.0.0.1 Administrator password
+saved document "my-document", cas=17486a1722b20000
+retrieved document "my-document", name="mike"
+row: {"airline":{"callsign":"MILE-AIR","country":"United States","iata":"Q5","icao":"MLA","id":10,"name":"40-Mile Air","type":"airline"}}
+
+ */
+//! [start-using]
+
+} // namespace start_using
+
+TEST_CASE("example: start using", "[integration]")
+{
+    test::utils::integration_test_guard integration;
+    if (!integration.cluster_version().supports_collections()) {
+        return;
+    }
+
+    const auto env = test::utils::test_context::load_from_environment();
+    const char* argv[] = {
+        "start_using", // name of the "executable"
+        env.connection_string.c_str(),
+        env.username.c_str(),
+        env.password.c_str(),
+    };
+
+    REQUIRE(start_using::main(4, argv) == 0);
+}


### PR DESCRIPTION
* show start using example on main page (compilation and execution checked in the test suite)

* declare default options for KV and Query APIs

* configure Doxygen to recurse into headers, not just consume toplevel headers

* smaller tweaks and fixes