### PR TITLE
use fully qualified names to avoid conflicts in wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /cmake-build-report.tar.gz
 /.idea/workspace.xml
 /.idea/sonarlint
+/.cache
 /.vs
 /.vscode
 /CMakeSettings.json

--- a/couchbase/get_and_lock_options.hxx
+++ b/couchbase/get_and_lock_options.hxx
@@ -86,8 +86,8 @@ initiate_get_and_lock_operation(std::shared_ptr<couchbase::core::cluster> core,
                                 std::string collection_name,
                                 std::string document_key,
                                 std::chrono::seconds lock_duration,
-                                get_and_lock_options::built options,
-                                get_and_lock_handler&& handler);
+                                couchbase::get_and_lock_options::built options,
+                                couchbase::get_and_lock_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/get_and_touch_options.hxx
+++ b/couchbase/get_and_touch_options.hxx
@@ -86,8 +86,8 @@ initiate_get_and_touch_operation(std::shared_ptr<couchbase::core::cluster> core,
                                  std::string collection_name,
                                  std::string document_key,
                                  std::uint32_t expiry,
-                                 get_and_touch_options::built options,
-                                 get_and_touch_handler&& handler);
+                                 couchbase::get_and_touch_options::built options,
+                                 couchbase::get_and_touch_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/get_options.hxx
+++ b/couchbase/get_options.hxx
@@ -129,8 +129,8 @@ initiate_get_operation(std::shared_ptr<couchbase::core::cluster> core,
                        std::string scope_name,
                        std::string collection_name,
                        std::string document_key,
-                       get_options::built options,
-                       get_handler&& handler);
+                       couchbase::get_options::built options,
+                       couchbase::get_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/insert_options.hxx
+++ b/couchbase/insert_options.hxx
@@ -127,9 +127,9 @@ initiate_insert_operation(std::shared_ptr<couchbase::core::cluster> core,
                           std::string scope_name,
                           std::string collection_name,
                           std::string document_key,
-                          codec::encoded_value encoded,
-                          insert_options::built options,
-                          insert_handler&& handler);
+                          couchbase::codec::encoded_value encoded,
+                          couchbase::insert_options::built options,
+                          couchbase::insert_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/lookup_in_options.hxx
+++ b/couchbase/lookup_in_options.hxx
@@ -111,8 +111,8 @@ initiate_lookup_in_operation(std::shared_ptr<couchbase::core::cluster> core,
                              std::string collection_name,
                              std::string document_key,
                              const std::vector<couchbase::core::impl::subdoc::command>& specs,
-                             lookup_in_options::built options,
-                             lookup_in_handler&& handler);
+                             couchbase::lookup_in_options::built options,
+                             couchbase::lookup_in_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/mutate_in_options.hxx
+++ b/couchbase/mutate_in_options.hxx
@@ -225,8 +225,8 @@ initiate_mutate_in_operation(std::shared_ptr<couchbase::core::cluster> core,
                              std::string collection_name,
                              std::string document_key,
                              const std::vector<couchbase::core::impl::subdoc::command>& specs,
-                             mutate_in_options::built options,
-                             mutate_in_handler&& handler);
+                             couchbase::mutate_in_options::built options,
+                             couchbase::mutate_in_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/remove_options.hxx
+++ b/couchbase/remove_options.hxx
@@ -115,8 +115,8 @@ initiate_remove_operation(std::shared_ptr<couchbase::core::cluster> core,
                           std::string scope_name,
                           std::string collection_name,
                           std::string document_key,
-                          remove_options::built options,
-                          remove_handler&& handler);
+                          couchbase::remove_options::built options,
+                          couchbase::remove_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/replace_options.hxx
+++ b/couchbase/replace_options.hxx
@@ -175,9 +175,9 @@ initiate_replace_operation(std::shared_ptr<couchbase::core::cluster> core,
                            std::string scope_name,
                            std::string collection_name,
                            std::string document_key,
-                           codec::encoded_value encoded,
-                           replace_options::built options,
-                           replace_handler&& handler);
+                           couchbase::codec::encoded_value encoded,
+                           couchbase::replace_options::built options,
+                           couchbase::replace_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/touch_options.hxx
+++ b/couchbase/touch_options.hxx
@@ -86,8 +86,8 @@ initiate_touch_operation(std::shared_ptr<couchbase::core::cluster> core,
                          std::string collection_name,
                          std::string document_key,
                          std::uint32_t expiry,
-                         touch_options::built options,
-                         touch_handler&& handler);
+                         couchbase::touch_options::built options,
+                         couchbase::touch_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/unlock_options.hxx
+++ b/couchbase/unlock_options.hxx
@@ -89,8 +89,8 @@ initiate_unlock_operation(std::shared_ptr<couchbase::core::cluster> core,
                           std::string collection_name,
                           std::string document_key,
                           couchbase::cas cas,
-                          unlock_options::built options,
-                          unlock_handler&& handler);
+                          couchbase::unlock_options::built options,
+                          couchbase::unlock_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core

--- a/couchbase/upsert_options.hxx
+++ b/couchbase/upsert_options.hxx
@@ -149,9 +149,9 @@ initiate_upsert_operation(std::shared_ptr<couchbase::core::cluster> core,
                           std::string scope_name,
                           std::string collection_name,
                           std::string document_key,
-                          codec::encoded_value encoded,
-                          upsert_options::built options,
-                          upsert_handler&& handler);
+                          couchbase::codec::encoded_value encoded,
+                          couchbase::upsert_options::built options,
+                          couchbase::upsert_handler&& handler);
 #endif
 } // namespace impl
 } // namespace core


### PR DESCRIPTION
when wrapper includes both core and public API classes, some names might be sensitive to the order of the headers. In order to workaround this problem, use fully qualified names for the classes in the public headers