### PR TITLE
CXXCBC-383: Map `subdoc_doc_too_deep` KV status to `path_too_deep` error code

### DIFF
--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -129,7 +129,7 @@ map_status_code(protocol::client_opcode opcode, std::uint16_t status)
             return errc::key_value::path_too_big;
 
         case key_value_status_code::subdoc_doc_too_deep:
-            return errc::key_value::value_too_deep;
+            return errc::key_value::path_too_deep;
 
         case key_value_status_code::subdoc_value_cannot_insert:
             return errc::key_value::value_invalid;


### PR DESCRIPTION
From the RFC:
> [117 PathTooDeep](https://github.com/couchbaselabs/sdk-rfcs/blob/master/rfc/0058-error-handling.md#117-pathtoodeep)
Raised When
The document contains too many levels to parse.
KV Code 0xc4