### PR TITLE
CXXCBC-326: Set connection_string warnings property when invalid connection string parameter is encountered

### DIFF
--- a/core/utils/connection_string.cxx
+++ b/core/utils/connection_string.cxx
@@ -182,33 +182,39 @@ struct action<bucket_name> {
 } // namespace priv
 
 void
-parse_option(std::string& receiver, const std::string& /* name */, const std::string& value)
+parse_option(std::string& receiver, const std::string& /* name */, const std::string& value, std::vector<std::string>& /* warnings */)
 {
     receiver = string_codec::url_decode(value);
 }
 
 void
-parse_option(bool& receiver, const std::string& /* name */, const std::string& value)
+parse_option(bool& receiver, const std::string& name, const std::string& value, std::vector<std::string>& warnings)
 {
     if (value == "true" || value == "yes" || value == "on") {
         receiver = true;
     } else if (value == "false" || value == "no" || value == "off") {
         receiver = false;
+    } else {
+        warnings.push_back(fmt::format(
+          R"(unable to parse "{}" parameter in connection string (value "{}" cannot be interpreted as a boolean))", name, value));
     }
 }
 
 void
-parse_option(tls_verify_mode& receiver, const std::string& /* name */, const std::string& value)
+parse_option(tls_verify_mode& receiver, const std::string& name, const std::string& value, std::vector<std::string>& warnings)
 {
     if (value == "none") {
         receiver = tls_verify_mode::none;
     } else if (value == "peer") {
         receiver = tls_verify_mode::peer;
+    } else {
+        warnings.push_back(fmt::format(
+          R"(unable to parse "{}" parameter in connection string (value "{}" is not a valid TLS verification mode))", name, value));
     }
 }
 
 void
-parse_option(io::ip_protocol& receiver, const std::string& /* name */, const std::string& value)
+parse_option(io::ip_protocol& receiver, const std::string& name, const std::string& value, std::vector<std::string>& warnings)
 {
     if (value == "any") {
         receiver = io::ip_protocol::any;
@@ -216,23 +222,28 @@ parse_option(io::ip_protocol& receiver, const std::string& /* name */, const std
         receiver = io::ip_protocol::force_ipv4;
     } else if (value == "force_ipv6") {
         receiver = io::ip_protocol::force_ipv6;
+    } else {
+        warnings.push_back(fmt::format(
+          R"(unable to parse "{}" parameter in connection string (value "{}" is not a valid IP protocol preference))", name, value));
     }
 }
 
 void
-parse_option(std::size_t& receiver, const std::string& name, const std::string& value)
+parse_option(std::size_t& receiver, const std::string& name, const std::string& value, std::vector<std::string>& warnings)
 {
     try {
         receiver = std::stoull(value, nullptr, 10);
     } catch (const std::invalid_argument& ex1) {
-        CB_LOG_WARNING(R"(unable to parse "{}" parameter in connection string (value "{}" is not a number): {})", name, value, ex1.what());
+        warnings.push_back(
+          fmt::format(R"(unable to parse "{}" parameter in connection string (value "{}" is not a number): {})", name, value, ex1.what()));
     } catch (const std::out_of_range& ex2) {
-        CB_LOG_WARNING(R"(unable to parse "{}" parameter in connection string (value "{}" is out of range): {})", name, value, ex2.what());
+        warnings.push_back(
+          fmt::format(R"(unable to parse "{}" parameter in connection string (value "{}" is out of range): {})", name, value, ex2.what()));
     }
 }
 
 void
-parse_option(std::chrono::milliseconds& receiver, const std::string& name, const std::string& value)
+parse_option(std::chrono::milliseconds& receiver, const std::string& name, const std::string& value, std::vector<std::string>& warnings)
 {
     try {
         receiver = std::chrono::duration_cast<std::chrono::milliseconds>(parse_duration(value));
@@ -240,11 +251,11 @@ parse_option(std::chrono::milliseconds& receiver, const std::string& name, const
         try {
             receiver = std::chrono::milliseconds(std::stoull(value, nullptr, 10));
         } catch (const std::invalid_argument& ex1) {
-            CB_LOG_WARNING(
-              R"(unable to parse "{}" parameter in connection string (value "{}" is not a number): {})", name, value, ex1.what());
+            warnings.push_back(fmt::format(
+              R"(unable to parse "{}" parameter in connection string (value "{}" is not a number): {})", name, value, ex1.what()));
         } catch (const std::out_of_range& ex2) {
-            CB_LOG_WARNING(
-              R"(unable to parse "{}" parameter in connection string (value "{}" is out of range): {})", name, value, ex2.what());
+            warnings.push_back(fmt::format(
+              R"(unable to parse "{}" parameter in connection string (value "{}" is out of range): {})", name, value, ex2.what()));
         }
     }
 }
@@ -262,68 +273,68 @@ extract_options(connection_string& connstr)
              * Number of seconds the client should wait while attempting to connect to a node’s KV service via a socket.  Initial
              * connection, reconnecting, node added, etc.
              */
-            parse_option(connstr.options.connect_timeout, name, value);
+            parse_option(connstr.options.connect_timeout, name, value, connstr.warnings);
         } else if (name == "kv_timeout" || name == "key_value_timeout") {
             /**
              * Number of milliseconds to wait before timing out a KV operation by the client.
              */
-            parse_option(connstr.options.key_value_timeout, name, value);
+            parse_option(connstr.options.key_value_timeout, name, value, connstr.warnings);
         } else if (name == "kv_durable_timeout" || name == "key_value_durable_timeout") {
             /**
              * Number of milliseconds to wait before timing out a KV operation that is either using synchronous durability or
              * observe-based durability.
              */
-            parse_option(connstr.options.key_value_durable_timeout, name, value);
+            parse_option(connstr.options.key_value_durable_timeout, name, value, connstr.warnings);
         } else if (name == "view_timeout") {
             /**
              * Number of seconds to wait before timing out a View request  by the client..
              */
-            parse_option(connstr.options.view_timeout, name, value);
+            parse_option(connstr.options.view_timeout, name, value, connstr.warnings);
         } else if (name == "query_timeout") {
             /**
              * Number of seconds to wait before timing out a Query or N1QL request by the client.
              */
-            parse_option(connstr.options.query_timeout, name, value);
+            parse_option(connstr.options.query_timeout, name, value, connstr.warnings);
         } else if (name == "analytics_timeout") {
             /**
              * Number of seconds to wait before timing out an Analytics request by the client.
              */
-            parse_option(connstr.options.analytics_timeout, name, value);
+            parse_option(connstr.options.analytics_timeout, name, value, connstr.warnings);
         } else if (name == "search_timeout") {
             /**
              * Number of seconds to wait before timing out a Search request by the client.
              */
-            parse_option(connstr.options.search_timeout, name, value);
+            parse_option(connstr.options.search_timeout, name, value, connstr.warnings);
         } else if (name == "management_timeout") {
             /**
              * Number of seconds to wait before timing out a Management API request by the client.
              */
-            parse_option(connstr.options.management_timeout, name, value);
+            parse_option(connstr.options.management_timeout, name, value, connstr.warnings);
         } else if (name == "trust_certificate") {
-            parse_option(connstr.options.trust_certificate, name, value);
+            parse_option(connstr.options.trust_certificate, name, value, connstr.warnings);
         } else if (name == "enable_mutation_tokens") {
             /**
              * Request mutation tokens at connection negotiation time. Turning this off will save 16 bytes per operation response.
              */
-            parse_option(connstr.options.enable_mutation_tokens, name, value);
+            parse_option(connstr.options.enable_mutation_tokens, name, value, connstr.warnings);
         } else if (name == "enable_tcp_keep_alive") {
             /**
              * Gets or sets a value indicating whether enable TCP keep-alive.
              */
-            parse_option(connstr.options.enable_tcp_keep_alive, name, value);
+            parse_option(connstr.options.enable_tcp_keep_alive, name, value, connstr.warnings);
         } else if (name == "tcp_keep_alive_interval") {
             /**
              * Specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent. This applies to all
              * services, but is advisory: if the underlying platform does not support this on all connections, it will be applied only
              * on those it can be.
              */
-            parse_option(connstr.options.tcp_keep_alive_interval, name, value);
+            parse_option(connstr.options.tcp_keep_alive_interval, name, value, connstr.warnings);
         } else if (name == "force_ipv4") {
             /**
              * Sets the SDK configuration to do IPv4 Name Resolution
              */
             bool force_ipv4 = false;
-            parse_option(force_ipv4, name, value);
+            parse_option(force_ipv4, name, value, connstr.warnings);
             if (force_ipv4) {
                 connstr.options.use_ip_protocol = io::ip_protocol::force_ipv4;
             }
@@ -331,40 +342,40 @@ extract_options(connection_string& connstr)
             /**
              * Controls preference of IP protocol for name resolution
              */
-            parse_option(connstr.options.use_ip_protocol, name, value);
+            parse_option(connstr.options.use_ip_protocol, name, value, connstr.warnings);
         } else if (name == "config_poll_interval") {
-            parse_option(connstr.options.config_poll_interval, name, value);
+            parse_option(connstr.options.config_poll_interval, name, value, connstr.warnings);
         } else if (name == "config_poll_floor") {
-            parse_option(connstr.options.config_poll_floor, name, value);
+            parse_option(connstr.options.config_poll_floor, name, value, connstr.warnings);
         } else if (name == "max_http_connections") {
             /**
              * The maximum number of HTTP connections allowed on a per-host and per-port basis.  0 indicates an unlimited number of
              * connections are permitted.
              */
-            parse_option(connstr.options.max_http_connections, name, value);
+            parse_option(connstr.options.max_http_connections, name, value, connstr.warnings);
         } else if (name == "idle_http_connection_timeout") {
             /**
              * The period of time an HTTP connection can be idle before it is forcefully disconnected.
              */
-            parse_option(connstr.options.idle_http_connection_timeout, name, value);
+            parse_option(connstr.options.idle_http_connection_timeout, name, value, connstr.warnings);
         } else if (name == "bootstrap_timeout") {
             /**
              * The period of time allocated to complete bootstrap
              */
-            parse_option(connstr.options.bootstrap_timeout, name, value);
+            parse_option(connstr.options.bootstrap_timeout, name, value, connstr.warnings);
         } else if (name == "resolve_timeout") {
             /**
              * The period of time to resolve DNS name of the node to IP address
              */
-            parse_option(connstr.options.resolve_timeout, name, value);
+            parse_option(connstr.options.resolve_timeout, name, value, connstr.warnings);
         } else if (name == "enable_dns_srv") {
             if (connstr.bootstrap_nodes.size() == 1) {
-                parse_option(connstr.options.enable_dns_srv, name, value);
+                parse_option(connstr.options.enable_dns_srv, name, value, connstr.warnings);
             } else {
-                CB_LOG_WARNING(
-                  R"(parameter "{}" require single entry in bootstrap nodes list of the connection string, ignoring (value "{}"))",
+                connstr.warnings.push_back(fmt::format(
+                  R"(parameter "{}" requires single entry in bootstrap nodes list of the connection string, ignoring (value "{}"))",
                   name,
-                  value);
+                  value));
             }
         } else if (name == "network") {
             connstr.options.network = value; /* current known values are "auto", "default" and "external" */
@@ -372,51 +383,51 @@ extract_options(connection_string& connstr)
             /**
              * Whether to display N1QL, Analytics, Search queries on info level (default false)
              */
-            parse_option(connstr.options.show_queries, name, value);
+            parse_option(connstr.options.show_queries, name, value, connstr.warnings);
         } else if (name == "enable_clustermap_notification") {
             /**
              * Allow the server to push configuration updates asynchronously.
              */
-            parse_option(connstr.options.enable_clustermap_notification, name, value);
+            parse_option(connstr.options.enable_clustermap_notification, name, value, connstr.warnings);
         } else if (name == "enable_unordered_execution") {
             /**
              * Allow the server to reorder commands
              */
-            parse_option(connstr.options.enable_unordered_execution, name, value);
+            parse_option(connstr.options.enable_unordered_execution, name, value, connstr.warnings);
         } else if (name == "enable_compression") {
             /**
              * Announce support of compression (snappy) to server
              */
-            parse_option(connstr.options.enable_compression, name, value);
+            parse_option(connstr.options.enable_compression, name, value, connstr.warnings);
         } else if (name == "enable_tracing") {
             /**
              * true - use threshold_logging_tracer
              * false - use noop_tracer
              */
-            parse_option(connstr.options.enable_tracing, name, value);
+            parse_option(connstr.options.enable_tracing, name, value, connstr.warnings);
         } else if (name == "enable_metrics") {
             /**
              * true - use logging_meter
              * false - use noop_meter
              */
-            parse_option(connstr.options.enable_metrics, name, value);
+            parse_option(connstr.options.enable_metrics, name, value, connstr.warnings);
         } else if (name == "tls_verify") {
-            parse_option(connstr.options.tls_verify, name, value);
+            parse_option(connstr.options.tls_verify, name, value, connstr.warnings);
         } else if (name == "disable_mozilla_ca_certificates") {
-            parse_option(connstr.options.disable_mozilla_ca_certificates, name, value);
+            parse_option(connstr.options.disable_mozilla_ca_certificates, name, value, connstr.warnings);
         } else if (name == "user_agent_extra") {
             /**
              * string, that will be appended to identification fields of the server protocols (key in HELO packet for MCBP, "user-agent"
              * header for HTTP)
              */
-            parse_option(connstr.options.user_agent_extra, name, value);
+            parse_option(connstr.options.user_agent_extra, name, value, connstr.warnings);
         } else if (name == "dump_configuration") {
             /**
              * Whether to dump every new configuration on TRACE level
              */
-            parse_option(connstr.options.dump_configuration, name, value);
+            parse_option(connstr.options.dump_configuration, name, value, connstr.warnings);
         } else {
-            CB_LOG_WARNING(R"(unknown parameter "{}" in connection string (value "{}"))", name, value);
+            connstr.warnings.push_back(fmt::format(R"(unknown parameter "{}" in connection string (value "{}"))", name, value));
         }
     }
 }

--- a/core/utils/connection_string.hxx
+++ b/core/utils/connection_string.hxx
@@ -68,6 +68,7 @@ struct connection_string {
     bootstrap_mode default_mode{ connection_string::bootstrap_mode::gcccp };
     std::uint16_t default_port{ 11210 };
 
+    std::vector<std::string> warnings{};
     std::optional<std::string> error{};
 };
 

--- a/test/test_unit_connection_string.cxx
+++ b/test/test_unit_connection_string.cxx
@@ -440,10 +440,8 @@ TEST_CASE("unit: connection string", "[unit]")
 
         spec = couchbase::core::utils::parse_connection_string(
           "couchbase://localhost?query_timeout=10000&kv_timeout=true&management_timeout=11000");
-        CHECK(spec.warnings ==
-              std::vector<std::string>{
-                R"(unable to parse "kv_timeout" parameter in connection string (value "true" is not a number): stoull: no conversion)",
-              });
+        std::string warning_prefix = R"(unable to parse "kv_timeout" parameter in connection string (value "true" is not a number))";
+        CHECK(spec.warnings.at(0).substr(0, warning_prefix.size()) == warning_prefix);
         CHECK(spec.options.query_timeout == std::chrono::milliseconds(10000));
         CHECK(spec.options.management_timeout == std::chrono::milliseconds(11000));
     }

--- a/test/test_unit_connection_string.cxx
+++ b/test/test_unit_connection_string.cxx
@@ -416,4 +416,35 @@ TEST_CASE("unit: connection string", "[unit]")
         CHECK(couchbase::core::utils::parse_connection_string("couchbase://2001:db8:85a3:8d3:1319:8a2e:370:7348").error.value() ==
               R"(failed to parse connection string (column: 18, trailer: "db8:85a3:8d3:1319:8a2e:370:7348"))");
     }
+
+    SECTION("parsing warnings")
+    {
+        auto spec = couchbase::core::utils::parse_connection_string("couchbase://127.0.0.1?kv_timeout=42&foo=bar");
+        CHECK(spec.warnings == std::vector<std::string>{
+                                 R"(unknown parameter "foo" in connection string (value "bar"))",
+                               });
+
+        spec = couchbase::core::utils::parse_connection_string("couchbase://127.0.0.1?enable_dns_srv=maybe&ip_protocol=yes");
+        CHECK(spec.warnings ==
+              std::vector<std::string>{
+                R"(unable to parse "enable_dns_srv" parameter in connection string (value "maybe" cannot be interpreted as a boolean))",
+                R"(unable to parse "ip_protocol" parameter in connection string (value "yes" is not a valid IP protocol preference))",
+              });
+
+        spec = couchbase::core::utils::parse_connection_string("couchbase://localhost:8091=http;127.0.0.1=mcd/default?enable_dns_srv=true");
+        CHECK(
+          spec.warnings ==
+          std::vector<std::string>{
+            R"(parameter "enable_dns_srv" requires single entry in bootstrap nodes list of the connection string, ignoring (value "true"))",
+          });
+
+        spec = couchbase::core::utils::parse_connection_string(
+          "couchbase://localhost?query_timeout=10000&kv_timeout=true&management_timeout=11000");
+        CHECK(spec.warnings ==
+              std::vector<std::string>{
+                R"(unable to parse "kv_timeout" parameter in connection string (value "true" is not a number): stoull: no conversion)",
+              });
+        CHECK(spec.options.query_timeout == std::chrono::milliseconds(10000));
+        CHECK(spec.options.management_timeout == std::chrono::milliseconds(11000));
+    }
 }


### PR DESCRIPTION
### Motivation
When an invalid connection string parameter (either invalid key or value) is encountered only a warning logging message is outputted. The caller (i.e. a wrapper SDK) cannot check for the existence of parsing issues to raise an appropriate exception if it wants.

### Changes
* Added a `warnings` property (`std::vector<std::string>`) in the `connection_string` struct where all parsing warnings can be gathered.
* Any warning logging messages that were previously outputted as a result of parsing issues are now pushed to the `warnings` vector instead, giving the option to the caller to decide whether to output logging messages or raise an exception
* Added some warnings for some parsing issues that were not previously being recorded (Invalid boolean, IP protocol and TLS verification mode values)
* Added relevant tests