### PR TITLE
CXXCBC-331: fix FTS index provisioning script and improve test stability

### DIFF
--- a/bin/api.rb
+++ b/bin/api.rb
@@ -1,0 +1,234 @@
+#  Copyright 2020-2021 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require "openssl"
+require "net/http"
+require "json"
+
+class Object
+  def to_b
+    ![nil, false, 0, "", "0", "f", "F", "false", "FALSE", "off", "OFF", "no", "NO"].include?(self)
+  end
+end
+
+
+class API
+  def initialize(options)
+    @options = options
+    connect
+  end
+
+  def connect
+    puts "# CONNECT #{@options}"
+    @client = Net::HTTP.start(@options[:host], @options[:port],
+                              use_ssl: @options[:strict_encryption],
+                              verify_mode: OpenSSL::SSL::VERIFY_NONE)
+  end
+
+  def url(path)
+    "#{@client.use_ssl? ? 'https' : 'http'}://#{@options[:username]}@#{@options[:host]}:#{@options[:port]}#{path}"
+  end
+
+  def decode_response(response)
+    payload =
+      if response['content-type'] =~ /application\/json/
+        JSON.parse(response.body)
+      else
+        response.body
+      end
+    if @options[:verbose]
+      p status: response.code, payload: payload
+    end
+    payload
+  end
+
+  def setup_request(request)
+    request.basic_auth(@options[:username], @options[:password])
+    request['accept'] = "application/json"
+  end
+
+  def get(path)
+    puts "# GET #{url(path)}"
+    req = Net::HTTP::Get.new(path)
+    setup_request(req)
+    res = @client.request(req)
+    decode_response(res)
+  rescue EOFError
+    connect
+    retry
+  rescue => ex
+    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
+    sleep(1)
+    retry
+  end
+
+  def post_form(path, fields = {})
+    puts "# POST #{url(path)} #{fields}"
+    req = Net::HTTP::Post.new(path)
+    setup_request(req)
+    req.form_data = fields
+    res = @client.request(req)
+    decode_response(res)
+  rescue EOFError
+    connect
+    retry
+  rescue => ex
+    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
+    sleep(1)
+    retry
+  end
+
+  def post_json(path, object)
+    data = JSON.generate(object)
+    puts "# POST #{url(path)} #{data}"
+    req = Net::HTTP::Post.new(path)
+    req['content-type'] = "application/json"
+    setup_request(req)
+    res = @client.request(req, data)
+    decode_response(res)
+  rescue EOFError
+    connect
+    retry
+  rescue => ex
+    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
+    sleep(1)
+    retry
+  end
+
+  def put_json(path, object)
+    data = JSON.generate(object)
+    puts "# PUT #{url(path)} #{data}"
+    req = Net::HTTP::Put.new(path)
+    req['content-type'] = "application/json"
+    setup_request(req)
+    res = @client.request(req, data)
+    decode_response(res)
+  rescue EOFError
+    connect
+    retry
+  rescue => ex
+    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
+    sleep(1)
+    retry
+  end
+
+  def delete(path)
+    puts "# DELETE #{url(path)}"
+    req = Net::HTTP::Delete.new(path)
+    setup_request(req)
+    res = @client.request(req)
+    decode_response(res)
+  rescue EOFError
+    connect
+    retry
+  rescue => ex
+    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
+    sleep(1)
+    retry
+  end
+end
+
+def service_address_for_bucket(api, service, bucket, options)
+  port_key = options[:strict_encryption] ? "#{service}SSL" : service
+  host = nil
+  port = 0
+  while port.zero?
+    config = api.get("/pools/default/b/#{bucket}")
+    node_with_service = config["nodesExt"].find{|n| n["services"].key?(port_key)} rescue nil
+    if node_with_service
+      host = node_with_service["hostname"]
+      port = node_with_service["services"][port_key].to_i rescue 0
+    end
+    sleep 1
+  end
+ {host: host || options[:host], port: port}
+end
+
+def ensure_search_index_created(index_definition_path, options)
+  loop do
+    catch :retry do
+      search_api = API.new(options)
+
+      puts "using index definition: #{File.basename(index_definition_path)}"
+      index_definition = JSON.load(File.read(index_definition_path))
+      search_api.put_json("/api/index/travel-sample-index", index_definition)
+
+      expected_number_of_the_documents = 1000
+      indexed_documents = 0
+      times_zero_documents_has_been_seen = 0
+      Timeout.timeout(10 * 60) do # give it 10 minutes to index
+        while indexed_documents < expected_number_of_the_documents
+          resp = search_api.get("/api/index/travel-sample-index/count")
+          indexed_documents = resp['count'].to_i
+          times_zero_documents_has_been_seen += 1 if indexed_documents.zero?
+          if times_zero_documents_has_been_seen >= 60
+            # lets not tolerate 60 seconds of not getting data indexed
+            search_api.delete("/api/index/travel-sample-index")
+            throw :retry
+          end
+          sleep 1
+        end
+      end
+      return
+    end
+  end
+end
+
+def ensure_sample_bucket_loaded(management_api, expected_number_of_the_documents, options)
+  loop do
+    catch :retry do
+      management_api.post_json("/sampleBuckets/install", [options[:bucket]])
+
+      service_address = nil
+      begin
+        Timeout.timeout(60) do # a minute for bucket creation
+          service_address = service_address_for_bucket(management_api, "n1ql", options[:bucket], options)
+        end
+      rescue Timeout::Error
+        management_api.delete("/pools/default/buckets/#{options[:bucket]}")
+        sleep 1
+        throw :retry
+      end
+      puts query_service: service_address
+
+      query_api = API.new(options.merge(service_address))
+      puts "create index for bucket \"#{options[:bucket]}\""
+
+      query_api.post_form("/query/service", statement: "CREATE PRIMARY INDEX ON `#{options[:bucket]}` USING GSI", timeout: "300s")
+
+      indexed_documents = 0
+      times_zero_documents_has_been_seen = 0
+      Timeout.timeout(10 * 60) do # give it 10 minutes to index
+        while indexed_documents < expected_number_of_the_documents
+          resp = query_api.post_form("/query/service", statement: "SELECT RAW COUNT(*) FROM `#{options[:bucket]}`")
+          indexed_documents = resp["results"][0].to_i rescue 0
+
+          if indexed_documents.zero?
+            times_zero_documents_has_been_seen += 1
+            puts times_zero_documents_has_been_seen: times_zero_documents_has_been_seen
+          end
+          if times_zero_documents_has_been_seen >= 60
+            # lets not tolerate 60 seconds of not getting data indexed
+            query_api.post_form("/query/service", statement: "DROP PRIMARY INDEX ON `#{options[:bucket]}`")
+            management_api.delete("/pools/default/buckets/#{options[:bucket]}")
+            sleep 1
+            throw :retry
+          end
+          sleep 1
+        end
+      end
+      return
+    end
+  end
+end

--- a/bin/init-cluster
+++ b/bin/init-cluster
@@ -17,13 +17,8 @@
 require "set"
 require "timeout"
 require "optparse"
-require "openssl"
 
-class Object
-  def to_b
-    ![nil, false, 0, "", "0", "f", "F", "false", "FALSE", "off", "OFF", "no", "NO"].include?(self)
-  end
-end
+require_relative "api"
 
 options = {
   verbose: ENV.fetch("CB_VERBOSE", true).to_b,
@@ -49,106 +44,6 @@ options[:port] = ENV.fetch("CB_PORT", default_port).to_i
 options[:sample_buckets] << "beer-sample" if ENV.fetch("CB_BEER_SAMPLE", false).to_b
 options[:sample_buckets] << "travel-sample" if ENV.fetch("CB_TRAVEL_SAMPLE", false).to_b
 
-require "net/http"
-require "json"
-
-class API
-  def initialize(options)
-    @options = options
-    connect
-  end
-
-  def connect
-    @client = Net::HTTP.start(@options[:host], @options[:port],
-                              use_ssl: @options[:strict_encryption],
-                              verify_mode: OpenSSL::SSL::VERIFY_NONE)
-  end
-
-  def url(path)
-    "#{@client.use_ssl? ? 'https' : 'http'}://#{@options[:username]}@#{@options[:host]}:#{@options[:port]}#{path}"
-  end
-
-  def decode_response(response)
-    payload =
-      if /application\/json/.match?(response['content-type'])
-        JSON.parse(response.body)
-      else
-        response.body
-      end
-    p payload if @options[:verbose]
-    payload
-  end
-
-  def setup_request(request)
-    request.basic_auth(@options[:username], @options[:password])
-    request['accept'] = "application/json"
-  end
-
-  def get(path)
-    puts "# GET #{url(path)}"
-    req = Net::HTTP::Get.new(path)
-    setup_request(req)
-    res = @client.request(req)
-    decode_response(res)
-  rescue EOFError
-    connect
-    retry
-  rescue => ex
-    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
-    sleep(1)
-    retry
-  end
-
-  def post_form(path, fields = {})
-    puts "# POST #{url(path)} #{fields}"
-    req = Net::HTTP::Post.new(path)
-    setup_request(req)
-    req.form_data = fields
-    res = @client.request(req)
-    decode_response(res)
-  rescue EOFError
-    connect
-    retry
-  rescue => ex
-    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
-    sleep(1)
-    retry
-  end
-
-  def post_json(path, object)
-    data = JSON.generate(object)
-    puts "# POST #{url(path)} #{data}"
-    req = Net::HTTP::Post.new(path)
-    req['content-type'] = "application/json"
-    setup_request(req)
-    res = @client.request(req, data)
-    decode_response(res)
-  rescue EOFError
-    connect
-    retry
-  rescue => ex
-    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
-    sleep(1)
-    retry
-  end
-
-  def put_json(path, object)
-    data = JSON.generate(object)
-    puts "# PUT #{url(path)} #{data}"
-    req = Net::HTTP::Put.new(path)
-    req['content-type'] = "application/json"
-    setup_request(req)
-    res = @client.request(req, data)
-    decode_response(res)
-  rescue EOFError
-    connect
-    retry
-  rescue => ex
-    puts "#{__method__}: #{ex}, sleep for 1 second and retry"
-    sleep(1)
-    retry
-  end
-end
 
 api = 
   begin
@@ -235,50 +130,30 @@ if options[:sec_bucket].to_b
               name: options[:sec_bucket])
 end
 
-api.post_json("/sampleBuckets/install", options[:sample_buckets].to_a) if options[:sample_buckets].any?
-
 api.post_form("/settings/developerPreview", enabled: true) if options[:enable_developer_preview]
 
-def service_port_for_bucket(api, service, bucket, options)
-  port_key = options[:strict_encryption] ? "#{service}SSL" : service
-  port = 0
-  while port.zero?
-    config = api.get("/pools/default/b/#{bucket}")
-    port = config["nodesExt"].find{|n| n["services"].key?(port_key)}["services"][port_key].to_i rescue 0
-    sleep 1
-  end
-  port
-end
+service_address = service_address_for_bucket(api, "n1ql", options[:bucket], options)
+puts query_service: service_address
 
-query_api = API.new(options.merge(port: service_port_for_bucket(api, "n1ql", options[:bucket], options)))
+query_api = API.new(options.merge(service_address))
 query_api.post_form("/query/service", statement: "CREATE PRIMARY INDEX ON `#{options[:bucket]}` USING GSI")
-options[:sample_buckets].each do |bucket|
-  service_port_for_bucket(api, "n1ql", bucket, options)
-  query_api.post_form("/query/service", statement: "CREATE PRIMARY INDEX ON `#{bucket}` USING GSI")
-end
 
-puts service_port_for_bucket(api, "fts", options[:bucket], options)
+expected_counts = {
+  "travel-sample" => 30_000,
+  "beer-sample" => 7_000,
+}
+options[:sample_buckets].each do |bucket|
+  ensure_sample_bucket_loaded(api, expected_counts[bucket], options.merge(bucket: bucket))
+end
 
 if options[:sample_buckets].include?("travel-sample") && services.include?("fts")
-  search_api = API.new(options.merge(port: service_port_for_bucket(api, "fts", options[:bucket], options)))
+  service_address = service_address_for_bucket(api, "fts", options[:bucket], options)
+  puts search_service: service_address
 
   has_v6_nodes = 
     api.get("/pools/default")["nodes"]
     .any? { |node| node["version"] =~ /^6\./ && node["services"].include?("fts") }
-
   index_definition_path = File.join(__dir__, "travel-sample-index#{"-v6" if has_v6_nodes}.json")
-  puts "using index definition: #{File.basename(index_definition_path)}"
-  index_definition = JSON.load(File.read(index_definition_path))
-  search_api.put_json("/api/index/travel-sample-index", index_definition)
-
-  expected_number_of_the_documents = 1000
-  indexed_documents = 0
-  Timeout.timeout(10 * 60) do # give it 10 minutes to index
-    while indexed_documents < expected_number_of_the_documents
-      resp = search_api.get("/api/index/travel-sample-index/count")
-      indexed_documents = resp['count'].to_i
-      sleep 1
-    end
-  end
+  ensure_search_index_created(index_definition_path, options.merge(service_address))
 end
 

--- a/bin/load-sample-buckets
+++ b/bin/load-sample-buckets
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 require "timeout"
+require "set"
 
 require_relative "api"
 
@@ -25,7 +26,13 @@ options = {
   password: ENV.fetch("CB_PASSWORD", ARGV[3] || "password"),
   verbose: ENV.fetch("CB_VERBOSE", true).to_b,
   bucket: "travel-sample",
+  sample_buckets: Set.new,
 }
+options[:sample_buckets] << "beer-sample" if ENV.fetch("CB_BEER_SAMPLE", false).to_b
+options[:sample_buckets] << "travel-sample" if ENV.fetch("CB_TRAVEL_SAMPLE", false).to_b
+options[:sample_buckets] |= ARGV[4..-1]
+return if options[:sample_buckets].empty?
+
 p options: options
 
 management_api =
@@ -36,12 +43,12 @@ management_api =
     sleep(1)
     retry
   end
-service_address = service_address_for_bucket(management_api, "fts", options[:bucket], options)
-p search_service: service_address
 
-has_v6_nodes =
-  management_api.get("/pools/default")["nodes"]
-  .any? { |node| node["version"] =~ /^6\./ && node["services"].include?("fts") }
+expected_counts = {
+  "travel-sample" => 30_000,
+  "beer-sample" => 7_000,
+}
 
-index_definition_path = File.join(__dir__, "travel-sample-index#{"-v6" if has_v6_nodes}.json")
-ensure_search_index_created(index_definition_path, options.merge(service_address))
+options[:sample_buckets].each do |bucket|
+  ensure_sample_bucket_loaded(management_api, expected_counts[bucket], options.merge(bucket: bucket))
+end

--- a/core/topology/collections_manifest_fmt.hxx
+++ b/core/topology/collections_manifest_fmt.hxx
@@ -47,6 +47,6 @@ struct fmt::formatter<couchbase::core::topology::collections_manifest> {
                          couchbase::core::uuid::to_string(manifest.id),
                          manifest.uid,
                          collections.size(),
-                         utils::join_strings(collections, ", "));
+                         couchbase::core::utils::join_strings(collections, ", "));
     }
 };

--- a/test/test_integration_collections.cxx
+++ b/test/test_integration_collections.cxx
@@ -113,6 +113,12 @@ TEST_CASE("integration: get and insert non default scope and collection", "[inte
         REQUIRE_SUCCESS(resp.ctx.ec());
         REQUIRE(resp.value == couchbase::core::utils::to_binary(key));
     }
+
+    {
+        couchbase::core::operations::management::scope_drop_request req{ integration.ctx.bucket, scope_name };
+        auto resp = test::utils::execute(integration.cluster, req);
+        REQUIRE_SUCCESS(resp.ctx.ec);
+    }
 }
 
 TEST_CASE("integration: insert into dropped scope", "[integration]")

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -132,6 +132,9 @@ row: {"airline":{"callsign":"MILE-AIR","country":"United States","iata":"Q5","ic
 TEST_CASE("example: start using", "[integration]")
 {
     test::utils::integration_test_guard integration;
+    if (integration.cluster_version().is_capella()) {
+        SKIP("Capella does not allow to use REST API to load sample buckets");
+    }
     if (!integration.cluster_version().supports_collections()) {
         SKIP("cluster does not support collections");
     }
@@ -438,8 +441,12 @@ row: {"airline":{"callsign":"MILE-AIR","country":"United States","iata":"Q5","ic
 TEST_CASE("example: search", "[integration]")
 {
     test::utils::integration_test_guard integration;
+
+    if (integration.cluster_version().is_capella()) {
+        SKIP("Capella does not allow to use REST API to load sample buckets");
+    }
     if (!integration.cluster_version().supports_collections()) {
-        return;
+        SKIP("cluster does not support collections");
     }
 
     const auto env = test::utils::test_context::load_from_environment();

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -32,7 +32,7 @@ async_options()
     return cfg;
 }
 
-TEST_CASE("can async get", "[transactions]")
+TEST_CASE("transactions public async API: can async get", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -62,7 +62,7 @@ TEST_CASE("can async get", "[transactions]")
     f.get();
 }
 
-TEST_CASE("can get fail as expected", "[transactions]")
+TEST_CASE("transactions public async API: can get fail as expected", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -85,7 +85,7 @@ TEST_CASE("can get fail as expected", "[transactions]")
       async_options());
     f.get();
 }
-TEST_CASE("can async remove", "[transactions]")
+TEST_CASE("transactions public async API: can async remove", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -114,7 +114,7 @@ TEST_CASE("can async remove", "[transactions]")
     f.get();
 }
 
-TEST_CASE("async remove with bad cas fails as expected", "[transactions]")
+TEST_CASE("transactions public async API: async remove with bad cas fails as expected", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -144,7 +144,8 @@ TEST_CASE("async remove with bad cas fails as expected", "[transactions]")
       async_options());
     f.get();
 }
-TEST_CASE("can async insert", "[transactions]")
+
+TEST_CASE("transactions public async API: can async insert", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -168,7 +169,7 @@ TEST_CASE("can async insert", "[transactions]")
     f.get();
 }
 
-TEST_CASE("async insert fails when doc already exists, but doesn't rollback", "[transactions]")
+TEST_CASE("transactions public async API: async insert fails when doc already exists, but doesn't rollback", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -196,7 +197,7 @@ TEST_CASE("async insert fails when doc already exists, but doesn't rollback", "[
     f.get();
 }
 
-TEST_CASE("can async replace", "[transactions]")
+TEST_CASE("transactions public async API: can async replace", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -227,7 +228,7 @@ TEST_CASE("can async replace", "[transactions]")
       async_options());
     f.get();
 }
-TEST_CASE("async replace fails as expected with bad cas", "[transactions]")
+TEST_CASE("transactions public async API: async replace fails as expected with bad cas", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -259,7 +260,7 @@ TEST_CASE("async replace fails as expected with bad cas", "[transactions]")
     f.get();
 }
 
-TEST_CASE("uncaught exception will rollback", "[transactions]")
+TEST_CASE("transactions public async API: uncaught exception will rollback", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -293,7 +294,7 @@ TEST_CASE("uncaught exception will rollback", "[transactions]")
     f.get();
 }
 
-TEST_CASE("can set transaction options", "[transactions]")
+TEST_CASE("transactions public async API: can set transaction options", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -334,7 +335,7 @@ TEST_CASE("can set transaction options", "[transactions]")
     f.get();
 }
 
-TEST_CASE("can do mutating query", "[transactions]")
+TEST_CASE("transactions public async API: can do mutating query", "[transactions]")
 {
 
     test::utils::integration_test_guard integration;
@@ -360,7 +361,7 @@ TEST_CASE("can do mutating query", "[transactions]")
     f.get();
 }
 
-TEST_CASE("some query errors rollback", "[transactions]")
+TEST_CASE("transactions public async API: some query errors rollback", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -94,7 +94,7 @@ upsert_scope_and_collection(std::shared_ptr<couchbase::core::cluster> cluster,
     }
 }
 
-TEST_CASE("can get", "[transactions]")
+TEST_CASE("transactions public blocking API: can get", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -118,7 +118,7 @@ TEST_CASE("can get", "[transactions]")
     CHECK_FALSE(tx_err.ec());
 }
 
-TEST_CASE("get returns error if doc doesn't exist", "[transactions]")
+TEST_CASE("transactions public blocking API: get returns error if doc doesn't exist", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -137,7 +137,7 @@ TEST_CASE("get returns error if doc doesn't exist", "[transactions]")
     CHECK_FALSE(tx_err.ec());
 }
 
-TEST_CASE("can insert", "[transactions]")
+TEST_CASE("transactions public blocking API: can insert", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -165,7 +165,7 @@ TEST_CASE("can insert", "[transactions]")
     REQUIRE(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("insert has error as expected when doc already exists", "[transactions]")
+TEST_CASE("transactions public blocking API: insert has error as expected when doc already exists", "[transactions]")
 {
 
     test::utils::integration_test_guard integration;
@@ -193,7 +193,7 @@ TEST_CASE("insert has error as expected when doc already exists", "[transactions
     REQUIRE(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("can replace", "[transactions]")
+TEST_CASE("transactions public blocking API: can replace", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -225,7 +225,7 @@ TEST_CASE("can replace", "[transactions]")
             couchbase::core::utils::json::generate_binary(new_content));
 }
 
-TEST_CASE("replace fails as expected with bad cas", "[transactions]")
+TEST_CASE("transactions public blocking API: replace fails as expected with bad cas", "[transactions]")
 {
 
     test::utils::integration_test_guard integration;
@@ -255,7 +255,7 @@ TEST_CASE("replace fails as expected with bad cas", "[transactions]")
     REQUIRE(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("can remove", "[transactions]")
+TEST_CASE("transactions public blocking API: can remove", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -280,7 +280,7 @@ TEST_CASE("can remove", "[transactions]")
     REQUIRE(final_err.ec() == couchbase::errc::key_value::document_not_found);
 }
 
-TEST_CASE("remove fails as expected with bad cas", "[transactions]")
+TEST_CASE("transactions public blocking API: remove fails as expected with bad cas", "[transactions]")
 {
 
     test::utils::integration_test_guard integration;
@@ -307,7 +307,7 @@ TEST_CASE("remove fails as expected with bad cas", "[transactions]")
     CHECK(tx_err.ec());
 }
 
-TEST_CASE("remove fails as expected with missing doc", "[transactions]")
+TEST_CASE("transactions public blocking API: remove fails as expected with missing doc", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -331,7 +331,7 @@ TEST_CASE("remove fails as expected with missing doc", "[transactions]")
     CHECK(tx_err.cause() == couchbase::errc::transaction_op::unknown);
 }
 
-TEST_CASE("uncaught exception in lambda will rollback without retry", "[transactions]")
+TEST_CASE("transactions public blocking API: uncaught exception in lambda will rollback without retry", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -352,7 +352,7 @@ TEST_CASE("uncaught exception in lambda will rollback without retry", "[transact
     CHECK(tx_err.cause() == couchbase::errc::transaction_op::unknown);
 }
 
-TEST_CASE("can pass per-transaction configs", "[transactions]")
+TEST_CASE("transactions public blocking API: can pass per-transaction configs", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -386,7 +386,7 @@ TEST_CASE("can pass per-transaction configs", "[transactions]")
     CHECK(tx_err.ec());
 }
 
-TEST_CASE("can do simple query", "[transactions]")
+TEST_CASE("transactions public blocking API: can do simple query", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -407,7 +407,7 @@ TEST_CASE("can do simple query", "[transactions]")
     CHECK_FALSE(result.transaction_id.empty());
 }
 
-TEST_CASE("can do simple mutating query", "[transactions]")
+TEST_CASE("transactions public blocking API: can do simple mutating query", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -430,7 +430,7 @@ TEST_CASE("can do simple mutating query", "[transactions]")
     CHECK(final_doc.content_as<tao::json::value>().at("some_number") == 10);
 }
 
-TEST_CASE("some query errors don't force rollback", "[transactions]")
+TEST_CASE("transactions public blocking API: some query errors don't force rollback", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -455,7 +455,7 @@ TEST_CASE("some query errors don't force rollback", "[transactions]")
     CHECK(final_doc.content_as<tao::json::value>() == content);
 }
 
-TEST_CASE("some query errors do rollback", "[transactions]")
+TEST_CASE("transactions public blocking API: some query errors do rollback", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -484,7 +484,7 @@ TEST_CASE("some query errors do rollback", "[transactions]")
     CHECK(doc2.cas().empty());
 }
 
-TEST_CASE("some query errors are seen immediately", "[transactions]")
+TEST_CASE("transactions public blocking API: some query errors are seen immediately", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -503,7 +503,7 @@ TEST_CASE("some query errors are seen immediately", "[transactions]")
     CHECK(result.unstaging_complete);
 }
 
-TEST_CASE("can query from a scope", "[transactions]")
+TEST_CASE("transactions public blocking API: can query from a scope", "[transactions]")
 {
     const std::string new_scope_name("newscope");
     const std::string new_coll_name("newcoll");
@@ -529,9 +529,15 @@ TEST_CASE("can query from a scope", "[transactions]")
       txn_opts());
     CHECK_FALSE(tx_err.ec());
     CHECK_FALSE(result.transaction_id.empty());
+
+    {
+        couchbase::core::operations::management::scope_drop_request req{ integration.ctx.bucket, new_scope_name };
+        auto resp = test::utils::execute(integration.cluster, req);
+        REQUIRE_SUCCESS(resp.ctx.ec);
+    }
 }
 
-TEST_CASE("can get doc from bucket not yet opened", "[transactions]")
+TEST_CASE("transactions public blocking API: can get doc from bucket not yet opened", "[transactions]")
 {
 
     auto id = test::utils::uniq_id("txn");
@@ -559,7 +565,7 @@ TEST_CASE("can get doc from bucket not yet opened", "[transactions]")
     });
 }
 
-TEST_CASE("can insert doc into bucket not yet opened", "[transactions]")
+TEST_CASE("transactions public blocking API: can insert doc into bucket not yet opened", "[transactions]")
 {
     test::utils::integration_test_guard integration;
 
@@ -585,7 +591,7 @@ TEST_CASE("can insert doc into bucket not yet opened", "[transactions]")
     });
 }
 
-TEST_CASE("can replace doc in bucket not yet opened", "[transactions]")
+TEST_CASE("transactions public blocking API: can replace doc in bucket not yet opened", "[transactions]")
 {
 
     auto id = test::utils::uniq_id("txn");
@@ -620,7 +626,7 @@ TEST_CASE("can replace doc in bucket not yet opened", "[transactions]")
     });
 }
 
-TEST_CASE("can remove doc in bucket not yet opened", "[transactions]")
+TEST_CASE("transactions public blocking API: can remove doc in bucket not yet opened", "[transactions]")
 {
 
     auto id = test::utils::uniq_id("txn");

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -215,6 +215,11 @@ struct server_version {
     {
         return supports_search() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
     }
+
+    [[nodiscard]] bool is_capella() const
+    {
+        return deployment == deployment_type::capella;
+    }
 };
 
 } // namespace test::utils

--- a/test/utils/wait_until.hxx
+++ b/test/utils/wait_until.hxx
@@ -61,7 +61,9 @@ wait_until_bucket_healthy(std::shared_ptr<couchbase::core::cluster> cluster, con
 bool
 wait_until_collection_manifest_propagated(std::shared_ptr<couchbase::core::cluster> cluster,
                                           const std::string& bucket_name,
-                                          const std::uint64_t current_manifest_uid);
+                                          const std::uint64_t current_manifest_uid,
+                                          std::size_t successful_rounds = 4,
+                                          std::chrono::seconds total_timeout = std::chrono::minutes{ 5 });
 bool
 wait_until_user_present(const std::shared_ptr<couchbase::core::cluster>& cluster, const std::string& username);
 


### PR DESCRIPTION
it contains improved setup scripts, as well as some test stability improvements, 
* better waiting for collections to be propagated (still not perfect, but closer), 
* cleanup of the collections (it behaves worse when tests leave a lot of the scopes and collections)
* skipping travel-sample for Capella
* avoid using non-portable index options for FTS
* improved test case naming in transactions