### PR TITLE
Patch BoringSSL for Windows MinGW and detect Apple ARM

### DIFF
--- a/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch
+++ b/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch
@@ -1,21 +1,21 @@
-From 51e44ffee037f4528407c81087fa18b60bf7fb27 Mon Sep 17 00:00:00 2001
+From 6bdc93aac66f2282823dceee802b60e2447c4ba9 Mon Sep 17 00:00:00 2001
 From: Sergey Avseyev <sergey.avseyev@gmail.com>
 Date: Fri, 20 Oct 2023 20:48:33 -0700
 Subject: [PATCH] fix build for mingw-w64-ucrt-x86_64-toolchain
 
 ---
- crypto/CMakeLists.txt        | 4 ++++
- crypto/curve25519/internal.h | 2 +-
+ src/crypto/CMakeLists.txt        | 4 ++++
+ src/crypto/curve25519/internal.h | 2 +-
  2 files changed, 5 insertions(+), 1 deletion(-)
 
-diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+diff --git a/src/crypto/CMakeLists.txt b/src/crypto/CMakeLists.txt
 index 68fb65b30..f53a9eee9 100644
---- a/crypto/CMakeLists.txt
-+++ b/crypto/CMakeLists.txt
+--- a/src/crypto/CMakeLists.txt
++++ b/src/crypto/CMakeLists.txt
 @@ -335,6 +335,10 @@ if(WIN32)
    target_link_libraries(crypto ws2_32)
  endif()
- 
+
 +if(MINGW)
 +  target_link_libraries(crypto --static-libgcc --static-libstdc++)
 +endif()
@@ -23,19 +23,18 @@ index 68fb65b30..f53a9eee9 100644
  if(NOT ANDROID)
    find_package(Threads REQUIRED)
    target_link_libraries(crypto Threads::Threads)
-diff --git a/crypto/curve25519/internal.h b/crypto/curve25519/internal.h
+diff --git a/src/crypto/curve25519/internal.h b/src/crypto/curve25519/internal.h
 index 0cd1a12aa..ab33badc0 100644
---- a/crypto/curve25519/internal.h
-+++ b/crypto/curve25519/internal.h
+--- a/src/crypto/curve25519/internal.h
++++ b/src/crypto/curve25519/internal.h
 @@ -32,7 +32,7 @@ void x25519_NEON(uint8_t out[32], const uint8_t scalar[32],
  #endif
- 
+
  #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
 -    defined(__GNUC__) && defined(__x86_64__)
 +    defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
  #define BORINGSSL_FE25519_ADX
- 
- // fiat_curve25519_adx_mul is defined in
--- 
-2.41.0.windows.3
 
+ // fiat_curve25519_adx_mul is defined in
+--
+2.42.0.windows.2

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -25,7 +25,17 @@ elseif(COUCHBASE_CXX_CLIENT_STATIC_BORINGSSL)
           "CMAKE_C_VISIBILITY_PRESET hidden"
           "CMAKE_CXX_VISIBILITY_PRESET hidden"
           "CMAKE_POSITION_INDEPENDENT_CODE ON")
-
+  if(MINGW)
+    set(boringssl_PATCH "${PROJECT_SOURCE_DIR}/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch")
+    message("Applying ${boringssl_PATCH} in ${boringssl_SOURCE_DIR} for MinGW gcc")
+    execute_process(
+      COMMAND patch --input ${boringssl_PATCH} --ignore-whitespace --strip=1
+      WORKING_DIRECTORY ${boringssl_SOURCE_DIR}
+      RESULT_VARIABLE PATCH_RESULT)
+    if(NOT PATCH_RESULT EQUAL "0")
+      message(FATAL_ERROR "Failed to apply patch to BoringSSL. Failed with: ${PATCH_RESULT}.")
+    endif()
+  endif()
   add_library(OpenSSL::SSL ALIAS ssl)
   add_library(OpenSSL::Crypto ALIAS ssl)
 else()

--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -12,28 +12,46 @@ elseif(COUCHBASE_CXX_CLIENT_STATIC_BORINGSSL)
   set(COUCHBASE_CXX_CLIENT_BORINGSSL_SHA "2ff4b968a7e0cfee66d9f151cb95635b43dc1d5b")
   set(COUCHBASE_CXX_CLIENT_BORINGSSL_VERSION "202308211007")
   cpmaddpackage(
-          NAME
-          boringssl
-          GIT_TAG
-          ${COUCHBASE_CXX_CLIENT_BORINGSSL_SHA}
-          VERSION
-          ${COUCHBASE_CXX_CLIENT_BORINGSSL_VERSION}
-          GITHUB_REPOSITORY
-          "google/boringssl"
-          OPTIONS
-          "BUILD_SHARED_LIBS OFF"
-          "CMAKE_C_VISIBILITY_PRESET hidden"
-          "CMAKE_CXX_VISIBILITY_PRESET hidden"
-          "CMAKE_POSITION_INDEPENDENT_CODE ON")
+    NAME
+    boringssl
+    GIT_TAG
+    ${COUCHBASE_CXX_CLIENT_BORINGSSL_SHA}
+    VERSION
+    ${COUCHBASE_CXX_CLIENT_BORINGSSL_VERSION}
+    GITHUB_REPOSITORY
+    "google/boringssl"
+    OPTIONS
+    "BUILD_SHARED_LIBS OFF"
+    "CMAKE_C_VISIBILITY_PRESET hidden"
+    "CMAKE_CXX_VISIBILITY_PRESET hidden"
+    "CMAKE_POSITION_INDEPENDENT_CODE ON")
   if(MINGW)
     set(boringssl_PATCH "${PROJECT_SOURCE_DIR}/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch")
     message("Applying ${boringssl_PATCH} in ${boringssl_SOURCE_DIR} for MinGW gcc")
     execute_process(
-      COMMAND patch --input ${boringssl_PATCH} --ignore-whitespace --strip=1
+      COMMAND patch --input ${boringssl_PATCH} --ignore-whitespace --strip=1 --forward
       WORKING_DIRECTORY ${boringssl_SOURCE_DIR}
       RESULT_VARIABLE PATCH_RESULT)
-    if(NOT PATCH_RESULT EQUAL "0")
+    if(PATCH_RESULT GREATER 1)
       message(FATAL_ERROR "Failed to apply patch to BoringSSL. Failed with: ${PATCH_RESULT}.")
+    endif()
+  endif()
+  if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles(
+      "int main() {
+       #if defined(__ARM_FEATURE_SHA2)
+       return 0;
+       #else
+       #error __ARM_FEATURE_SHA2 not defined
+       #endif
+     }"
+      HAVE_ARM_FEATURE_SHA2)
+    if(NOT HAVE_ARM_FEATURE_SHA2)
+      message(
+        FATAL_ERROR
+          "The compiler ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}) does not support BoringSSL, use OpenSSL or different compiler"
+      )
     endif()
   endif()
   add_library(OpenSSL::SSL ALIAS ssl)


### PR DESCRIPTION
Apple ARM should provide support for all three features below, otherwise BoringSSL will fail to compile:

* __ARM_NEON
* __ARM_FEATURE_AES
* __ARM_FEATURE_SHA2

https://github.com/google/boringssl/blob/ad57528d2c978543106f9b115bd0eb658f3ebdd2/crypto/cpu_aarch64_apple.c#L49-L54

It turns out, that at this time all three versions of gcc from homebrew (11, 12, 13) only expose `__ARM_NEON`

```
$ echo | g++-13 -dM -E -x c++ - | grep '__ARM_NEON\|__ARM_FEATURE_AES\|__ARM_FEATURE_SHA2'
#define __ARM_NEON 1

$ echo | g++-12 -dM -E -x c++ - | grep '__ARM_NEON\|__ARM_FEATURE_AES\|__ARM_FEATURE_SHA2'
#define __ARM_NEON 1

$ echo | g++-11 -dM -E -x c++ - | grep '__ARM_NEON\|__ARM_FEATURE_AES\|__ARM_FEATURE_SHA2'
#define __ARM_NEON 1
```

while system compiler which is Apple Clang, exposes all of them
```
$ echo | g++ -dM -E -x c++ - | grep '__ARM_NEON\|__ARM_FEATURE_AES\|__ARM_FEATURE_SHA2'
#define __ARM_FEATURE_AES 1
#define __ARM_FEATURE_SHA2 1
#define __ARM_NEON 1
#define __ARM_NEON_FP 0xE
#define __ARM_NEON__ 1
```

So as a solution, we try to detect dysfunctional compilers for Apple ARM platform, and stop the build. Because BoringSSL is not default, and must be explicitly selected, we cannot just fallback to OpenSSL.

The second part of the commit just applies patch for MinGW to allow building BoringSSL, the patch is in the source tree already, we just missed the part that applies it during porting process.