### PR TITLE
CXXCBC-310 Explore fit errors

### DIFF
--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -456,7 +456,7 @@ class attempt_context_impl
 
     void state(attempt_state s)
     {
-        overall_.current_attempt().state = s;
+        overall_.current_attempt_state(s);
     }
 
     [[nodiscard]] const std::string atr_id()

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -45,6 +45,7 @@ void
 transaction_context::add_attempt()
 {
     transaction_attempt attempt{};
+    std::lock_guard<std::mutex> lock(mutex_);
     attempts_.push_back(attempt);
 }
 


### PR DESCRIPTION
While looking for issues, and running with TSAN, I noticed this race. Ultimately an obvious one, surprised I didn't see it till now.  We just needed to lock access to the {{attempts_}} in the {{transaction_context}}.   