### PR TITLE
CXXCBC-320 Negative expiry in atr can result in 'stuck' docs.

### DIFF
--- a/core/transactions/active_transaction_record.hxx
+++ b/core/transactions/active_transaction_record.hxx
@@ -153,7 +153,7 @@ class active_transaction_record
                 if (const auto* compat = val.find(ATR_FIELD_FORWARD_COMPAT); compat != nullptr) {
                     forward_compat = *compat;
                 }
-
+                std::optional<uint32_t> expires_after_msec = std::max(val.optional<int32_t>(ATR_FIELD_EXPIRES_AFTER_MSECS).value_or(0), 0);
                 entries.emplace_back(resp.ctx.bucket(),
                                      resp.ctx.id(),
                                      key,
@@ -163,7 +163,7 @@ class active_transaction_record
                                      parse_mutation_cas(val.optional<std::string>(ATR_FIELD_TIMESTAMP_COMPLETE).value_or("")),
                                      parse_mutation_cas(val.optional<std::string>(ATR_FIELD_TIMESTAMP_ROLLBACK_START).value_or("")),
                                      parse_mutation_cas(val.optional<std::string>(ATR_FIELD_TIMESTAMP_ROLLBACK_COMPLETE).value_or("")),
-                                     val.optional<std::uint32_t>(ATR_FIELD_EXPIRES_AFTER_MSECS),
+                                     expires_after_msec,
                                      process_document_ids(val, ATR_FIELD_DOCS_INSERTED),
                                      process_document_ids(val, ATR_FIELD_DOCS_REPLACED),
                                      process_document_ids(val, ATR_FIELD_DOCS_REMOVED),


### PR DESCRIPTION
The effect is that the expiry seems to be a very large positive number. Lets just read it as an int32_t, cap it at 0 on the low side.  Turns out we definitely cap at 0 when we write, so this probably has to be from some old version that had flawed logic when writing.