### PR TITLE
CXXCBC-387: Cache formatted mbcp_session endpoints

### DIFF
--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -665,18 +665,12 @@ class mcbp_session_impl
 
     std::string remote_address() const
     {
-        if (endpoint_.protocol() == asio::ip::tcp::v6()) {
-            return fmt::format("[{}]:{}", endpoint_address_, endpoint_.port());
-        }
-        return fmt::format("{}:{}", endpoint_address_, endpoint_.port());
+        return endpoint_address_;
     }
 
     std::string local_address() const
     {
-        if (endpoint_.protocol() == asio::ip::tcp::v6()) {
-            return fmt::format("[{}]:{}", local_endpoint_address_, local_endpoint_.port());
-        }
-        return fmt::format("{}:{}", local_endpoint_address_, local_endpoint_.port());
+        return local_endpoint_address_;
     }
 
     [[nodiscard]] diag::endpoint_diag_info diag_info() const
@@ -1327,9 +1321,19 @@ class mcbp_session_impl
         } else {
             stream_->set_options();
             local_endpoint_ = stream_->local_endpoint();
-            local_endpoint_address_ = local_endpoint_.address().to_string();
+            if (endpoint_.protocol() == asio::ip::tcp::v6()) {
+                local_endpoint_address_ = fmt::format("[{}]:{}", local_endpoint_.address().to_string(), local_endpoint_.port());
+            }
+            else {
+                local_endpoint_address_ = fmt::format("{}:{}", local_endpoint_.address().to_string(), local_endpoint_.port());
+            }
             endpoint_ = it->endpoint();
-            endpoint_address_ = endpoint_.address().to_string();
+            if (endpoint_.protocol() == asio::ip::tcp::v6()) {
+                endpoint_address_ = fmt::format("[{}]:{}", endpoint_.address().to_string(), endpoint_.port());
+            }
+            else {
+                endpoint_address_ = fmt::format("{}:{}", endpoint_.address().to_string(), endpoint_.port());
+            }
             CB_LOG_DEBUG("{} connected to {}:{}", log_prefix_, endpoint_address_, it->endpoint().port());
             log_prefix_ = fmt::format("[{}/{}/{}/{}] <{}/{}:{}>",
                                       client_id_,

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -1323,15 +1323,13 @@ class mcbp_session_impl
             local_endpoint_ = stream_->local_endpoint();
             if (endpoint_.protocol() == asio::ip::tcp::v6()) {
                 local_endpoint_address_ = fmt::format("[{}]:{}", local_endpoint_.address().to_string(), local_endpoint_.port());
-            }
-            else {
+            } else {
                 local_endpoint_address_ = fmt::format("{}:{}", local_endpoint_.address().to_string(), local_endpoint_.port());
             }
             endpoint_ = it->endpoint();
             if (endpoint_.protocol() == asio::ip::tcp::v6()) {
                 endpoint_address_ = fmt::format("[{}]:{}", endpoint_.address().to_string(), endpoint_.port());
-            }
-            else {
+            } else {
                 endpoint_address_ = fmt::format("{}:{}", endpoint_.address().to_string(), endpoint_.port());
             }
             CB_LOG_DEBUG("{} connected to {}:{}", log_prefix_, endpoint_address_, it->endpoint().port());


### PR DESCRIPTION
Profiling indicates that non-trivial time is spent in this logic, which is called on every request.

There appears to be no reason not to cache this formatting in the existing variables, as local_endpoint_address_ is only being used here.

When tested together with another optimisation, this resulted in around a 15% performance improvement.