### PR TITLE
CXXCBC-403: Allow retries for KV not_my_vbucket response

### DIFF
--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -269,7 +269,7 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
                                                                                                  : errc::common::ambiguous_timeout));
               }
               if (ec == errc::common::request_canceled) {
-                  if (reason == retry_reason::do_not_retry) {
+                  if (!self->request.retries.idempotent() && !allows_non_idempotent_retry(reason)) {
                       if (self->span_->uses_tags())
                           self->span_->add_tag(tracing::attributes::orphan, "canceled");
                       return self->invoke_handler(ec);

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -1040,8 +1040,10 @@ class mcbp_session_impl
             }
         }
 
+        auto reason = status == static_cast<std::uint16_t>(key_value_status_code::not_my_vbucket) ? retry_reason::key_value_not_my_vbucket
+                                                                                                  : retry_reason::do_not_retry;
         if (fun) {
-            fun(protocol::map_status_code(opcode, status), retry_reason::do_not_retry, std::move(msg), decode_error_code(status));
+            fun(protocol::map_status_code(opcode, status), reason, std::move(msg), decode_error_code(status));
             return true;
         }
 
@@ -1059,11 +1061,8 @@ class mcbp_session_impl
             }
         }
         if (request) {
-            handler->handle_response(std::move(request),
-                                     protocol::map_status_code(opcode, status),
-                                     retry_reason::do_not_retry,
-                                     std::move(msg),
-                                     decode_error_code(status));
+            handler->handle_response(
+              std::move(request), protocol::map_status_code(opcode, status), reason, std::move(msg), decode_error_code(status));
             return true;
         }
         return false;


### PR DESCRIPTION
Motivation
----------
Currently if a KV operation receives a NMVB, it is possible the operation will raise a request_canceled error. When the client receives a NMVB there are circumstances in which we should attempt to retry the operation instead of raising a request_canceled.

Changes
-------
Update logic for handling NMVB KV responses so that retries are possible when appropriate.