### PR TITLE
CXXCBC-404: KV_LOCKED status should be exposed as cas_mismatch for unlock

### DIFF
--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -75,6 +75,9 @@ map_status_code(protocol::client_opcode opcode, std::uint16_t status)
             return errc::common::bucket_not_found;
 
         case key_value_status_code::locked:
+            if (opcode == protocol::client_opcode::unlock) {
+                return errc::common::cas_mismatch;
+            }
             return errc::key_value::document_locked;
 
         case key_value_status_code::auth_stale:

--- a/test/test_integration_crud.cxx
+++ b/test/test_integration_crud.cxx
@@ -246,7 +246,7 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
         couchbase::core::operations::unlock_request req{ id };
         req.cas = couchbase::cas{ cas.value() - 1 };
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE(resp.ctx.ec() == couchbase::errc::key_value::document_locked);
+        REQUIRE(resp.ctx.ec() == couchbase::errc::common::cas_mismatch);
         REQUIRE_FALSE(resp.ctx.retried_because_of(couchbase::retry_reason::key_value_locked));
     }
 
@@ -841,7 +841,7 @@ TEST_CASE("integration: pessimistic locking with public API", "[integration]")
     {
         auto wrong_cas = couchbase::cas{ cas.value() - 1 };
         auto ctx = collection.unlock(id, wrong_cas, {}).get();
-        REQUIRE(ctx.ec() == couchbase::errc::key_value::document_locked);
+        REQUIRE(ctx.ec() == couchbase::errc::common::cas_mismatch);
         REQUIRE_FALSE(ctx.retried_because_of(couchbase::retry_reason::key_value_locked));
     }
 


### PR DESCRIPTION
KV_LOCKED should be exposed as `cas_mismatch` only for the unlock operation. This makes it consistent with the behaviour of other SDKs and the expectation of the relevant FIT test.

From the retry handling RFC:

> Locked 0x09 (Reason: KV_LOCKED)
Note: do NOT retry on KV_LOCKED for the "Unlock" command (the retry handler should never see it in the first place! (Reason is that _**this needs to be surfaced as a cas mismatch exception to the user**_ and not being retried