### PR TITLE
fix macro symbols for build info

### DIFF
--- a/core/meta/version.cxx
+++ b/core/meta/version.cxx
@@ -76,7 +76,7 @@ sdk_build_info()
     info["link_libraries"] = COUCHBASE_CXX_CLIENT_LINK_LIBRARIES;
     info["link_options"] = COUCHBASE_CXX_CLIENT_LINK_OPTIONS;
     info["static_stdlib"] =
-#if defined(STATIC_STDLIB)
+#if defined(COUCHBASE_CXX_CLIENT_STATIC_STDLIB)
       "true"
 #else
       "false"
@@ -84,7 +84,7 @@ sdk_build_info()
       ;
     info["post_linked_openssl"] = COUCHBASE_CXX_CLIENT_POST_LINKED_OPENSSL;
     info["static_openssl"] =
-#if defined(STATIC_OPENSSL)
+#if defined(COUCHBASE_CXX_CLIENT_STATIC_OPENSSL)
       "true"
 #else
       "false"


### PR DESCRIPTION
These symbols were renamed, but version.cxx was not updated accordingly.