### PR TITLE
CXXCBC-359: Reduce default HTTP idle timeout

### DIFF
--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -336,6 +336,13 @@ class cluster : public std::enable_shared_from_this<cluster>
     template<typename Handler>
     void do_open(Handler&& handler)
     {
+        // Warn users if idle_http_connection_timeout is too close to server idle timeouts
+        if (origin_.options().idle_http_connection_timeout > std::chrono::milliseconds(4'500)) {
+            CB_LOG_INFO("[{}]: The SDK may produce trivial warnings due to the idle HTTP connection timeout being set above the idle"
+                        "timeout of various services",
+                        id_);
+        }
+
         // Warn users if they attempt to use Capella without TLS being enabled.
         bool has_capella_host = false;
         {

--- a/core/timeout_defaults.hxx
+++ b/core/timeout_defaults.hxx
@@ -40,5 +40,5 @@ constexpr std::chrono::milliseconds tcp_keep_alive_interval{ 60'000 };
 constexpr std::chrono::milliseconds config_poll_interval{ 2'500 };
 constexpr std::chrono::milliseconds config_poll_floor{ 50 };
 constexpr std::chrono::milliseconds config_idle_redial_timeout{ 5 * 60'000 };
-constexpr std::chrono::milliseconds idle_http_connection_timeout{ 4'500 };
+constexpr std::chrono::milliseconds idle_http_connection_timeout{ 1'000 };
 } // namespace couchbase::core::timeout_defaults


### PR DESCRIPTION
Changes to be consistent with the latest RFC updates:
* Reducing the default value for `idle_http_connection_timeout` from 4.5s to 1s
* Producing an info-level logging message when `idle_http_connection_timeout` is more than 4.5s