### PR TITLE
CXXCBC-340: Support query with read from replica

### DIFF
--- a/core/impl/query.cxx
+++ b/core/impl/query.cxx
@@ -161,6 +161,7 @@ build_query_request(std::string statement, query_options::built options)
         options.readonly,
         options.flex_index,
         options.preserve_expiry,
+        options.use_replica,
         options.max_parallelism,
         options.scan_cap,
         options.scan_wait,

--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -85,6 +85,17 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
         case couchbase::query_profile::off:
             break;
     }
+    if (use_replica.has_value()) {
+        if (context.config.supports_read_from_replica()) {
+            if (use_replica.value()) {
+                body["use_replica"] = "on";
+            } else {
+                body["use_replica"] = "off";
+            }
+        } else {
+            return errc::common::feature_not_available;
+        }
+    }
     if (max_parallelism) {
         body["max_parallelism"] = std::to_string(max_parallelism.value());
     }

--- a/core/operations/document_query.hxx
+++ b/core/operations/document_query.hxx
@@ -91,6 +91,7 @@ struct query_request {
     bool flex_index{ false };
     bool preserve_expiry{ false };
 
+    std::optional<bool> use_replica{};
     std::optional<std::uint64_t> max_parallelism{};
     std::optional<std::uint64_t> scan_cap{};
     std::optional<std::chrono::milliseconds> scan_wait{};

--- a/core/topology/capabilities.hxx
+++ b/core/topology/capabilities.hxx
@@ -39,5 +39,6 @@ enum class cluster_capability {
     n1ql_javascript_functions,
     n1ql_inline_functions,
     n1ql_enhanced_prepared_statements,
+    n1ql_read_from_replica,
 };
 } // namespace couchbase::core

--- a/core/topology/capabilities_fmt.hxx
+++ b/core/topology/capabilities_fmt.hxx
@@ -100,6 +100,8 @@ struct fmt::formatter<couchbase::core::cluster_capability> {
             case couchbase::core::cluster_capability::n1ql_enhanced_prepared_statements:
                 name = "n1ql_enhanced_prepared_statements";
                 break;
+            case couchbase::core::cluster_capability::n1ql_read_from_replica:
+                name = "n1ql_read_from_replica";
         }
         return format_to(ctx.out(), "{}", name);
     }

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -112,6 +112,11 @@ struct configuration {
         return cluster_capabilities.find(cluster_capability::n1ql_enhanced_prepared_statements) != cluster_capabilities.end();
     }
 
+    [[nodiscard]] bool supports_read_from_replica() const
+    {
+        return cluster_capabilities.find(cluster_capability::n1ql_read_from_replica) != cluster_capabilities.end();
+    }
+
     [[nodiscard]] bool ephemeral() const
     {
         // Use bucket capabilities to identify if couchapi is missing (then its ephemeral). If its null then

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -249,6 +249,8 @@ struct traits<couchbase::core::topology::configuration> {
                         result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_inline_functions);
                     } else if (name == "enhancedPreparedStatements") {
                         result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_enhanced_prepared_statements);
+                    } else if (name == "readFromReplica") {
+                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
                     }
                 }
             }

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -51,6 +51,7 @@ struct query_options : public common_options<query_options> {
         const bool readonly;
         const bool flex_index;
         const bool preserve_expiry;
+        std::optional<bool> use_replica;
         std::optional<std::uint64_t> max_parallelism;
         std::optional<std::uint64_t> scan_cap;
         std::optional<std::chrono::milliseconds> scan_wait;
@@ -84,6 +85,7 @@ struct query_options : public common_options<query_options> {
             readonly_,
             flex_index_,
             preserve_expiry_,
+            use_replica_,
             max_parallelism_,
             scan_cap_,
             scan_wait_,
@@ -222,6 +224,21 @@ struct query_options : public common_options<query_options> {
     auto preserve_expiry(bool preserve_expiry) -> query_options&
     {
         preserve_expiry_ = preserve_expiry;
+        return self();
+    }
+
+    /**
+     * Specifies that the query engine should use replica nodes for KV fetches if the active node is down.
+     *
+     * @param use_replica whether replica nodes should be used if the active node is down. If not provided, the server default will be used.
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto use_replica(bool use_replica) -> query_options&
+    {
+        use_replica_ = use_replica;
         return self();
     }
 
@@ -529,6 +546,7 @@ struct query_options : public common_options<query_options> {
     bool readonly_{ false };
     bool flex_index_{ false };
     bool preserve_expiry_{ false };
+    std::optional<bool> use_replica_{};
     std::optional<std::uint64_t> max_parallelism_{};
     std::optional<std::uint64_t> scan_cap_{};
     std::optional<std::uint64_t> pipeline_batch_{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ unit_test(jsonsl)
 unit_test(config_profiles)
 unit_test(options)
 unit_test(search)
+unit_test(query)
 target_link_libraries(test_unit_jsonsl jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_query.cxx
+++ b/test/test_unit_query.cxx
@@ -1,0 +1,75 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include "utils/move_only_context.hxx"
+
+#include "core/operations/document_query.hxx"
+
+couchbase::core::http_context
+make_http_context(couchbase::core::topology::configuration& config)
+{
+    static couchbase::core::query_cache query_cache{};
+    static couchbase::core::cluster_options cluster_options{};
+    std::string hostname{};
+    std::uint16_t port{};
+    couchbase::core::http_context ctx{ config, cluster_options, query_cache, hostname, port };
+    return ctx;
+}
+
+TEST_CASE("unit: query with read from replica", "[unit]")
+{
+    couchbase::core::topology::configuration config{};
+    config.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
+    auto ctx = make_http_context(config);
+
+    SECTION("use_replica true")
+    {
+        couchbase::core::io::http_request http_req;
+        couchbase::core::operations::query_request req{};
+        req.use_replica = true;
+        auto ec = req.encode_to(http_req, ctx);
+        REQUIRE_SUCCESS(ec);
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+        REQUIRE(body.is_object());
+        REQUIRE(body.get_object().at("use_replica").get_string() == "on");
+    }
+
+    SECTION("use_replica true")
+    {
+        couchbase::core::io::http_request http_req;
+        couchbase::core::operations::query_request req{};
+        req.use_replica = false;
+        auto ec = req.encode_to(http_req, ctx);
+        REQUIRE_SUCCESS(ec);
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+        REQUIRE(body.is_object());
+        REQUIRE(body.get_object().at("use_replica").get_string() == "off");
+    }
+
+    SECTION("use_replica not set")
+    {
+        couchbase::core::io::http_request http_req;
+        couchbase::core::operations::query_request req{};
+        auto ec = req.encode_to(http_req, ctx);
+        REQUIRE_SUCCESS(ec);
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+        REQUIRE(body.is_object());
+        REQUIRE_FALSE(body.get_object().count("use_replica"));
+    }
+}

--- a/test/test_unit_query.cxx
+++ b/test/test_unit_query.cxx
@@ -50,7 +50,7 @@ TEST_CASE("unit: query with read from replica", "[unit]")
         REQUIRE(body.get_object().at("use_replica").get_string() == "on");
     }
 
-    SECTION("use_replica true")
+    SECTION("use_replica false")
     {
         couchbase::core::io::http_request http_req;
         couchbase::core::operations::query_request req{};


### PR DESCRIPTION
* Added `use_replica` option for query in both core and public APIs as an optional boolean. If set, it is included in the query request body.
* Added `n1ql_read_from_replica` cluster capability which is checked when `use_replica` is set and a `feature_not_available` error code is returned if the capability is not present.