### PR TITLE
CXXCBC-119 Subdoc exists should return a true/false value rather than error

### DIFF
--- a/core/impl/lookup_in_all_replicas.cxx
+++ b/core/impl/lookup_in_all_replicas.cxx
@@ -113,6 +113,10 @@ initiate_lookup_in_all_replicas_operation(std::shared_ptr<cluster> core,
                                 lookup_in_entry.value = field.value;
                                 lookup_in_entry.exists = field.exists;
                                 lookup_in_entry.original_index = field.original_index;
+                                lookup_in_entry.ec = field.ec;
+                                if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
+                                    lookup_in_entry.ec.clear();
+                                }
                                 entries.emplace_back(lookup_in_entry);
                             }
                             ctx->result_.emplace_back(lookup_in_replica_result{ resp.cas, entries, resp.deleted, true /* replica */ });
@@ -155,6 +159,10 @@ initiate_lookup_in_all_replicas_operation(std::shared_ptr<cluster> core,
                           lookup_in_entry.value = field.value;
                           lookup_in_entry.exists = field.exists;
                           lookup_in_entry.original_index = field.original_index;
+                          lookup_in_entry.ec = field.ec;
+                          if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
+                              lookup_in_entry.ec.clear();
+                          }
                           entries.emplace_back(lookup_in_entry);
                       }
                       ctx->result_.emplace_back(lookup_in_replica_result{ resp.cas, entries, resp.deleted, false /* active */ });

--- a/core/impl/lookup_in_any_replica.cxx
+++ b/core/impl/lookup_in_any_replica.cxx
@@ -118,6 +118,11 @@ initiate_lookup_in_any_replica_operation(std::shared_ptr<cluster> core,
                                         entry.original_index = field.original_index;
                                         entry.exists = field.exists;
                                         entry.value = field.value;
+                                        entry.ec = field.ec;
+                                        if (field.opcode == protocol::subdoc_opcode::exists &&
+                                            field.ec == errc::key_value::path_not_found) {
+                                            entry.ec.clear();
+                                        }
                                         entries.emplace_back(entry);
                                     }
                                     return local_handler(std::move(resp.ctx),
@@ -156,6 +161,10 @@ initiate_lookup_in_any_replica_operation(std::shared_ptr<cluster> core,
                       entry.original_index = field.original_index;
                       entry.exists = field.exists;
                       entry.value = field.value;
+                      entry.ec = field.ec;
+                      if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
+                          entry.ec.clear();
+                      }
                       entries.emplace_back(entry);
                   }
                   return local_handler(std::move(resp.ctx),

--- a/core/operations/document_lookup_in.cxx
+++ b/core/operations/document_lookup_in.cxx
@@ -70,6 +70,9 @@ lookup_in_request::make_response(key_value_error_context&& ctx, const encoded_re
             fields[i].status = res_entry.status;
             fields[i].ec =
               protocol::map_status_code(protocol::client_opcode::subdoc_multi_mutation, static_cast<std::uint16_t>(res_entry.status));
+            if (fields[i].opcode == protocol::subdoc_opcode::exists && fields[i].ec == errc::key_value::path_not_found) {
+                fields[i].ec.clear();
+            }
             if (!fields[i].ec && !ctx.ec()) {
                 ec = fields[i].ec;
             }

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -127,6 +127,10 @@ struct lookup_in_all_replicas_request {
                                                 lookup_in_entry.exists = field.exists;
                                                 lookup_in_entry.original_index = field.original_index;
                                                 lookup_in_entry.opcode = field.opcode;
+                                                if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
+                                                    lookup_in_entry.ec == errc::key_value::path_not_found) {
+                                                    lookup_in_entry.ec.clear();
+                                                }
                                                 top_entry.fields.emplace_back(lookup_in_entry);
                                             }
                                             ctx->result_.emplace_back(lookup_in_all_replicas_response::entry{ top_entry });
@@ -169,6 +173,10 @@ struct lookup_in_all_replicas_request {
                               lookup_in_entry.exists = field.exists;
                               lookup_in_entry.original_index = field.original_index;
                               lookup_in_entry.opcode = field.opcode;
+                              if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
+                                  lookup_in_entry.ec == errc::key_value::path_not_found) {
+                                  lookup_in_entry.ec.clear();
+                              }
                               top_entry.fields.emplace_back(lookup_in_entry);
                           }
                           ctx->result_.emplace_back(lookup_in_all_replicas_response::entry{ top_entry });

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -133,6 +133,10 @@ struct lookup_in_any_replica_request {
                                             lookup_in_entry.exists = field.exists;
                                             lookup_in_entry.original_index = field.original_index;
                                             lookup_in_entry.opcode = field.opcode;
+                                            if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
+                                                lookup_in_entry.ec == errc::key_value::path_not_found) {
+                                                lookup_in_entry.ec.clear();
+                                            }
                                             res.fields.emplace_back(lookup_in_entry);
                                         }
                                         return local_handler(res);
@@ -173,6 +177,10 @@ struct lookup_in_any_replica_request {
                           lookup_in_entry.exists = field.exists;
                           lookup_in_entry.original_index = field.original_index;
                           lookup_in_entry.opcode = field.opcode;
+                          if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
+                              lookup_in_entry.ec == errc::key_value::path_not_found) {
+                              lookup_in_entry.ec.clear();
+                          }
                           res.fields.emplace_back(lookup_in_entry);
                       }
                       return local_handler(res);


### PR DESCRIPTION
Changes:

- Subdoc exists spec doesn't return an error, per the RFC
- Fixed bug with public API lookupInReplica not setting per-entry error code