### PR TITLE
Return range_scan_completed if more items are requested after scan cancellation

### DIFF
--- a/test/test_integration_range_scan.cxx
+++ b/test/test_integration_range_scan.cxx
@@ -1195,10 +1195,13 @@ TEST_CASE("integration: manager prefix scan, get 10 items and cancel", "[integra
 
     REQUIRE(expected_id_count == entry_ids.size());
 
-    for (const auto& id : entry_ids) {
-        REQUIRE(std::find(ids.begin(), ids.end(), id) != ids.end());
+    for (const auto& entry_id : entry_ids) {
+        REQUIRE(std::count(ids.begin(), ids.end(), entry_id) == 0);
     }
 
+    auto next_item = result->next();
+    REQUIRE(!next_item.has_value());
+    REQUIRE(next_item.error() == couchbase::errc::key_value::range_scan_completed);
     REQUIRE(result->is_cancelled());
 }
 


### PR DESCRIPTION
Currently the behaviour when this happens is undefined. Return range_scan_completed if the scan is cancelled to indicate that no more results are going to be returned. Wrappers use range_scan_completed as a signal to end the result iteration