### PR TITLE
use preinstalled OpenSSL for github actions windows agent

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,9 +13,6 @@ jobs:
         os: [windows-2022, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install build environment
-        run: |
-          choco install --no-progress openssl
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -86,7 +86,7 @@ FileUtils.mkdir_p(BUILD_DIR, verbose: true)
 
 Dir.chdir(BUILD_DIR) do
   if RUBY_PLATFORM =~ /mswin|mingw/
-    CB_CMAKE_EXTRAS << "-DOPENSSL_ROOT_DIR=C:/Program Files/OpenSSL-Win64"
+    CB_CMAKE_EXTRAS << "-DOPENSSL_ROOT_DIR=C:/Program Files/OpenSSL"
   else
     CB_CMAKE_EXTRAS << "-DCMAKE_C_COMPILER=#{CB_CC}" << "-DCMAKE_CXX_COMPILER=#{CB_CXX}"
   end


### PR DESCRIPTION
I found what was the problem with openssl on windows at github actions was.  They updated agent which now has openssl preinstalled. And for some reason 'choco install openssl' there now install into that preinstalled directory (i believe that choco just delegates installation process to .exe installed, which in turn discovers previous installation and tries to update it), Anyway all we need to do is to stop using 'choco install' and update cmake command line to use new location.
