### PR TITLE
Add `is_cancelled()` method to `scan_result`

### DIFF
--- a/core/range_scan_orchestrator.cxx
+++ b/core/range_scan_orchestrator.cxx
@@ -442,6 +442,11 @@ class range_scan_orchestrator_impl
         }
     }
 
+    bool is_cancelled() override
+    {
+        return cancelled_;
+    }
+
     auto next() -> std::future<tl::expected<range_scan_item, std::error_code>> override
     {
         auto barrier = std::make_shared<std::promise<tl::expected<range_scan_item, std::error_code>>>();

--- a/core/scan_result.cxx
+++ b/core/scan_result.cxx
@@ -45,6 +45,11 @@ class scan_result_impl
         return iterator_->cancel();
     }
 
+    [[nodiscard]] auto is_cancelled() -> bool
+    {
+        return iterator_->is_cancelled();
+    }
+
   private:
     std::shared_ptr<range_scan_item_iterator> iterator_;
 };
@@ -70,5 +75,11 @@ void
 scan_result::cancel()
 {
     return impl_->cancel();
+}
+
+auto
+scan_result::is_cancelled() -> bool
+{
+    return impl_->is_cancelled();
 }
 } // namespace couchbase::core

--- a/core/scan_result.hxx
+++ b/core/scan_result.hxx
@@ -44,6 +44,7 @@ class range_scan_item_iterator
     virtual auto next() -> std::future<tl::expected<range_scan_item, std::error_code>> = 0;
     virtual void next(utils::movable_function<void(range_scan_item, std::error_code)> callback) = 0;
     virtual void cancel() = 0;
+    virtual bool is_cancelled() = 0;
 };
 
 class scan_result
@@ -53,6 +54,7 @@ class scan_result
     [[nodiscard]] auto next() const -> tl::expected<range_scan_item, std::error_code>;
     void next(utils::movable_function<void(range_scan_item, std::error_code)> callback) const;
     void cancel();
+    [[nodiscard]] auto is_cancelled() -> bool;
 
   private:
     std::shared_ptr<scan_result_impl> impl_{};


### PR DESCRIPTION
Added `is_cancelled()` method which is useful for some wrappers (e.g. Python). Included a test to verify that it works correctly