### PR TITLE
CXXCBC-374: create_bucket does not return a BucketExists error when a duplicate bucket is created

### DIFF
--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -161,6 +161,9 @@ bucket_create_request::make_response(error_context::http&& ctx, const encoded_re
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
                     for (const auto& [code, message] : errors->get_object()) {
+                        if (message.get_string().find("Bucket with given name already exists") != std::string::npos) {
+                            response.ctx.ec = errc::management::bucket_exists;
+                        }
                         error_list.emplace_back(message.get_string());
                     }
                     if (!error_list.empty()) {

--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -160,9 +160,15 @@ bucket_create_request::make_response(error_context::http&& ctx, const encoded_re
                 auto* errors = payload.find("errors");
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
+                    bool error_overridden = false;
                     for (const auto& [code, message] : errors->get_object()) {
                         if (message.get_string().find("Bucket with given name already exists") != std::string::npos) {
                             response.ctx.ec = errc::management::bucket_exists;
+                            error_overridden = true;
+                        }
+                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos
+                            && !error_overridden) {
+                            response.ctx.ec = errc::common::feature_not_available;
                         }
                         error_list.emplace_back(message.get_string());
                     }

--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -160,15 +160,9 @@ bucket_create_request::make_response(error_context::http&& ctx, const encoded_re
                 auto* errors = payload.find("errors");
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
-                    bool error_overridden = false;
                     for (const auto& [code, message] : errors->get_object()) {
                         if (message.get_string().find("Bucket with given name already exists") != std::string::npos) {
                             response.ctx.ec = errc::management::bucket_exists;
-                            error_overridden = true;
-                        }
-                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos &&
-                            !error_overridden) {
-                            response.ctx.ec = errc::common::feature_not_available;
                         }
                         error_list.emplace_back(message.get_string());
                     }

--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -166,8 +166,8 @@ bucket_create_request::make_response(error_context::http&& ctx, const encoded_re
                             response.ctx.ec = errc::management::bucket_exists;
                             error_overridden = true;
                         }
-                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos
-                            && !error_overridden) {
+                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos &&
+                            !error_overridden) {
                             response.ctx.ec = errc::common::feature_not_available;
                         }
                         error_list.emplace_back(message.get_string());

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -120,9 +120,6 @@ bucket_update_request::make_response(error_context::http&& ctx, const encoded_re
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
                     for (const auto& [field, message] : errors->get_object()) {
-                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos) {
-                            response.ctx.ec = errc::common::feature_not_available;
-                        }
                         error_list.emplace_back(message.get_string());
                     }
                     if (!error_list.empty()) {

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -120,6 +120,9 @@ bucket_update_request::make_response(error_context::http&& ctx, const encoded_re
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
                     for (const auto& [field, message] : errors->get_object()) {
+                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos) {
+                            response.ctx.ec = errc::common::feature_not_available;
+                        }
                         error_list.emplace_back(message.get_string());
                     }
                     if (!error_list.empty()) {

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -109,6 +109,14 @@ TEST_CASE("integration: bucket management", "[integration]")
                 REQUIRE(bucket_settings.compression_mode == resp.bucket.compression_mode);
                 REQUIRE(bucket_settings.replica_indexes == resp.bucket.replica_indexes);
             }
+
+            {
+                couchbase::core::operations::management::bucket_create_request req;
+                req.bucket = bucket_settings;
+                auto resp = test::utils::execute(integration.cluster, req);
+                REQUIRE(resp.ctx.ec == couchbase::errc::management::bucket_exists);
+            }
+
             std::uint64_t old_quota_mb{ 0 };
             {
                 couchbase::core::operations::management::bucket_get_all_request req{};


### PR DESCRIPTION
Changes:

- Add check for bucket already exists message in create_bucket