### PR TITLE
CXXCBC-387: Optimising tags for noop_tracer

### DIFF
--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -74,8 +74,8 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
         if (span_ == nullptr) {
             return;
         }
-        span_->add_tag(tracing::attributes::remote_socket, remote_address);
-        span_->add_tag(tracing::attributes::local_socket, local_address);
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::remote_socket, remote_address);
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_socket, local_address);
         span_->end();
         span_ = nullptr;
     }
@@ -83,8 +83,8 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
     void start(http_command_handler&& handler)
     {
         span_ = tracer_->start_span(tracing::span_name_for_http_service(request.type), parent_span);
-        span_->add_tag(tracing::attributes::service, tracing::service_name_for_http_service(request.type));
-        span_->add_tag(tracing::attributes::operation_id, client_context_id_);
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::service, tracing::service_name_for_http_service(request.type));
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::operation_id, client_context_id_);
         handler_ = std::move(handler);
         deadline.expires_after(timeout_);
         deadline.async_wait([self = this->shared_from_this()](std::error_code ec) {
@@ -123,7 +123,7 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
             return;
         }
         session_ = std::move(session);
-        span_->add_tag(tracing::attributes::local_id, session_->id());
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_id, session_->id());
         send();
     }
 

--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -74,8 +74,10 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
         if (span_ == nullptr) {
             return;
         }
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::remote_socket, remote_address);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_socket, local_address);
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::remote_socket, remote_address);
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::local_socket, local_address);
         span_->end();
         span_ = nullptr;
     }
@@ -83,8 +85,10 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
     void start(http_command_handler&& handler)
     {
         span_ = tracer_->start_span(tracing::span_name_for_http_service(request.type), parent_span);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::service, tracing::service_name_for_http_service(request.type));
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::operation_id, client_context_id_);
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::service, tracing::service_name_for_http_service(request.type));
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::operation_id, client_context_id_);
         handler_ = std::move(handler);
         deadline.expires_after(timeout_);
         deadline.async_wait([self = this->shared_from_this()](std::error_code ec) {
@@ -123,7 +127,8 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
             return;
         }
         session_ = std::move(session);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_id, session_->id());
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::local_id, session_->id());
         send();
     }
 

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -93,8 +93,10 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     void start(mcbp_command_handler&& handler)
     {
         span_ = manager_->tracer()->start_span(tracing::span_name_for_mcbp_command(encoded_request_type::body_type::opcode), parent_span);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::service, tracing::service::key_value);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::instance, request.id.bucket());
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::service, tracing::service::key_value);
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::instance, request.id.bucket());
 
         handler_ = std::move(handler);
         deadline.expires_after(timeout_);
@@ -199,7 +201,8 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     {
         opaque_ = session_->next_opaque();
         request.opaque = *opaque_;
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::operation_id, fmt::format("0x{:x}", request.opaque));
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::operation_id, fmt::format("0x{:x}", request.opaque));
         if (request.id.use_collections() && !request.id.is_collection_resolved()) {
             if (session_->supports_feature(protocol::hello_feature::collections)) {
                 auto collection_id = session_->get_collection_uid(request.id.collection_path());
@@ -249,13 +252,15 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
 
               self->retry_backoff.cancel();
               if (ec == asio::error::operation_aborted) {
-                  if (self->span_->uses_tags()) self->span_->add_tag(tracing::attributes::orphan, "aborted");
+                  if (self->span_->uses_tags())
+                      self->span_->add_tag(tracing::attributes::orphan, "aborted");
                   return self->invoke_handler(make_error_code(self->request.retries.idempotent() ? errc::common::unambiguous_timeout
                                                                                                  : errc::common::ambiguous_timeout));
               }
               if (ec == errc::common::request_canceled) {
                   if (reason == retry_reason::do_not_retry) {
-                      if (self->span_->uses_tags()) self->span_->add_tag(tracing::attributes::orphan, "canceled");
+                      if (self->span_->uses_tags())
+                          self->span_->add_tag(tracing::attributes::orphan, "canceled");
                       return self->invoke_handler(ec);
                   }
                   return io::retry_orchestrator::maybe_retry(self->manager_, self, reason, ec);
@@ -314,9 +319,12 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
             return;
         }
         session_ = std::move(session);
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::remote_socket, session_->remote_address());
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_socket, session_->local_address());
-        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_id, session_->id());
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::remote_socket, session_->remote_address());
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::local_socket, session_->local_address());
+        if (span_->uses_tags())
+            span_->add_tag(tracing::attributes::local_id, session_->id());
         send();
     }
 };

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -93,8 +93,8 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     void start(mcbp_command_handler&& handler)
     {
         span_ = manager_->tracer()->start_span(tracing::span_name_for_mcbp_command(encoded_request_type::body_type::opcode), parent_span);
-        span_->add_tag(tracing::attributes::service, tracing::service::key_value);
-        span_->add_tag(tracing::attributes::instance, request.id.bucket());
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::service, tracing::service::key_value);
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::instance, request.id.bucket());
 
         handler_ = std::move(handler);
         deadline.expires_after(timeout_);
@@ -199,7 +199,7 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     {
         opaque_ = session_->next_opaque();
         request.opaque = *opaque_;
-        span_->add_tag(tracing::attributes::operation_id, fmt::format("0x{:x}", request.opaque));
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::operation_id, fmt::format("0x{:x}", request.opaque));
         if (request.id.use_collections() && !request.id.is_collection_resolved()) {
             if (session_->supports_feature(protocol::hello_feature::collections)) {
                 auto collection_id = session_->get_collection_uid(request.id.collection_path());
@@ -249,13 +249,13 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
 
               self->retry_backoff.cancel();
               if (ec == asio::error::operation_aborted) {
-                  self->span_->add_tag(tracing::attributes::orphan, "aborted");
+                  if (self->span_->uses_tags()) self->span_->add_tag(tracing::attributes::orphan, "aborted");
                   return self->invoke_handler(make_error_code(self->request.retries.idempotent() ? errc::common::unambiguous_timeout
                                                                                                  : errc::common::ambiguous_timeout));
               }
               if (ec == errc::common::request_canceled) {
                   if (reason == retry_reason::do_not_retry) {
-                      self->span_->add_tag(tracing::attributes::orphan, "canceled");
+                      if (self->span_->uses_tags()) self->span_->add_tag(tracing::attributes::orphan, "canceled");
                       return self->invoke_handler(ec);
                   }
                   return io::retry_orchestrator::maybe_retry(self->manager_, self, reason, ec);
@@ -314,9 +314,9 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
             return;
         }
         session_ = std::move(session);
-        span_->add_tag(tracing::attributes::remote_socket, session_->remote_address());
-        span_->add_tag(tracing::attributes::local_socket, session_->local_address());
-        span_->add_tag(tracing::attributes::local_id, session_->id());
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::remote_socket, session_->remote_address());
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_socket, session_->local_address());
+        if (span_->uses_tags()) span_->add_tag(tracing::attributes::local_id, session_->id());
         send();
     }
 };

--- a/core/tracing/noop_tracer.hxx
+++ b/core/tracing/noop_tracer.hxx
@@ -38,6 +38,11 @@ class noop_span : public couchbase::tracing::request_span
     {
         /* do nothing */
     }
+
+    virtual bool uses_tags() const
+    {
+        return false;
+    }
 };
 
 class noop_tracer : public couchbase::tracing::request_tracer

--- a/core/tracing/noop_tracer.hxx
+++ b/core/tracing/noop_tracer.hxx
@@ -39,7 +39,7 @@ class noop_span : public couchbase::tracing::request_span
         /* do nothing */
     }
 
-    virtual bool uses_tags() const
+    bool uses_tags() const override
     {
         return false;
     }

--- a/couchbase/tracing/request_span.hxx
+++ b/couchbase/tracing/request_span.hxx
@@ -56,6 +56,11 @@ class request_span
         return parent_;
     }
 
+    virtual bool uses_tags() const
+    {
+        return true;
+    }
+
   private:
     std::string name_{};
     std::shared_ptr<request_span> parent_{ nullptr };


### PR DESCRIPTION
Profiling indicates that non-trivial time is spent assigning tags to spans, which is wasted effort if noop_tracer is being used.

Borrowing an optimisation from the JVM SDKs, where we skip this assignment in this case.

This optimisation, together with another small one that will be submitted separately, produced around a 15% performance improvement.

Downside: this does have to touch the public request_span API.