### PR TITLE
Handle collection not found response in update_collection

### DIFF
--- a/core/operations/management/collection_update.cxx
+++ b/core/operations/management/collection_update.cxx
@@ -58,7 +58,10 @@ collection_update_request::make_response(error_context::http&& ctx, const encode
             } break;
             case 404: {
                 std::regex scope_not_found("Scope with name .+ is not found");
-                if (std::regex_search(encoded.body.data(), scope_not_found)) {
+                std::regex collection_not_found("Collection with name .+ is not found");
+                if (std::regex_search(encoded.body.data(), collection_not_found)) {
+                    response.ctx.ec = errc::common::collection_not_found;
+                } else if (std::regex_search(encoded.body.data(), scope_not_found)) {
                     response.ctx.ec = errc::common::scope_not_found;
                 } else {
                     response.ctx.ec = errc::common::bucket_not_found;


### PR DESCRIPTION
In `update_collection`, convert `collection with name ... not found` response to a `collection_not_found`  error code, similar to `bucket_not_found` and `scope_not_found`