### PR TITLE
CXXCBC-348: Add range_scan bucket capability

### DIFF
--- a/core/topology/capabilities.hxx
+++ b/core/topology/capabilities.hxx
@@ -31,6 +31,7 @@ enum class bucket_capability {
     collections,
     durable_write,
     tombstoned_user_xattrs,
+    range_scan,
 };
 
 enum class cluster_capability {

--- a/core/topology/capabilities_fmt.hxx
+++ b/core/topology/capabilities_fmt.hxx
@@ -67,6 +67,9 @@ struct fmt::formatter<couchbase::core::bucket_capability> {
             case couchbase::core::bucket_capability::tombstoned_user_xattrs:
                 name = "tombstoned_user_xattrs";
                 break;
+            case couchbase::core::bucket_capability::range_scan:
+                name = "range_scan";
+                break;
         }
         return format_to(ctx.out(), "{}", name);
     }

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -117,6 +117,11 @@ struct configuration {
         return cluster_capabilities.find(cluster_capability::n1ql_read_from_replica) != cluster_capabilities.end();
     }
 
+    [[nodiscard]] bool supports_range_scan() const
+    {
+        return bucket_capabilities.find(bucket_capability::range_scan) != bucket_capabilities.end();
+    }
+
     [[nodiscard]] bool ephemeral() const
     {
         // Use bucket capabilities to identify if couchapi is missing (then its ephemeral). If its null then

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -233,6 +233,8 @@ struct traits<couchbase::core::topology::configuration> {
                     result.bucket_capabilities.insert(couchbase::core::bucket_capability::nodes_ext);
                 } else if (name == "xattr") {
                     result.bucket_capabilities.insert(couchbase::core::bucket_capability::xattr);
+                } else if (name == "rangeScan") {
+                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::range_scan);
                 }
             }
         }


### PR DESCRIPTION
Adding the ability to check whether range scan is supported so wrappers have the option of failing the operation before creating a range scan orchestrator