### PR TITLE
CXXCBC-376 Create and Update bucket sending unnecessary fields to server

### DIFF
--- a/core/impl/get_all_buckets.cxx
+++ b/core/impl/get_all_buckets.cxx
@@ -52,14 +52,26 @@ map_bucket_settings(const couchbase::core::management::cluster::bucket_settings&
     couchbase::management::cluster::bucket_settings bucket_settings{};
     bucket_settings.name = bucket.name;
     bucket_settings.ram_quota_mb = bucket.ram_quota_mb;
-    bucket_settings.max_expiry = bucket.max_expiry;
     bucket_settings.minimum_durability_level = bucket.minimum_durability_level;
-    bucket_settings.num_replicas = bucket.num_replicas;
-    bucket_settings.replica_indexes = bucket.replica_indexes;
-    bucket_settings.flush_enabled = bucket.flush_enabled;
     bucket_settings.history_retention_collection_default = bucket.history_retention_collection_default;
-    bucket_settings.history_retention_bytes = bucket.history_retention_bytes;
-    bucket_settings.history_retention_duration = bucket.history_retention_duration;
+    if (bucket.max_expiry.has_value()) {
+        bucket_settings.max_expiry = bucket.max_expiry.value();
+    }
+    if (bucket.num_replicas.has_value()) {
+        bucket_settings.num_replicas = bucket.num_replicas.value();
+    }
+    if (bucket.replica_indexes.has_value()) {
+        bucket_settings.replica_indexes = bucket.replica_indexes.value();
+    }
+    if (bucket.flush_enabled.has_value()) {
+        bucket_settings.flush_enabled = bucket.flush_enabled.value();
+    }
+    if (bucket.history_retention_bytes.has_value()) {
+        bucket_settings.history_retention_bytes = bucket.history_retention_bytes.value();
+    }
+    if (bucket.history_retention_duration.has_value()) {
+        bucket_settings.history_retention_duration = bucket.history_retention_duration.value();
+    }
     switch (bucket.conflict_resolution_type) {
         case core::management::cluster::bucket_conflict_resolution::unknown:
             bucket_settings.conflict_resolution_type = management::cluster::bucket_conflict_resolution::unknown;

--- a/core/impl/get_bucket.cxx
+++ b/core/impl/get_bucket.cxx
@@ -52,14 +52,26 @@ map_bucket_settings(const couchbase::core::management::cluster::bucket_settings&
     couchbase::management::cluster::bucket_settings bucket_settings{};
     bucket_settings.name = bucket.name;
     bucket_settings.ram_quota_mb = bucket.ram_quota_mb;
-    bucket_settings.max_expiry = bucket.max_expiry;
     bucket_settings.minimum_durability_level = bucket.minimum_durability_level;
-    bucket_settings.num_replicas = bucket.num_replicas;
-    bucket_settings.replica_indexes = bucket.replica_indexes;
-    bucket_settings.flush_enabled = bucket.flush_enabled;
     bucket_settings.history_retention_collection_default = bucket.history_retention_collection_default;
-    bucket_settings.history_retention_bytes = bucket.history_retention_bytes;
-    bucket_settings.history_retention_duration = bucket.history_retention_duration;
+    if (bucket.max_expiry.has_value()) {
+        bucket_settings.max_expiry = bucket.max_expiry.value();
+    }
+    if (bucket.num_replicas.has_value()) {
+        bucket_settings.num_replicas = bucket.num_replicas.value();
+    }
+    if (bucket.replica_indexes.has_value()) {
+        bucket_settings.replica_indexes = bucket.replica_indexes.value();
+    }
+    if (bucket.flush_enabled.has_value()) {
+        bucket_settings.flush_enabled = bucket.flush_enabled.value();
+    }
+    if (bucket.history_retention_bytes.has_value()) {
+        bucket_settings.history_retention_bytes = bucket.history_retention_bytes.value();
+    }
+    if (bucket.history_retention_duration.has_value()) {
+        bucket_settings.history_retention_duration = bucket.history_retention_duration.value();
+    }
     switch (bucket.conflict_resolution_type) {
         case core::management::cluster::bucket_conflict_resolution::unknown:
             bucket_settings.conflict_resolution_type = management::cluster::bucket_conflict_resolution::unknown;

--- a/core/management/bucket_settings.hxx
+++ b/core/management/bucket_settings.hxx
@@ -105,19 +105,19 @@ struct bucket_settings {
 
     std::string name;
     std::string uuid;
+    std::uint64_t ram_quota_mb{ 0 }; // If not explicitly set, defaults to 100 on create_bucket, unset on update_bucket
     cluster::bucket_type bucket_type{ cluster::bucket_type::unknown };
-    std::uint64_t ram_quota_mb{ 100 };
-    std::uint32_t max_expiry{ 0 };
+    std::optional<std::uint32_t> max_expiry{};
     bucket_compression compression_mode{ bucket_compression::unknown };
     std::optional<couchbase::durability_level> minimum_durability_level{};
-    std::uint32_t num_replicas{ 1 };
-    bool replica_indexes{ false };
-    bool flush_enabled{ false };
+    std::optional<std::uint32_t> num_replicas{};
+    std::optional<bool> replica_indexes{};
+    std::optional<bool> flush_enabled{};
     bucket_eviction_policy eviction_policy{ bucket_eviction_policy::unknown };
     bucket_conflict_resolution conflict_resolution_type{ bucket_conflict_resolution::unknown };
     std::optional<bool> history_retention_collection_default{};
-    std::uint32_t history_retention_bytes{ 0 };
-    std::uint32_t history_retention_duration{ 0 };
+    std::optional<std::uint32_t> history_retention_bytes;
+    std::optional<std::uint32_t> history_retention_duration{};
 
     /**
      * UNCOMMITTED: This API may change in the future

--- a/core/management/bucket_settings_json.hxx
+++ b/core/management/bucket_settings_json.hxx
@@ -33,20 +33,20 @@ struct traits<couchbase::core::management::cluster::bucket_settings> {
         result.uuid = v.at("uuid").get_string();
         const static std::uint64_t megabyte = 1024LLU * 1024LLU;
         result.ram_quota_mb = v.at("quota").at("rawRAM").get_unsigned() / megabyte;
-        result.num_replicas = v.at("replicaNumber").template as<std::uint32_t>();
+        result.num_replicas = v.at("replicaNumber").template as<std::optional<std::uint32_t>>();
 
         if (auto* max_ttl = v.find("maxTTL"); max_ttl != nullptr) {
-            result.max_expiry = max_ttl->template as<std::uint32_t>();
+            result.max_expiry = max_ttl->template as<std::optional<std::uint32_t>>();
         }
 
         if (auto* history_retention_default = v.find("historyRetentionCollectionDefault"); history_retention_default != nullptr) {
             result.history_retention_collection_default = history_retention_default->template as<std::optional<bool>>();
         }
         if (auto* history_retention_bytes = v.find("historyRetentionBytes"); history_retention_bytes != nullptr) {
-            result.history_retention_bytes = history_retention_bytes->template as<std::uint32_t>();
+            result.history_retention_bytes = history_retention_bytes->template as<std::optional<std::uint32_t>>();
         }
         if (auto* history_retention_duration = v.find("historyRetentionSeconds"); history_retention_duration != nullptr) {
-            result.history_retention_duration = history_retention_duration->template as<std::uint32_t>();
+            result.history_retention_duration = history_retention_duration->template as<std::optional<std::uint32_t>>();
         }
 
         if (auto& str = v.at("bucketType").get_string(); str == "couchbase" || str == "membase") {

--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -168,15 +168,9 @@ bucket_create_request::make_response(error_context::http&& ctx, const encoded_re
                 auto* errors = payload.find("errors");
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
-                    bool error_overridden = false;
                     for (const auto& [code, message] : errors->get_object()) {
                         if (message.get_string().find("Bucket with given name already exists") != std::string::npos) {
                             response.ctx.ec = errc::management::bucket_exists;
-                            error_overridden = true;
-                        }
-                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos &&
-                            !error_overridden) {
-                            response.ctx.ec = errc::common::feature_not_available;
                         }
                         error_list.emplace_back(message.get_string());
                     }

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -33,23 +33,34 @@ bucket_update_request::encode_to(encoded_request_type& encoded, http_context& /*
     encoded.path = fmt::format("/pools/default/buckets/{}", bucket.name);
 
     encoded.headers["content-type"] = "application/x-www-form-urlencoded";
-    encoded.body.append(fmt::format("&ramQuotaMB={}", bucket.ram_quota_mb));
-    encoded.body.append(fmt::format("&replicaNumber={}", bucket.num_replicas));
-    if (bucket.max_expiry > 0) {
-        encoded.body.append(fmt::format("&maxTTL={}", bucket.max_expiry));
+
+    if (bucket.ram_quota_mb > 0) {
+        encoded.body.append(fmt::format("&ramQuotaMB={}", bucket.ram_quota_mb));
+    }
+    if (bucket.num_replicas.has_value()) {
+        encoded.body.append(fmt::format("&replicaNumber={}", bucket.num_replicas.value()));
+    }
+
+    if (bucket.max_expiry.has_value()) {
+        encoded.body.append(fmt::format("&maxTTL={}", bucket.max_expiry.value()));
     }
     if (bucket.history_retention_collection_default.has_value()) {
         encoded.body.append(
           fmt::format("&historyRetentionCollectionDefault={}", bucket.history_retention_collection_default.value() ? "true" : "false"));
     }
-    if (bucket.history_retention_bytes > 0) {
-        encoded.body.append(fmt::format("&historyRetentionBytes={}", bucket.history_retention_bytes));
+    if (bucket.history_retention_bytes.has_value()) {
+        encoded.body.append(fmt::format("&historyRetentionBytes={}", bucket.history_retention_bytes.value()));
     }
-    if (bucket.history_retention_duration > 0) {
-        encoded.body.append(fmt::format("&historyRetentionSeconds={}", bucket.history_retention_duration));
+    if (bucket.history_retention_duration.has_value()) {
+        encoded.body.append(fmt::format("&historyRetentionSeconds={}", bucket.history_retention_duration.value()));
     }
-    encoded.body.append(fmt::format("&replicaIndex={}", bucket.replica_indexes ? "1" : "0"));
-    encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled ? "1" : "0"));
+    if (bucket.replica_indexes.has_value()) {
+        encoded.body.append(fmt::format("&replicaIndex={}", bucket.replica_indexes.value() ? "1" : "0"));
+    }
+    if (bucket.flush_enabled.has_value()) {
+        encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled.value() ? "1" : "0"));
+    }
+
     switch (bucket.eviction_policy) {
         case couchbase::core::management::cluster::bucket_eviction_policy::full:
             encoded.body.append("&evictionPolicy=fullEviction");
@@ -120,6 +131,9 @@ bucket_update_request::make_response(error_context::http&& ctx, const encoded_re
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
                     for (const auto& [field, message] : errors->get_object()) {
+                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos) {
+                            response.ctx.ec = errc::common::feature_not_available;
+                        }
                         error_list.emplace_back(message.get_string());
                     }
                     if (!error_list.empty()) {

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -131,9 +131,6 @@ bucket_update_request::make_response(error_context::http&& ctx, const encoded_re
                 if (errors != nullptr) {
                     std::vector<std::string> error_list{};
                     for (const auto& [field, message] : errors->get_object()) {
-                        if (message.get_string().find("History Retention can only used with Magma") != std::string::npos) {
-                            response.ctx.ec = errc::common::feature_not_available;
-                        }
                         error_list.emplace_back(message.get_string());
                     }
                     if (!error_list.empty()) {

--- a/couchbase/management/bucket_settings.hxx
+++ b/couchbase/management/bucket_settings.hxx
@@ -98,7 +98,7 @@ struct bucket_settings {
 
     std::string name;
     cluster::bucket_type bucket_type{ cluster::bucket_type::unknown };
-    std::uint64_t ram_quota_mb{ 100 };
+    std::uint64_t ram_quota_mb{ 0 };
     std::optional<std::uint32_t> max_expiry{};
     bucket_compression compression_mode{ bucket_compression::unknown };
     std::optional<couchbase::durability_level> minimum_durability_level{};

--- a/couchbase/management/bucket_settings.hxx
+++ b/couchbase/management/bucket_settings.hxx
@@ -99,17 +99,17 @@ struct bucket_settings {
     std::string name;
     cluster::bucket_type bucket_type{ cluster::bucket_type::unknown };
     std::uint64_t ram_quota_mb{ 100 };
-    std::uint32_t max_expiry{ 0 };
+    std::optional<std::uint32_t> max_expiry{};
     bucket_compression compression_mode{ bucket_compression::unknown };
     std::optional<couchbase::durability_level> minimum_durability_level{};
-    std::uint32_t num_replicas{ 1 };
-    bool replica_indexes{ false };
-    bool flush_enabled{ false };
+    std::optional<std::uint32_t> num_replicas{};
+    std::optional<bool> replica_indexes{};
+    std::optional<bool> flush_enabled{};
     bucket_eviction_policy eviction_policy{ bucket_eviction_policy::unknown };
     bucket_conflict_resolution conflict_resolution_type{ bucket_conflict_resolution::unknown };
     std::optional<bool> history_retention_collection_default{};
-    std::uint32_t history_retention_bytes{ 0 };
-    std::uint32_t history_retention_duration{ 0 };
+    std::optional<std::uint32_t> history_retention_bytes;
+    std::optional<std::uint32_t> history_retention_duration{};
 
     /**
      * UNCOMMITTED: This API may change in the future


### PR DESCRIPTION
Changes: 

- Change BucketSettings unrequired fields to be optional
- Update request encoding logic so the SDK doesn't send the fields unless they are specified