### PR TITLE
CXXCBC-119: Set value of subdoc exists to "true" or "false" if result is success or path-not-found

### DIFF
--- a/core/impl/lookup_in_all_replicas.cxx
+++ b/core/impl/lookup_in_all_replicas.cxx
@@ -114,9 +114,6 @@ initiate_lookup_in_all_replicas_operation(std::shared_ptr<cluster> core,
                                 lookup_in_entry.exists = field.exists;
                                 lookup_in_entry.original_index = field.original_index;
                                 lookup_in_entry.ec = field.ec;
-                                if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
-                                    lookup_in_entry.ec.clear();
-                                }
                                 entries.emplace_back(lookup_in_entry);
                             }
                             ctx->result_.emplace_back(lookup_in_replica_result{ resp.cas, entries, resp.deleted, true /* replica */ });
@@ -160,9 +157,6 @@ initiate_lookup_in_all_replicas_operation(std::shared_ptr<cluster> core,
                           lookup_in_entry.exists = field.exists;
                           lookup_in_entry.original_index = field.original_index;
                           lookup_in_entry.ec = field.ec;
-                          if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
-                              lookup_in_entry.ec.clear();
-                          }
                           entries.emplace_back(lookup_in_entry);
                       }
                       ctx->result_.emplace_back(lookup_in_replica_result{ resp.cas, entries, resp.deleted, false /* active */ });

--- a/core/impl/lookup_in_any_replica.cxx
+++ b/core/impl/lookup_in_any_replica.cxx
@@ -119,10 +119,6 @@ initiate_lookup_in_any_replica_operation(std::shared_ptr<cluster> core,
                                         entry.exists = field.exists;
                                         entry.value = field.value;
                                         entry.ec = field.ec;
-                                        if (field.opcode == protocol::subdoc_opcode::exists &&
-                                            field.ec == errc::key_value::path_not_found) {
-                                            entry.ec.clear();
-                                        }
                                         entries.emplace_back(entry);
                                     }
                                     return local_handler(std::move(resp.ctx),
@@ -162,9 +158,6 @@ initiate_lookup_in_any_replica_operation(std::shared_ptr<cluster> core,
                       entry.exists = field.exists;
                       entry.value = field.value;
                       entry.ec = field.ec;
-                      if (field.opcode == protocol::subdoc_opcode::exists && field.ec == errc::key_value::path_not_found) {
-                          entry.ec.clear();
-                      }
                       entries.emplace_back(entry);
                   }
                   return local_handler(std::move(resp.ctx),

--- a/core/operations/document_lookup_in.cxx
+++ b/core/operations/document_lookup_in.cxx
@@ -82,7 +82,11 @@ lookup_in_request::make_response(key_value_error_context&& ctx, const encoded_re
             }
             fields[i].exists =
               res_entry.status == key_value_status_code::success || res_entry.status == key_value_status_code::subdoc_success_deleted;
-            fields[i].value = utils::to_binary(res_entry.value);
+            if (fields[i].opcode == protocol::subdoc_opcode::exists && !fields[i].ec) {
+                fields[i].value = utils::json::generate_binary(fields[i].exists);
+            } else {
+                fields[i].value = utils::to_binary(res_entry.value);
+            }
         }
         if (!ec) {
             cas = encoded.cas();

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -127,10 +127,6 @@ struct lookup_in_all_replicas_request {
                                                 lookup_in_entry.exists = field.exists;
                                                 lookup_in_entry.original_index = field.original_index;
                                                 lookup_in_entry.opcode = field.opcode;
-                                                if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
-                                                    lookup_in_entry.ec == errc::key_value::path_not_found) {
-                                                    lookup_in_entry.ec.clear();
-                                                }
                                                 top_entry.fields.emplace_back(lookup_in_entry);
                                             }
                                             ctx->result_.emplace_back(lookup_in_all_replicas_response::entry{ top_entry });
@@ -173,10 +169,6 @@ struct lookup_in_all_replicas_request {
                               lookup_in_entry.exists = field.exists;
                               lookup_in_entry.original_index = field.original_index;
                               lookup_in_entry.opcode = field.opcode;
-                              if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
-                                  lookup_in_entry.ec == errc::key_value::path_not_found) {
-                                  lookup_in_entry.ec.clear();
-                              }
                               top_entry.fields.emplace_back(lookup_in_entry);
                           }
                           ctx->result_.emplace_back(lookup_in_all_replicas_response::entry{ top_entry });

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -133,10 +133,6 @@ struct lookup_in_any_replica_request {
                                             lookup_in_entry.exists = field.exists;
                                             lookup_in_entry.original_index = field.original_index;
                                             lookup_in_entry.opcode = field.opcode;
-                                            if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
-                                                lookup_in_entry.ec == errc::key_value::path_not_found) {
-                                                lookup_in_entry.ec.clear();
-                                            }
                                             res.fields.emplace_back(lookup_in_entry);
                                         }
                                         return local_handler(res);
@@ -177,10 +173,6 @@ struct lookup_in_any_replica_request {
                           lookup_in_entry.exists = field.exists;
                           lookup_in_entry.original_index = field.original_index;
                           lookup_in_entry.opcode = field.opcode;
-                          if (lookup_in_entry.opcode == protocol::subdoc_opcode::exists &&
-                              lookup_in_entry.ec == errc::key_value::path_not_found) {
-                              lookup_in_entry.ec.clear();
-                          }
                           res.fields.emplace_back(lookup_in_entry);
                       }
                       return local_handler(res);


### PR DESCRIPTION
## Motivation
Path not found errors were cleared in #444. In addition to that, the value of the spec result should be set to the JSON representation of the exists field if the result was success or path-not-found. Relevant section of the RFC:

> If the result came from an `exists` lookup, calls Exists to get a boolean, and uses the JSON representation of that boolean as the "value" in the next step. Propagates any exceptions thrown by `Exists`.

## Changes

* Set value to the JSON encoding of the `exists` boolean for `exists` spec results
* Clear the `path_not_found` error in `lookup_in_replica_request::make_response`, to avoid having to duplicate the logic for `lookup_in_any_replica` and `lookup_in_all_replicas`. Remove the checks for a `path_not_found` error code everywhere that's no longer necessary because of this change.
* Update the tests to reflect the change in the value of an `exists` subdoc result


## Example

```cpp
const std::string document_id{ "minimal_example" };
const tao::json::value basic_doc{
    { "a", 1.0 },
    { "b", 2.0 },
};
collection.upsert(document_id, basic_doc).get();

auto specs = couchbase::lookup_in_specs{
    couchbase::lookup_in_specs::exists("a"),
    couchbase::lookup_in_specs::exists("c")
};
auto [ctx, resp] = collection.lookup_in("minimal_example", specs).get();
std::cout << "Spec 0 - content (as bool): " << resp.content_as<bool>(0) << ", exists: " << resp.exists(0) << "\n";
std::cout << "Spec 1 - content (as bool): " << resp.content_as<bool>(1) << ", exists: " << resp.exists(1) << "\n";
```
will output

```
Spec 0 - content (as bool): 1, exists: 1
Spec 1 - content (as bool): 0, exists: 0
```