### PR TITLE
CXXCBC-310 Transaction fit test errors

### DIFF
--- a/core/transactions/staged_mutation.cxx
+++ b/core/transactions/staged_mutation.cxx
@@ -315,7 +315,7 @@ staged_mutation_queue::commit_doc(attempt_context_impl* ctx, staged_mutation& it
 
             result res;
             if (item.type() == staged_mutation_type::INSERT && !cas_zero_mode) {
-                core::operations::insert_request req{ item.doc().id(), item.doc().content() };
+                core::operations::insert_request req{ item.doc().id(), item.content() };
                 req.flags = couchbase::codec::codec_flags::json_common_flags;
                 wrap_durable_request(req, ctx->overall_.config());
                 auto barrier = std::make_shared<std::promise<result>>();


### PR DESCRIPTION
When we stage an insert, and get an ambiguous fail back, we look for the
doc and examine it to see if we can retry, etc...   When doing so, if
the doc was staged successfully, we just need to make sure the that we
use the staged_mutation's content, not the content in the
staged_mutation's doc, as that will have the results of looking at the
document after we staged it as a tombstone, so the content will be
empty.   This showed up in some ambiguous fail tests in fit.  Simple
fix.
