### PR TITLE
CXXCBC-328: fix restarting MCBP sessions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ set(couchbase_cxx_client_FILES
         core/impl/internal_search_row_locations.cxx
         core/impl/internal_term_facet_result.cxx
         core/impl/key_value_error_category.cxx
+        core/impl/key_value_error_context.cxx
         core/impl/lookup_in.cxx
         core/impl/management_error_category.cxx
         core/impl/match_all_query.cxx
@@ -322,6 +323,7 @@ set(couchbase_cxx_client_FILES
         core/impl/prepend.cxx
         core/impl/query.cxx
         core/impl/query_error_category.cxx
+        core/impl/query_error_context.cxx
         core/impl/query_string_query.cxx
         core/impl/regexp_query.cxx
         core/impl/remove.cxx

--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -342,8 +342,8 @@ class bucket_impl
                                          : io::mcbp_session(client_id_, ctx_, origin, state_listener_, name_, known_features_);
             CB_LOG_DEBUG(R"({} rev={}, restart idx={}, session="{}", address="{}:{}")",
                          log_prefix_,
-                         node.index,
                          config_->rev_str(),
+                         node.index,
                          session.id(),
                          hostname,
                          port);

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -116,9 +116,10 @@ class bucket
         }
         auto session = find_session_by_index(index);
         if (!session || !session->has_config()) {
-            CB_LOG_TRACE(R"({} defer operation id={}, session={}, has_config={})",
+            CB_LOG_TRACE(R"({} defer operation id={}, index={}, session={}, has_config={})",
                          log_prefix(),
                          cmd->id_,
+                         index,
                          session.has_value(),
                          session.has_value() && session->has_config());
             return defer_command([self = shared_from_this(), cmd]() { self->map_and_send(cmd); });

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -83,7 +83,7 @@ class bucket
         auto cmd = std::make_shared<operations::mcbp_command<bucket, Request>>(ctx_, shared_from_this(), request, default_timeout());
         cmd->start([cmd, handler = std::forward<Handler>(handler)](std::error_code ec, std::optional<io::mcbp_message>&& msg) mutable {
             using encoded_response_type = typename Request::encoded_response_type;
-            std::uint16_t status_code = msg ? msg->header.status() : 0U;
+            std::uint16_t status_code = msg ? msg->header.status() : 0xffffU;
             auto resp = msg ? encoded_response_type(std::move(*msg)) : encoded_response_type{};
             auto ctx = make_key_value_error_context(ec, status_code, cmd, resp);
             handler(cmd->request.make_response(std::move(ctx), std::move(resp)));
@@ -116,23 +116,32 @@ class bucket
         }
         auto session = find_session_by_index(index);
         if (!session || !session->has_config()) {
-            CB_LOG_TRACE(R"({} defer operation id={}, index={}, session={}, has_config={})",
+            CB_LOG_TRACE(R"({} defer operation id={}, key=\"{}\", partition={}, index={}, session={} ("{}"), has_config={})",
                          log_prefix(),
                          cmd->id_,
+                         cmd->request.id,
+                         cmd->request.partition,
                          index,
                          session.has_value(),
+                         session.has_value() ? session->bootstrap_address() : "",
                          session.has_value() && session->has_config());
             return defer_command([self = shared_from_this(), cmd]() { self->map_and_send(cmd); });
         }
         if (session->is_stopped()) {
-            CB_LOG_TRACE(R"({} the session has been found for idx={}, but it is stopped, retrying id={}, session={})",
-                         log_prefix(),
-                         index,
-                         cmd->id_,
-                         session->id());
+            CB_LOG_TRACE(
+              R"({} the session has been found for idx={}, but it is stopped, retrying id={}, key=\"{}\", partition={}, session={} ("{}"))",
+              log_prefix(),
+              index,
+              cmd->id_,
+              cmd->request.id,
+              cmd->request.partition,
+              session->id(),
+              session->bootstrap_address());
             return io::retry_orchestrator::maybe_retry(
               cmd->manager_, cmd, retry_reason::node_not_available, errc::common::request_canceled);
         }
+        cmd->last_dispatched_from_ = session->local_address();
+        cmd->last_dispatched_to_ = session->bootstrap_address();
         cmd->send_to(session.value());
     }
 

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -124,8 +124,11 @@ class bucket
             return defer_command([self = shared_from_this(), cmd]() { self->map_and_send(cmd); });
         }
         if (session->is_stopped()) {
-            CB_LOG_TRACE(
-              R"({} the session has been found, but it is stopped, retrying id={}, session={})", log_prefix(), cmd->id_, session->id());
+            CB_LOG_TRACE(R"({} the session has been found for idx={}, but it is stopped, retrying id={}, session={})",
+                         log_prefix(),
+                         index,
+                         cmd->id_,
+                         session->id());
             return io::retry_orchestrator::maybe_retry(
               cmd->manager_, cmd, retry_reason::node_not_available, errc::common::request_canceled);
         }

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -107,7 +107,7 @@ class bucket
             auto [partition, server] = map_id(cmd->request.id);
             if (!server.has_value()) {
                 CB_LOG_TRACE(
-                  R"({} unable to map key=\"{}\" to the node, id={}, partition={})", log_prefix(), cmd->request.id, cmd->id_, partition);
+                  R"({} unable to map key="{}" to the node, id={}, partition={})", log_prefix(), cmd->request.id, cmd->id_, partition);
                 return io::retry_orchestrator::maybe_retry(
                   cmd->manager_, cmd, retry_reason::node_not_available, errc::common::request_canceled);
             }
@@ -116,7 +116,7 @@ class bucket
         }
         auto session = find_session_by_index(index);
         if (!session || !session->has_config()) {
-            CB_LOG_TRACE(R"({} defer operation id={}, key=\"{}\", partition={}, index={}, session={} ("{}"), has_config={})",
+            CB_LOG_TRACE(R"({} defer operation id={}, key="{}", partition={}, index={}, session={}, address="{}", has_config={})",
                          log_prefix(),
                          cmd->id_,
                          cmd->request.id,
@@ -129,7 +129,7 @@ class bucket
         }
         if (session->is_stopped()) {
             CB_LOG_TRACE(
-              R"({} the session has been found for idx={}, but it is stopped, retrying id={}, key=\"{}\", partition={}, session={} ("{}"))",
+              R"({} the session has been found for idx={}, but it is stopped, retrying id={}, key="{}", partition={}, session={}, address="{}")",
               log_prefix(),
               index,
               cmd->id_,

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -483,7 +483,7 @@ class cluster : public std::enable_shared_from_this<cluster>
                 }
                 self->session_manager_->set_configuration(config, self->origin_.options());
                 self->session_->on_configuration_update(self->session_manager_);
-                self->session_->on_stop([self](retry_reason) {
+                self->session_->on_stop([self]() {
                     if (self->session_) {
                         self->session_.reset();
                     }

--- a/core/error_context/key_value.cxx
+++ b/core/error_context/key_value.cxx
@@ -24,7 +24,7 @@ key_value_error_context
 make_key_value_error_context(std::error_code ec, const document_id& id)
 {
     return {
-        ec, {}, {}, 0, {}, id.key(), id.bucket(), id.scope(), id.collection(), 0, {}, {}, {}, {},
+        {}, ec, {}, {}, 0, {}, id.key(), id.bucket(), id.scope(), id.collection(), 0, {}, {}, {}, {},
     };
 }
 
@@ -36,6 +36,7 @@ make_subdocument_error_context(const key_value_error_context& ctx,
                                bool deleted)
 {
     return {
+        ctx.operation_id(),
         ec,
         ctx.last_dispatched_to(),
         ctx.last_dispatched_from(),

--- a/core/error_context/key_value.hxx
+++ b/core/error_context/key_value.hxx
@@ -56,8 +56,8 @@ make_key_value_error_context(std::error_code ec, std::uint16_t status_code, cons
 
     return { command->id_,
              ec,
-             command->last_dispatched_from_,
              command->last_dispatched_to_,
+             command->last_dispatched_from_,
              retry_attempts,
              std::move(retry_reasons),
              key,

--- a/core/impl/key_value_error_context.cxx
+++ b/core/impl/key_value_error_context.cxx
@@ -1,0 +1,93 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/key_value_error_context.hxx>
+
+#include <couchbase/fmt/cas.hxx>
+#include <couchbase/fmt/key_value_error_map_attribute.hxx>
+#include <couchbase/fmt/key_value_status_code.hxx>
+#include <couchbase/fmt/retry_reason.hxx>
+
+#include <tao/json/to_string.hpp>
+
+namespace couchbase
+{
+auto
+key_value_error_context::to_json() const -> std::string
+{
+    tao::json::value json = {
+        {
+          "ec",
+          tao::json::value{
+            { "value", ec().value() },
+            { "message", ec().message() },
+          },
+        },
+        { "operation_id", operation_id() },
+        { "id", id_ },
+        { "bucket", bucket_ },
+        { "scope", scope_ },
+        { "collection", collection_ },
+        { "opaque", opaque_ },
+        { "retry_attempts", retry_attempts() },
+    };
+
+    if (!cas_.empty()) {
+        json["cas"] = fmt::format("{}", cas_);
+    }
+
+    if (const auto& reasons = retry_reasons(); !reasons.empty()) {
+        tao::json::value reasons_json = tao::json::empty_array;
+        for (const auto& reason : reasons) {
+            reasons_json.emplace_back(fmt::format("{}", reason));
+        }
+        json["retry_reasons"] = reasons_json;
+    }
+    if (const auto& val = last_dispatched_from(); val.has_value()) {
+        json["last_dispatched_from"] = val.value();
+    }
+    if (const auto& val = last_dispatched_to(); val.has_value()) {
+        json["last_dispatched_to"] = val.value();
+    }
+    if (const auto& val = status_code_; val.has_value()) {
+        json["status_code"] = fmt::format("{}", val.value());
+    }
+    if (const auto& val = extended_error_info_; val.has_value()) {
+        json["extended_error_info"] = tao::json::value{
+            { "context", val->context() },
+            { "reference", val->reference() },
+        };
+    }
+    if (const auto& val = error_map_info_; val.has_value()) {
+        tao::json::value info{
+            { "code", val->code() },
+            { "name", val->name() },
+            { "description", val->description() },
+        };
+        if (const auto& attributes = val->attributes(); !attributes.empty()) {
+            tao::json::value attrs_json = tao::json::empty_array;
+            for (const auto& attr : attributes) {
+                attrs_json.emplace_back(fmt::format("{}", attr));
+            }
+            info["attributes"] = attrs_json;
+        }
+        json["error_map_info"] = info;
+    }
+
+    return tao::json::to_string(json, 2);
+}
+} // namespace couchbase

--- a/core/impl/key_value_error_context.cxx
+++ b/core/impl/key_value_error_context.cxx
@@ -42,9 +42,14 @@ key_value_error_context::to_json() const -> std::string
         { "bucket", bucket_ },
         { "scope", scope_ },
         { "collection", collection_ },
-        { "opaque", opaque_ },
-        { "retry_attempts", retry_attempts() },
     };
+
+    if (auto val = retry_attempts(); val > 0) {
+        json["retry_attempts"] = val;
+    }
+    if (opaque_ > 0) {
+        json["opaque"] = opaque_;
+    }
 
     if (!cas_.empty()) {
         json["cas"] = fmt::format("{}", cas_);

--- a/core/impl/query_error_context.cxx
+++ b/core/impl/query_error_context.cxx
@@ -1,0 +1,75 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/query_error_context.hxx>
+
+#include <couchbase/fmt/retry_reason.hxx>
+
+#include <tao/json/to_string.hpp>
+
+namespace couchbase
+{
+auto
+query_error_context::to_json() const -> std::string
+{
+    tao::json::value json = {
+        {
+          "ec",
+          tao::json::value{
+            { "value", ec().value() },
+            { "message", ec().message() },
+          },
+        },
+        { "operation_id", operation_id() },
+        { "retry_attempts", retry_attempts() },
+        { "client_context_id", client_context_id_ },
+        { "statement", statement_ },
+        { "method", statement_ },
+        { "path", statement_ },
+        { "http_status", http_status_ },
+        { "http_body", http_body_ },
+        { "hostname", hostname_ },
+        { "port", port_ },
+    };
+
+    if (const auto& val = parameters_; val.has_value()) {
+        json["parameters"] = val.value();
+    }
+    if (first_error_code_ > 0) {
+        json["first_error_code"] = first_error_code_;
+    }
+    if (!first_error_message_.empty()) {
+        json["first_error_message"] = first_error_message_;
+    }
+
+    if (const auto& reasons = retry_reasons(); !reasons.empty()) {
+        tao::json::value reasons_json = tao::json::empty_array;
+        for (const auto& reason : reasons) {
+            reasons_json.emplace_back(fmt::format("{}", reason));
+        }
+        json["retry_reasons"] = reasons_json;
+    }
+    if (const auto& val = last_dispatched_from(); val.has_value()) {
+        json["last_dispatched_from"] = val.value();
+    }
+    if (const auto& val = last_dispatched_to(); val.has_value()) {
+        json["last_dispatched_to"] = val.value();
+    }
+
+    return tao::json::to_string(json, 2);
+}
+} // namespace couchbase

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -62,6 +62,8 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     std::string id_{ uuid::to_string(uuid::random()) };
     std::shared_ptr<couchbase::tracing::request_span> span_{ nullptr };
     std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
+    std::optional<std::string> last_dispatched_from_{};
+    std::optional<std::string> last_dispatched_to_{};
 
     mcbp_command(asio::io_context& ctx, std::shared_ptr<Manager> manager, Request req, std::chrono::milliseconds default_timeout)
       : deadline(ctx)

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -113,7 +113,10 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
                 handler_ = nullptr;
             }
         }
-        invoke_handler(request.retries.idempotent() ? errc::common::unambiguous_timeout : errc::common::ambiguous_timeout);
+        invoke_handler(request.retries.idempotent() || !opaque_.has_value()
+                         ? errc::common::unambiguous_timeout // safe to retry or has not been sent to the server
+                         : errc::common::ambiguous_timeout   // non-idempotent and has been sent to the server
+        );
     }
 
     void invoke_handler(std::error_code ec, std::optional<io::mcbp_message>&& msg = {})

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -59,7 +59,9 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     mcbp_command_handler handler_{};
     std::shared_ptr<Manager> manager_{};
     std::chrono::milliseconds timeout_{};
-    std::string id_{ uuid::to_string(uuid::random()) };
+    std::string id_{
+        fmt::format("{:02x}/{}", static_cast<std::uint8_t>(encoded_request_type::body_type::opcode), uuid::to_string(uuid::random()))
+    };
     std::shared_ptr<couchbase::tracing::request_span> span_{ nullptr };
     std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
     std::optional<std::string> last_dispatched_from_{};

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -101,8 +101,7 @@ class mcbp_session
     [[nodiscard]] mcbp_context context() const;
     [[nodiscard]] bool supports_feature(protocol::hello_feature feature);
     [[nodiscard]] std::vector<protocol::hello_feature> supported_features() const;
-    //[[nodiscard]] const std::string& id() const;
-    [[nodiscard]] std::string id() const;
+    [[nodiscard]] const std::string& id() const;
     [[nodiscard]] std::string remote_address() const;
     [[nodiscard]] std::string local_address() const;
     [[nodiscard]] const std::string& bootstrap_hostname() const;
@@ -111,7 +110,7 @@ class mcbp_session
     void write_and_subscribe(std::uint32_t opaque, std::vector<std::byte>&& data, command_handler&& handler);
     void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler,
                    bool retry_on_bucket_not_found = false);
-    void on_stop(utils::movable_function<void(retry_reason)> handler);
+    void on_stop(utils::movable_function<void()> handler);
     void stop(retry_reason reason);
     [[nodiscard]] std::size_t index() const;
     [[nodiscard]] bool has_config() const;

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -106,6 +106,7 @@ class mcbp_session
     [[nodiscard]] std::string local_address() const;
     [[nodiscard]] const std::string& bootstrap_hostname() const;
     [[nodiscard]] const std::string& bootstrap_port() const;
+    [[nodiscard]] std::uint16_t bootstrap_port_number() const;
     void write_and_subscribe(std::shared_ptr<mcbp::queue_request>, std::shared_ptr<response_handler> handler);
     void write_and_subscribe(std::uint32_t opaque, std::vector<std::byte>&& data, command_handler&& handler);
     void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler,

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -104,6 +104,7 @@ class mcbp_session
     [[nodiscard]] const std::string& id() const;
     [[nodiscard]] std::string remote_address() const;
     [[nodiscard]] std::string local_address() const;
+    [[nodiscard]] const std::string& bootstrap_address() const;
     [[nodiscard]] const std::string& bootstrap_hostname() const;
     [[nodiscard]] const std::string& bootstrap_port() const;
     [[nodiscard]] std::uint16_t bootstrap_port_number() const;

--- a/core/protocol/client_response.hxx
+++ b/core/protocol/client_response.hxx
@@ -148,6 +148,7 @@ class client_response
         data_.resize(body_size_);
 
         memcpy(&opaque_, header_.data() + 12, sizeof(opaque_));
+        opaque_ = utils::byte_swap(opaque_);
 
         memcpy(&cas_, header_.data() + 16, sizeof(cas_));
         cas_ = utils::byte_swap(cas_);

--- a/couchbase/analytics_error_context.hxx
+++ b/couchbase/analytics_error_context.hxx
@@ -57,7 +57,7 @@ class analytics_error_context : public error_context
                             std::string http_body,
                             std::string hostname,
                             std::uint16_t port)
-      : error_context{ ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
+      : error_context{ {}, ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
       , first_error_code_{ first_error_code }
       , first_error_message_{ std::move(first_error_message) }
       , client_context_id_{ std::move(client_context_id) }

--- a/couchbase/error_context.hxx
+++ b/couchbase/error_context.hxx
@@ -57,17 +57,24 @@ class error_context
      * @since 1.0.0
      * @internal
      */
-    error_context(std::error_code ec,
+    error_context(std::string operation_id,
+                  std::error_code ec,
                   std::optional<std::string> last_dispatched_to,
                   std::optional<std::string> last_dispatched_from,
                   std::size_t retry_attempts,
                   std::set<retry_reason> retry_reasons)
-      : ec_{ ec }
+      : operation_id_{ std::move(operation_id) }
+      , ec_{ ec }
       , last_dispatched_to_{ std::move(last_dispatched_to) }
       , last_dispatched_from_{ std::move(last_dispatched_from) }
       , retry_attempts_{ retry_attempts }
       , retry_reasons_{ std::move(retry_reasons) }
     {
+    }
+
+    [[nodiscard]] virtual auto operation_id() const -> const std::string&
+    {
+        return operation_id_;
     }
 
     /**
@@ -165,6 +172,7 @@ class error_context
     }
 
   private:
+    std::string operation_id_{};
     std::error_code ec_{};
     std::optional<std::string> last_dispatched_to_{};
     std::optional<std::string> last_dispatched_from_{};

--- a/couchbase/fmt/key_value_error_map_attribute.hxx
+++ b/couchbase/fmt/key_value_error_map_attribute.hxx
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include "error_map.hxx"
+#include <couchbase/key_value_error_map_attribute.hxx>
 
 #include <fmt/core.h>
 
 template<>
-struct fmt::formatter<couchbase::api::key_value_error_map_attribute> {
+struct fmt::formatter<couchbase::key_value_error_map_attribute> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
     {
@@ -30,62 +30,62 @@ struct fmt::formatter<couchbase::api::key_value_error_map_attribute> {
     }
 
     template<typename FormatContext>
-    auto format(couchbase::api::key_value_error_map_attribute attr, FormatContext& ctx) const
+    auto format(couchbase::key_value_error_map_attribute attr, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (attr) {
-            case couchbase::api::key_value_error_map_attribute::success:
+            case couchbase::key_value_error_map_attribute::success:
                 name = "success";
                 break;
-            case couchbase::api::key_value_error_map_attribute::item_only:
+            case couchbase::key_value_error_map_attribute::item_only:
                 name = "item-only";
                 break;
-            case couchbase::api::key_value_error_map_attribute::invalid_input:
+            case couchbase::key_value_error_map_attribute::invalid_input:
                 name = "invalid-input";
                 break;
-            case couchbase::api::key_value_error_map_attribute::fetch_config:
+            case couchbase::key_value_error_map_attribute::fetch_config:
                 name = "fetch-config";
                 break;
-            case couchbase::api::key_value_error_map_attribute::conn_state_invalidated:
+            case couchbase::key_value_error_map_attribute::conn_state_invalidated:
                 name = "conn-state-invalidated";
                 break;
-            case couchbase::api::key_value_error_map_attribute::auth:
+            case couchbase::key_value_error_map_attribute::auth:
                 name = "auth";
                 break;
-            case couchbase::api::key_value_error_map_attribute::special_handling:
+            case couchbase::key_value_error_map_attribute::special_handling:
                 name = "special-handling";
                 break;
-            case couchbase::api::key_value_error_map_attribute::support:
+            case couchbase::key_value_error_map_attribute::support:
                 name = "support";
                 break;
-            case couchbase::api::key_value_error_map_attribute::temp:
+            case couchbase::key_value_error_map_attribute::temp:
                 name = "temp";
                 break;
-            case couchbase::api::key_value_error_map_attribute::internal:
+            case couchbase::key_value_error_map_attribute::internal:
                 name = "internal";
                 break;
-            case couchbase::api::key_value_error_map_attribute::retry_now:
+            case couchbase::key_value_error_map_attribute::retry_now:
                 name = "retry-now";
                 break;
-            case couchbase::api::key_value_error_map_attribute::retry_later:
+            case couchbase::key_value_error_map_attribute::retry_later:
                 name = "retry-later";
                 break;
-            case couchbase::api::key_value_error_map_attribute::subdoc:
+            case couchbase::key_value_error_map_attribute::subdoc:
                 name = "subdoc";
                 break;
-            case couchbase::api::key_value_error_map_attribute::dcp:
+            case couchbase::key_value_error_map_attribute::dcp:
                 name = "dcp";
                 break;
-            case couchbase::api::key_value_error_map_attribute::auto_retry:
+            case couchbase::key_value_error_map_attribute::auto_retry:
                 name = "auto-retry";
                 break;
-            case couchbase::api::key_value_error_map_attribute::item_locked:
+            case couchbase::key_value_error_map_attribute::item_locked:
                 name = "item-locked";
                 break;
-            case couchbase::api::key_value_error_map_attribute::item_deleted:
+            case couchbase::key_value_error_map_attribute::item_deleted:
                 name = "item-deleted";
                 break;
-            case couchbase::api::key_value_error_map_attribute::rate_limit:
+            case couchbase::key_value_error_map_attribute::rate_limit:
                 name = "rate-limit";
                 break;
         }

--- a/couchbase/key_value_error_context.hxx
+++ b/couchbase/key_value_error_context.hxx
@@ -48,6 +48,7 @@ class key_value_error_context : public error_context
     /**
      * Creates and initializes error context with given parameters.
      *
+     * @param operation_id
      * @param ec
      * @param last_dispatched_to
      * @param last_dispatched_from
@@ -66,7 +67,8 @@ class key_value_error_context : public error_context
      * @since 1.0.0
      * @internal
      */
-    key_value_error_context(std::error_code ec,
+    key_value_error_context(std::string operation_id,
+                            std::error_code ec,
                             std::optional<std::string> last_dispatched_to,
                             std::optional<std::string> last_dispatched_from,
                             std::size_t retry_attempts,
@@ -80,7 +82,8 @@ class key_value_error_context : public error_context
                             couchbase::cas cas,
                             std::optional<key_value_error_map_info> error_map_info,
                             std::optional<key_value_extended_error_info> extended_error_info)
-      : error_context{ ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
+      : error_context{ std::move(operation_id), ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts,
+                       std::move(retry_reasons) }
       , id_{ std::move(id) }
       , bucket_{ std::move(bucket) }
       , scope_{ std::move(scope) }
@@ -209,6 +212,8 @@ class key_value_error_context : public error_context
     {
         return extended_error_info_;
     }
+
+    [[nodiscard]] auto to_json() const -> std::string;
 
   private:
     std::string id_{};

--- a/couchbase/manager_error_context.hxx
+++ b/couchbase/manager_error_context.hxx
@@ -67,7 +67,7 @@ class manager_error_context : public error_context
                           std::uint32_t http_status,
                           std::string content,
                           std::string path)
-      : error_context{ ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
+      : error_context{ {}, ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
       , client_context_id_{ std::move(client_context_id) }
       , http_status_{ http_status }
       , content_{ std::move(content) }

--- a/couchbase/query_error_context.hxx
+++ b/couchbase/query_error_context.hxx
@@ -57,7 +57,7 @@ class query_error_context : public error_context
                         std::string http_body,
                         std::string hostname,
                         std::uint16_t port)
-      : error_context{ ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
+      : error_context{ {}, ec, std::move(last_dispatched_to), std::move(last_dispatched_from), retry_attempts, std::move(retry_reasons) }
       , first_error_code_{ first_error_code }
       , first_error_message_{ std::move(first_error_message) }
       , client_context_id_{ std::move(client_context_id) }
@@ -126,6 +126,8 @@ class query_error_context : public error_context
     {
         return port_;
     }
+
+    [[nodiscard]] auto to_json() const -> std::string;
 
   private:
     std::uint64_t first_error_code_{};

--- a/couchbase/subdocument_error_context.hxx
+++ b/couchbase/subdocument_error_context.hxx
@@ -62,7 +62,8 @@ class subdocument_error_context : public key_value_error_context
      * @since 1.0.0
      * @internal
      */
-    subdocument_error_context(std::error_code ec,
+    subdocument_error_context(std::string operation_id,
+                              std::error_code ec,
                               std::optional<std::string> last_dispatched_to,
                               std::optional<std::string> last_dispatched_from,
                               std::size_t retry_attempts,
@@ -79,7 +80,8 @@ class subdocument_error_context : public key_value_error_context
                               std::optional<std::string> first_error_path,
                               std::optional<std::uint64_t> first_error_index,
                               bool deleted)
-      : key_value_error_context{ ec,
+      : key_value_error_context{ std::move(operation_id),
+                                 ec,
                                  std::move(last_dispatched_to),
                                  std::move(last_dispatched_from),
                                  retry_attempts,

--- a/docs/cbc-get.md
+++ b/docs/cbc-get.md
@@ -18,6 +18,7 @@ Retrieve one or more documents from the server and print them to standard output
 
 <dl>
 <dt>`-h|--help`</dt><dd>Show help message.</dd>
+<dt>`--verbose`</dt><dd>Include more context and information where it is applicable.</dd>
 <dt>`--bucket-name=STRING`</dt><dd>Name of the bucket. [default: `default`]</dd>
 <dt>`--scope-name=STRING`</dt><dd>Name of the scope. [default: `_default`]</dd>
 <dt>`--collection-name=STRING`</dt><dd>Name of the collection. [default: `_default`]</dd>

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -22,6 +22,7 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 <dt>`--scope-name=STRING`</dt><dd>Name of the scope. [default: `_default`]</dd>
 <dt>`--collection-name=STRING`</dt><dd>Name of the collection. [default: `_default`]</dd>
 <dt>`--batch-size=INTEGER`</dt><dd>Number of the operations in single batch. [default: `100`]</dd>
+<dt>`--batch-wait=DURATION`</dt><dd>Time to wait after the batch. [default: `0ms`]</dd>
 <dt>`--number-of-io-threads=INTEGER`</dt><dd>Number of the IO threads. [default: `1`]</dd>
 <dt>`--number-of-worker-threads=INTEGER`</dt><dd>Number of the IO threads. [default: `1`]</dd>
 <dt>`--chance-of-get=FLOAT`</dt><dd>The probability of get operation (where 1 means only get, and 0 - only upsert). [default: `0.6`]</dd>

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -32,7 +32,9 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 <dt>`--query-statement=STRING`</dt><dd>The N1QL query statement to use ({bucket_name}, {scope_name} and {collection_name} will be substituted). [default: <code>SELECT COUNT(*) FROM \`{bucket_name}\` WHERE type = "fake_profile"</code>]</dd>
 <dt>`--incompressible-body`</dt><dd>Use random characters to fill generated document value (by default uses 'x' to fill the body).</dd>
 <dt>`--document-body-size=INTEGER`</dt><dd>Size of the body (if zero, it will use predefined document). [default: `0`]</dd>
+<dt>`--number-of-keys-to-populate=INTEGER`</dt><dd>Preload keys before running workload, so that the worker will not generate new keys afterwards. [default: `1000`]</dd>
 <dt>`--operations-limit=INTEGER`</dt><dd>Stop and exit after the number of the operations reaches this limit. (zero for running indefinitely) [default: `0`]</dd>
+
 </dl>
 
 

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -17,9 +17,11 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 
 <dl>
 <dt>`-h|--help`</dt><dd>Show this screen.</dd>
+<dt>`--verbose`</dt><dd>Include more context and information where it is applicable.</dd>
 <dt>`--bucket-name=STRING`</dt><dd>Name of the bucket. [default: `default`]</dd>
 <dt>`--scope-name=STRING`</dt><dd>Name of the scope. [default: `_default`]</dd>
 <dt>`--collection-name=STRING`</dt><dd>Name of the collection. [default: `_default`]</dd>
+<dt>`--batch-size=INTEGER`</dt><dd>Number of the operations in single batch. [default: `100`]</dd>
 <dt>`--number-of-io-threads=INTEGER`</dt><dd>Number of the IO threads. [default: `1`]</dd>
 <dt>`--number-of-worker-threads=INTEGER`</dt><dd>Number of the IO threads. [default: `1`]</dd>
 <dt>`--chance-of-get=FLOAT`</dt><dd>The probability of get operation (where 1 means only get, and 0 - only upsert). [default: `0.6`]</dd>

--- a/tools/pillowfight.cxx
+++ b/tools/pillowfight.cxx
@@ -47,13 +47,14 @@ usage() -> std::string
     static const std::size_t default_number_of_worker_threads{ 1 };
     static const double default_chance_of_get{ 0.6 };
     static const double default_hit_chance_for_get{ 1.0 };
-    static const double default_hit_chance_for_upsert{ 0.5 };
+    static const double default_hit_chance_for_upsert{ 1 };
     static const double default_chance_of_query{ 0.0 };
     static const std::string default_query_statement{ "SELECT COUNT(*) FROM `{bucket_name}` WHERE type = \"fake_profile\"" };
     static const std::size_t default_document_body_size{ 0 };
     static const std::size_t default_operation_limit{ 0 };
     static const std::size_t default_batch_size{ 100 };
     static const std::chrono::milliseconds default_batch_wait{ 0 };
+    static const std::size_t default_number_of_keys_to_populate{ 1'000 };
 
     static const std::string usage_string = fmt::format(
       R"(Run workload generator.
@@ -63,23 +64,24 @@ Usage:
   cbc pillowfight (-h|--help)
 
 Options:
-  -h --help                           Show this screen.
-  --verbose                           Include more context and information where it is applicable.
-  --bucket-name=STRING                Name of the bucket. [default: {bucket_name}]
-  --scope-name=STRING                 Name of the scope. [default: {scope_name}]
-  --collection-name=STRING            Name of the collection. [default: {collection_name}]
-  --batch-size=INTEGER                Number of the operations in single batch. [default: {batch_size}]
-  --batch-wait=DURATION               Time to wait after the batch. [default: {batch_wait}]
-  --number-of-io-threads=INTEGER      Number of the IO threads. [default: {number_of_io_threads}]
-  --number-of-worker-threads=INTEGER  Number of the IO threads. [default: {number_of_worker_threads}]
-  --chance-of-get=FLOAT               The probability of get operation (where 1 means only get, and 0 - only upsert). [default: {chance_of_get}]
-  --hit-chance-for-get=FLOAT          The probability of using existing ID for get operation. [default: {hit_chance_for_get}]
-  --hit-chance-for-upsert=FLOAT       The probability of using existing ID for upsert operation. [default: {hit_chance_for_upsert}]
-  --chance-of-query=FLOAT             The probability of N1QL query will be send on after get/upsert. [default: {chance_of_query}]
-  --query-statement=STRING            The N1QL query statement to use ({{bucket_name}}, {{scope_name}} and {{collection_name}} will be substituted). [default: {query_statement}]
-  --incompressible-body               Use random characters to fill generated document value (by default uses 'x' to fill the body).
-  --document-body-size=INTEGER        Size of the body (if zero, it will use predefined document). [default: {document_body_size}]
-  --operations-limit=INTEGER          Stop and exit after the number of the operations reaches this limit. (zero for running indefinitely) [default: {operation_limit}]
+  -h --help                             Show this screen.
+  --verbose                             Include more context and information where it is applicable.
+  --bucket-name=STRING                  Name of the bucket. [default: {bucket_name}]
+  --scope-name=STRING                   Name of the scope. [default: {scope_name}]
+  --collection-name=STRING              Name of the collection. [default: {collection_name}]
+  --batch-size=INTEGER                  Number of the operations in single batch. [default: {batch_size}]
+  --batch-wait=DURATION                 Time to wait after the batch. [default: {batch_wait}]
+  --number-of-io-threads=INTEGER        Number of the IO threads. [default: {number_of_io_threads}]
+  --number-of-worker-threads=INTEGER    Number of the IO threads. [default: {number_of_worker_threads}]
+  --chance-of-get=FLOAT                 The probability of get operation (where 1 means only get, and 0 - only upsert). [default: {chance_of_get}]
+  --hit-chance-for-get=FLOAT            The probability of using existing ID for get operation. [default: {hit_chance_for_get}]
+  --hit-chance-for-upsert=FLOAT         The probability of using existing ID for upsert operation. [default: {hit_chance_for_upsert}]
+  --chance-of-query=FLOAT               The probability of N1QL query will be send on after get/upsert. [default: {chance_of_query}]
+  --query-statement=STRING              The N1QL query statement to use ({{bucket_name}}, {{scope_name}} and {{collection_name}} will be substituted). [default: {query_statement}]
+  --incompressible-body                 Use random characters to fill generated document value (by default uses 'x' to fill the body).
+  --document-body-size=INTEGER          Size of the body (if zero, it will use predefined document). [default: {document_body_size}]
+  --number-of-keys-to-populate=INTEGER  Preload keys before running workload, so that the worker will not generate new keys afterwards. [default: {number_of_keys_to_populate}]
+  --operations-limit=INTEGER            Stop and exit after the number of the operations reaches this limit. (zero for running indefinitely) [default: {operation_limit}]
 
 {logger_options}{cluster_options}
 )",
@@ -97,6 +99,7 @@ Options:
       fmt::arg("operation_limit", default_operation_limit),
       fmt::arg("batch_size", default_batch_size),
       fmt::arg("batch_wait", default_batch_wait),
+      fmt::arg("number_of_keys_to_populate", default_number_of_keys_to_populate),
       fmt::arg("logger_options", usage_block_for_logger()),
       fmt::arg("cluster_options", usage_block_for_cluster_options()));
 
@@ -152,6 +155,7 @@ struct command_options {
     std::chrono::milliseconds batch_wait;
     std::size_t number_of_io_threads;
     std::size_t number_of_worker_threads;
+    std::size_t number_of_keys_to_populate;
     double chance_of_get;
     double hit_chance_for_get;
     double hit_chance_for_upsert;
@@ -200,7 +204,7 @@ dump_stats(asio::steady_timer& timer, std::chrono::system_clock::time_point star
         auto diff = uptime.count();
         const std::uint64_t ops = total;
         fmt::print(
-          stderr, "\r\033[Kuptime: {}, rate: {} ops/s, total: {}", uptime, diff == 0 ? ops : ops / static_cast<std::uint64_t>(diff), ops);
+          stderr, "\r\033[Kuptime: {}, rate: {} ops/s, total: {}\r", uptime, diff == 0 ? ops : ops / static_cast<std::uint64_t>(diff), ops);
         return dump_stats(timer, start_time);
     });
 }
@@ -224,6 +228,19 @@ random_text(std::size_t length)
     return text;
 }
 
+auto
+generate_document_body(const command_options& options)
+{
+    if (options.document_body_size > 0) {
+        return couchbase::core::utils::json::generate_binary({
+          { "size", options.document_body_size },
+          { "text", options.incompressible_body ? random_text(options.document_body_size) : std::string(options.document_body_size, 'x') },
+        });
+    } else {
+        return couchbase::core::utils::to_binary(default_json_doc);
+    }
+}
+
 void
 worker(couchbase::cluster connected_cluster, command_options cmd_options, std::vector<std::string>& known_keys)
 {
@@ -235,15 +252,7 @@ worker(couchbase::cluster connected_cluster, command_options cmd_options, std::v
 
     auto collection = cluster.bucket(options.bucket_name).scope(options.scope_name).collection(options.collection_name);
 
-    std::vector<std::byte> json_doc{};
-    if (options.document_body_size > 0) {
-        json_doc = couchbase::core::utils::json::generate_binary({
-          { "size", options.document_body_size },
-          { "text", options.incompressible_body ? random_text(options.document_body_size) : std::string(options.document_body_size, 'x') },
-        });
-    } else {
-        json_doc = couchbase::core::utils::to_binary(default_json_doc);
-    }
+    std::vector<std::byte> json_doc = generate_document_body(options);
 
     while (running.test_and_set()) {
         std::list<std::variant<std::future<std::pair<couchbase::key_value_error_context, couchbase::mutation_result>>,
@@ -314,6 +323,60 @@ worker(couchbase::cluster connected_cluster, command_options cmd_options, std::v
 }
 
 void
+populate_keys(const couchbase::cluster& cluster, const command_options& options, std::vector<std::vector<std::string>>& known_keys)
+{
+    const std::size_t total_keys{ options.number_of_worker_threads * options.number_of_keys_to_populate };
+
+    auto collection = cluster.bucket(options.bucket_name).scope(options.scope_name).collection(options.collection_name);
+
+    const auto json_doc = generate_document_body(options);
+    const auto start_time = std::chrono::system_clock::now();
+
+    std::size_t stored_keys{ 0 };
+    std::size_t retried_keys{ 0 };
+    for (std::size_t i = 0; i < options.number_of_worker_threads; ++i) {
+        auto keys_left = options.number_of_keys_to_populate;
+
+        while (keys_left > 0) {
+            fmt::print(stderr,
+                       "\r\033[K{:02.2f}% {} of {}, {}\r",
+                       static_cast<double>(stored_keys) / gsl::narrow_cast<double>(total_keys) * 100,
+                       stored_keys,
+                       total_keys,
+                       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start_time));
+
+            auto batch_size = std::min(keys_left, options.batch_size);
+
+            std::vector<std::future<std::pair<couchbase::key_value_error_context, couchbase::mutation_result>>> futures;
+            futures.reserve(batch_size);
+            for (std::size_t k = 0; k < batch_size; ++k) {
+                const std::string document_id = uniq_id("id");
+                futures.emplace_back(collection.upsert<raw_json_transcoder>(document_id, json_doc));
+            }
+
+            for (auto&& future : futures) {
+                auto [ctx, res] = future.get();
+                if (ctx.ec()) {
+                    ++retried_keys;
+                } else {
+                    ++stored_keys;
+                    --keys_left;
+                }
+            }
+        }
+    }
+    const auto finish_time = std::chrono::system_clock::now();
+    const auto total_time = finish_time - start_time;
+
+    fmt::print(stderr,
+               "\r\033[K{} keys populated in {}s ({}ms) with {} retries\n",
+               stored_keys,
+               std::chrono::duration_cast<std::chrono::seconds>(total_time).count(),
+               std::chrono::duration_cast<std::chrono::milliseconds>(total_time).count(),
+               retried_keys);
+}
+
+void
 do_work(const std::string& connection_string, const couchbase::cluster_options& cluster_options, const command_options& cmd_options)
 {
     asio::io_context io;
@@ -339,12 +402,15 @@ do_work(const std::string& connection_string, const couchbase::cluster_options& 
         throw std::system_error(ec, "unable to connect to the cluster in time");
     }
 
+    std::vector<std::vector<std::string>> known_keys(cmd_options.number_of_worker_threads);
+    if (cmd_options.number_of_keys_to_populate > 0) {
+        populate_keys(cluster, cmd_options, known_keys);
+    }
+
     const auto start_time = std::chrono::system_clock::now();
 
     asio::steady_timer stats_timer(io);
     dump_stats(stats_timer, start_time);
-
-    std::vector<std::vector<std::string>> known_keys(cmd_options.number_of_worker_threads);
 
     std::vector<std::thread> worker_pool{};
     worker_pool.reserve(cmd_options.number_of_worker_threads);
@@ -409,6 +475,7 @@ cbc::pillowfight::execute(const std::vector<std::string>& argv)
     cmd_options.collection_name = options["--collection-name"].asString();
     cmd_options.batch_size = options["--batch-size"].asLong();
     parse_duration_option(cmd_options.set_batch_wait, "--batch-wait");
+    cmd_options.number_of_keys_to_populate = options["--number-of-keys-to-populate"].asLong();
     cmd_options.number_of_io_threads = options["--number-of-io-threads"].asLong();
     cmd_options.number_of_worker_threads = options["--number-of-worker-threads"].asLong();
     cmd_options.chance_of_get = get_double_option(options, "--chance-of-get");


### PR DESCRIPTION
Instead of letting session restarting itself, only allow it to removed itself from the bucket. And in the end, just notify the bucket to check configuration and establish connections to the endpoints that don't have it yet.