### PR TITLE
CXXCBC-365: lookup_in_any_replica not returning invalid arguments with too many specs

### DIFF
--- a/core/impl/lookup_in_any_replica.cxx
+++ b/core/impl/lookup_in_any_replica.cxx
@@ -63,6 +63,9 @@ initiate_lookup_in_any_replica_operation(std::shared_ptr<cluster> core,
           if (!config.supports_subdoc_read_replica()) {
               ec = errc::common::feature_not_available;
           }
+          if (r->specs().size() > 16) {
+              ec = errc::common::invalid_argument;
+          }
           if (ec) {
               std::optional<std::string> first_error_path{};
               std::optional<std::size_t> first_error_index{};

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -69,6 +69,9 @@ struct lookup_in_any_replica_request {
               if (!config.supports_subdoc_read_replica()) {
                   ec = errc::common::feature_not_available;
               }
+              if (specs.size() > 16) {
+                  ec = errc::common::invalid_argument;
+              }
 
               if (ec) {
                   std::optional<std::string> first_error_path{};


### PR DESCRIPTION
Changes: 

- Added a check to see if the spec count is above the maximum amount in core and public API for LookupInAnyReplica
- Added core and public API tests 