### PR TITLE
CXXCBC-391: Fix transactions API bugs

### DIFF
--- a/core/origin.cxx
+++ b/core/origin.cxx
@@ -168,7 +168,7 @@ struct traits<couchbase::transactions::transactions_config::built> {
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::transactions::transactions_config::built& o)
     {
         v = {
-            { "expiration_time", o.expiration_time },
+            { "timeout", o.timeout },
             { "durability_level", o.level },
             {
               "query_config",
@@ -186,9 +186,6 @@ struct traits<couchbase::transactions::transactions_config::built> {
               },
             },
         };
-        if (const auto& p = o.kv_timeout; p.has_value()) {
-            v["key_value_timeout"] = p.value();
-        }
         if (const auto& p = o.metadata_collection; p.has_value()) {
             v["metadata_collection"] = {
                 { "bucket", p.value().bucket },

--- a/core/transactions/active_transaction_record.hxx
+++ b/core/transactions/active_transaction_record.hxx
@@ -35,7 +35,6 @@ namespace couchbase::core::transactions
 class active_transaction_record
 {
   public:
-    // TODO: we should get the kv_timeout and put it in the request (pass in the transactions_config)
     template<typename Callback>
     static void get_atr(const core::cluster& cluster, const core::document_id& atr_id, Callback&& cb)
     {

--- a/core/transactions/internal/utils.hxx
+++ b/core/transactions/internal/utils.hxx
@@ -59,28 +59,16 @@ operator<<(OStream& os, const core::document_id& id)
 
 template<typename T>
 T&
-wrap_request(T&& req, const couchbase::transactions::transactions_config::built& config)
-{
-    if (config.kv_timeout) {
-        req.timeout = config.kv_timeout.value();
-    }
-    return req;
-}
-
-template<typename T>
-T&
 wrap_durable_request(T&& req, const couchbase::transactions::transactions_config::built& config)
 {
-    wrap_request(req, config);
     req.durability_level = config.level;
     return req;
 }
 
 template<typename T>
 T&
-wrap_durable_request(T&& req, const couchbase::transactions::transactions_config::built& config, durability_level level)
+wrap_durable_request(T&& req, durability_level level)
 {
-    wrap_request(req, config);
     req.durability_level = level;
     return req;
 }

--- a/core/transactions/transaction_options.cxx
+++ b/core/transactions/transaction_options.cxx
@@ -30,8 +30,7 @@ transaction_options::apply(const transactions_config::built& conf) const
         query_config.scan_consistency = *scan_consistency_;
     }
     return { durability_.value_or(conf.level),
-             expiration_time_.value_or(conf.expiration_time),
-             kv_timeout_ ? kv_timeout_ : conf.kv_timeout,
+             timeout_.value_or(conf.timeout),
              attempt_context_hooks_ ? attempt_context_hooks_ : conf.attempt_context_hooks,
              cleanup_hooks_ ? cleanup_hooks_ : conf.cleanup_hooks,
              metadata_collection_ ? metadata_collection_ : conf.metadata_collection,
@@ -80,23 +79,10 @@ transaction_options::scan_consistency() const
     return scan_consistency_;
 }
 
-transaction_options&
-transaction_options::kv_timeout(std::chrono::milliseconds kv_timeout)
-{
-    kv_timeout_ = kv_timeout;
-    return *this;
-}
-
-std::optional<std::chrono::milliseconds>
-transaction_options::kv_timeout()
-{
-    return kv_timeout_;
-}
-
 std::optional<std::chrono::nanoseconds>
-transaction_options::expiration_time()
+transaction_options::timeout()
 {
-    return expiration_time_;
+    return timeout_;
 }
 
 transaction_options&

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -77,7 +77,7 @@ wrap_run(transactions& txns, const couchbase::transactions::transaction_options&
     while (attempts++ < max_attempts) {
         // NOTE: new_attempt_context has the exponential backoff built in.  So, after
         // the first time it is called, it has a 1ms delay, then 2ms, etc... capped at 100ms
-        // until (for now) a timeout is reached (2x the expiration_time).   Soon, will build in
+        // until (for now) a timeout is reached (2x the timeout).   Soon, will build in
         // a max attempts instead.  In any case, the timeout occurs in the logic - adding
         // a max attempts or timeout is just in case a bug prevents timeout, etc...
         overall.new_attempt_context();

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -283,7 +283,6 @@ transactions_cleanup::get_active_clients(const couchbase::transactions::transact
               lookup_in_specs::get(subdoc::lookup_in_macro::vbucket).xattr(),
           }
             .specs();
-        wrap_request(req, config_);
         auto barrier = std::make_shared<std::promise<result>>();
         auto f = barrier->get_future();
         auto ec = config_.cleanup_hooks->client_record_before_get(keyspace.bucket);

--- a/core/transactions/transactions_config.cxx
+++ b/core/transactions/transactions_config.cxx
@@ -26,7 +26,7 @@ namespace couchbase::transactions
 
 transactions_config::transactions_config()
   : level_(couchbase::durability_level::majority)
-  , expiration_time_(std::chrono::seconds(15))
+  , timeout_(std::chrono::seconds(15))
   , attempt_context_hooks_(new core::transactions::attempt_context_testing_hooks())
   , cleanup_hooks_(new core::transactions::cleanup_testing_hooks())
 {
@@ -36,7 +36,7 @@ transactions_config::~transactions_config() = default;
 
 transactions_config::transactions_config(transactions_config&& c) noexcept
   : level_(c.level_)
-  , expiration_time_(c.expiration_time_)
+  , timeout_(c.timeout_)
   , attempt_context_hooks_(c.attempt_context_hooks_)
   , cleanup_hooks_(c.cleanup_hooks_)
   , metadata_collection_(std::move(c.metadata_collection_))
@@ -47,7 +47,7 @@ transactions_config::transactions_config(transactions_config&& c) noexcept
 
 transactions_config::transactions_config(const transactions_config& config)
   : level_(config.durability_level())
-  , expiration_time_(config.expiration_time())
+  , timeout_(config.timeout())
   , attempt_context_hooks_(std::make_shared<core::transactions::attempt_context_testing_hooks>(config.attempt_context_hooks()))
   , cleanup_hooks_(std::make_shared<core::transactions::cleanup_testing_hooks>(config.cleanup_hooks()))
   , metadata_collection_(config.metadata_collection())
@@ -61,7 +61,7 @@ transactions_config::operator=(const transactions_config& c)
 {
     if (this != &c) {
         level_ = c.level_;
-        expiration_time_ = c.expiration_time_;
+        timeout_ = c.timeout_;
         attempt_context_hooks_ = c.attempt_context_hooks_;
         cleanup_hooks_ = c.cleanup_hooks_;
         query_config_ = c.query_config_;
@@ -74,8 +74,9 @@ transactions_config::operator=(const transactions_config& c)
 transactions_config::built
 transactions_config::build() const
 {
-    return { level_,         expiration_time_,     kv_timeout_,           attempt_context_hooks_,
-             cleanup_hooks_, metadata_collection_, query_config_.build(), cleanup_config_.build() };
+    return {
+        level_, timeout_, attempt_context_hooks_, cleanup_hooks_, metadata_collection_, query_config_.build(), cleanup_config_.build()
+    };
 }
 
 } // namespace couchbase::transactions

--- a/couchbase/transactions/transaction_options.hxx
+++ b/couchbase/transactions/transaction_options.hxx
@@ -76,40 +76,25 @@ class transaction_options
     [[nodiscard]] std::optional<query_scan_consistency> scan_consistency() const;
 
     /**
-     * Set the timeout for key-value operations for this transaction.
+     * Set the timeout for this transaction.
      *
-     * @param kv_timeout Desired key-value timeout.
-     * @return reference to this object, convenient for chaining operations.
-     */
-    transaction_options& kv_timeout(std::chrono::milliseconds kv_timeout);
-
-    /**
-     * Get the key-value timeout if it has been set.
-     *
-     * @return The key-value timeout, if set.
-     */
-    std::optional<std::chrono::milliseconds> kv_timeout();
-
-    /**
-     * Set the expiration time for this transaction.
-     *
-     * @tparam T expiration time type, e.g. @ref std::chrono::milliseconds, or similar
-     * @param expiration_time Desired expiration time.
+     * @tparam T timeout type, e.g. @ref std::chrono::milliseconds, or similar
+     * @param timeout Desired timeout
      * @return reference to this object, convenient for chaining operations.
      */
     template<typename T>
-    transaction_options& expiration_time(T expiration_time)
+    transaction_options& timeout(T timeout)
     {
-        expiration_time_ = std::chrono::duration_cast<std::chrono::nanoseconds>(expiration_time);
+        timeout_ = std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
         return *this;
     }
 
     /**
-     * Get the expiration time, if set.
+     * Get the timeout, if set.
      *
-     * @return the expiration time, if set.
+     * @return the timeout, if set.
      */
-    std::optional<std::chrono::nanoseconds> expiration_time();
+    std::optional<std::chrono::nanoseconds> timeout();
 
     /**
      * Set the metadata collection to use for this transaction
@@ -150,8 +135,7 @@ class transaction_options
   private:
     std::optional<couchbase::durability_level> durability_;
     std::optional<couchbase::query_scan_consistency> scan_consistency_;
-    std::optional<std::chrono::milliseconds> kv_timeout_;
-    std::optional<std::chrono::nanoseconds> expiration_time_;
+    std::optional<std::chrono::nanoseconds> timeout_;
     std::optional<transaction_keyspace> metadata_collection_;
     std::shared_ptr<core::transactions::attempt_context_testing_hooks> attempt_context_hooks_;
     std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks_;

--- a/couchbase/transactions/transactions_config.hxx
+++ b/couchbase/transactions/transactions_config.hxx
@@ -79,55 +79,28 @@ class transactions_config
     }
 
     /**
-     * @brief Set kv_timeout
-     *
-     * @see kv_timeout()
-     * @param duration An std::chrono::duration representing the desired default kv operation timeout.
-     * @return reference to this, so calls can be chained.
-     */
-    template<typename T>
-    transactions_config& kv_timeout(T duration)
-    {
-        kv_timeout_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
-        return *this;
-    }
-
-    /**
-     * @brief Get kv_timeout
-     *
-     * This is the default kv operation timeout used throughout the transactions.  Note all the operations
-     * have an options class which allows you to override this value for a particular operation, if desired.
-     *
-     * @return The default kv operation timeout.
-     */
-    [[nodiscard]] std::optional<std::chrono::milliseconds> kv_timeout() const
-    {
-        return kv_timeout_;
-    }
-
-    /**
-     * @brief Get expiration time for transactions
+     * @brief Get the timeout for transactions
      *
      * Transactions can conflict (or other operations on those documents), and may retry.
      * This is the maximum time a transaction can take, including any retries.  The transaction will throw
      * an @ref transaction_expired and rollback when this occurs.
      *
-     * @return expiration time for transactions.
+     * @return timeout for transactions.
      */
-    [[nodiscard]] std::chrono::nanoseconds expiration_time() const
+    [[nodiscard]] std::chrono::nanoseconds timeout() const
     {
-        return expiration_time_;
+        return timeout_;
     }
     /**
-     * @brief Set the expiration time for transactions.
+     * @brief Set the timeout for transactions.
      *
      * @param duration desired expiration for transactions.
      * @return reference to this, so calls can be chained.
      */
     template<typename T>
-    transactions_config& expiration_time(T duration)
+    transactions_config& timeout(T duration)
     {
-        expiration_time_ = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+        timeout_ = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
         return *this;
     }
 
@@ -236,8 +209,7 @@ class transactions_config
     /** @private */
     struct built {
         couchbase::durability_level level;
-        std::chrono::nanoseconds expiration_time;
-        std::optional<std::chrono::milliseconds> kv_timeout;
+        std::chrono::nanoseconds timeout;
         std::shared_ptr<core::transactions::attempt_context_testing_hooks> attempt_context_hooks;
         std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks;
         std::optional<couchbase::transactions::transaction_keyspace> metadata_collection;
@@ -250,8 +222,7 @@ class transactions_config
 
   private:
     couchbase::durability_level level_{ couchbase::durability_level::majority };
-    std::chrono::nanoseconds expiration_time_{ std::chrono::seconds(15) };
-    std::optional<std::chrono::milliseconds> kv_timeout_;
+    std::chrono::nanoseconds timeout_{ std::chrono::seconds(15) };
     std::shared_ptr<core::transactions::attempt_context_testing_hooks> attempt_context_hooks_;
     std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks_;
     std::optional<couchbase::transactions::transaction_keyspace> metadata_collection_;

--- a/docs/cbc-analytics.md
+++ b/docs/cbc-analytics.md
@@ -103,8 +103,7 @@ Execute one or more Analytics queries and print results to standard output.
 
 <dl>
 <dt>`--transactions-durability-level=LEVEL`</dt><dd>Durability level of the transaction (allowed values: `none`, `majority`, `majority_and_persist_to_active`, `persist_to_majority`). [default: `majority`]</dd>
-<dt>`--transactions-expiration-time=DURATION`</dt><dd>Expiration time of the transaction. [default: `15000ms`]</dd>
-<dt>`--transactions-key-value-timeout=DURATION`</dt><dd>Override Key/Value timeout just for the transaction.</dd>
+<dt>`--transactions-timeout=DURATION`</dt><dd>Timeout of the transaction. [default: `15000ms`]</dd>
 <dt>`--transactions-metadata-bucket=STRING`</dt><dd>Bucket name where transaction metadata is stored.</dd>
 <dt>`--transactions-metadata-scope=STRING`</dt><dd>Scope name where transaction metadata is stored. [default: `_default`]</dd>
 <dt>`--transactions-metadata-collection=STRING`</dt><dd>Collection name where transaction metadata is stored. [default: `_default`]</dd>

--- a/docs/cbc-get.md
+++ b/docs/cbc-get.md
@@ -103,8 +103,7 @@ Retrieve one or more documents from the server and print them to standard output
 
 <dl>
 <dt>`--transactions-durability-level=LEVEL`</dt><dd>Durability level of the transaction (allowed values: `none`, `majority`, `majority_and_persist_to_active`, `persist_to_majority`). [default: `majority`]</dd>
-<dt>`--transactions-expiration-time=DURATION`</dt><dd>Expiration time of the transaction. [default: `15000ms`]</dd>
-<dt>`--transactions-key-value-timeout=DURATION`</dt><dd>Override Key/Value timeout just for the transaction.</dd>
+<dt>`--transactions-timeout=DURATION`</dt><dd>Timeout of the transaction. [default: `15000ms`]</dd>
 <dt>`--transactions-metadata-bucket=STRING`</dt><dd>Bucket name where transaction metadata is stored.</dd>
 <dt>`--transactions-metadata-scope=STRING`</dt><dd>Scope name where transaction metadata is stored. [default: `_default`]</dd>
 <dt>`--transactions-metadata-collection=STRING`</dt><dd>Collection name where transaction metadata is stored. [default: `_default`]</dd>

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -110,8 +110,7 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 
 <dl>
 <dt>`--transactions-durability-level=LEVEL`</dt><dd>Durability level of the transaction (allowed values: `none`, `majority`, `majority_and_persist_to_active`, `persist_to_majority`). [default: `majority`]</dd>
-<dt>`--transactions-expiration-time=DURATION`</dt><dd>Expiration time of the transaction. [default: `15000ms`]</dd>
-<dt>`--transactions-key-value-timeout=DURATION`</dt><dd>Override Key/Value timeout just for the transaction.</dd>
+<dt>`--transactions-timeout=DURATION`</dt><dd>Timeout of the transaction. [default: `15000ms`]</dd>
 <dt>`--transactions-metadata-bucket=STRING`</dt><dd>Bucket name where transaction metadata is stored.</dd>
 <dt>`--transactions-metadata-scope=STRING`</dt><dd>Scope name where transaction metadata is stored. [default: `_default`]</dd>
 <dt>`--transactions-metadata-collection=STRING`</dt><dd>Collection name where transaction metadata is stored. [default: `_default`]</dd>

--- a/docs/cbc-query.md
+++ b/docs/cbc-query.md
@@ -111,8 +111,7 @@ Execute one or more N1QL queries and print results to standard output.
 
 <dl>
 <dt>`--transactions-durability-level=LEVEL`</dt><dd>Durability level of the transaction (allowed values: `none`, `majority`, `majority_and_persist_to_active`, `persist_to_majority`). [default: `majority`]</dd>
-<dt>`--transactions-expiration-time=DURATION`</dt><dd>Expiration time of the transaction. [default: `15000ms`]</dd>
-<dt>`--transactions-key-value-timeout=DURATION`</dt><dd>Override Key/Value timeout just for the transaction.</dd>
+<dt>`--transactions-timeout=DURATION`</dt><dd>Timeout of the transaction. [default: `15000ms`]</dd>
 <dt>`--transactions-metadata-bucket=STRING`</dt><dd>Bucket name where transaction metadata is stored.</dd>
 <dt>`--transactions-metadata-scope=STRING`</dt><dd>Scope name where transaction metadata is stored. [default: `_default`]</dd>
 <dt>`--transactions-metadata-collection=STRING`</dt><dd>Collection name where transaction metadata is stored. [default: `_default`]</dd>

--- a/examples/game_server.cxx
+++ b/examples/game_server.cxx
@@ -223,7 +223,7 @@ main()
     options.transactions().durability_level(couchbase::durability_level::majority);
     options.transactions().cleanup_config().cleanup_lost_attempts(true);
     options.transactions().cleanup_config().cleanup_client_attempts(true);
-    options.transactions().expiration_time(std::chrono::milliseconds(100));
+    options.transactions().timeout(std::chrono::milliseconds(100));
 
     auto [cluster, ec] = couchbase::cluster::connect(io, "couchbase://localhost", options).get();
     if (ec) {

--- a/test/test_transaction_context.cxx
+++ b/test/test_transaction_context.cxx
@@ -70,8 +70,8 @@ TEST_CASE("transactions: can do simple transaction with transaction wrapper", "[
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -110,8 +110,8 @@ TEST_CASE("transactions: can do simple transaction with finalize", "[transaction
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -158,8 +158,8 @@ TEST_CASE("transactions: can do simple transaction explicit commit", "[transacti
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -204,8 +204,8 @@ TEST_CASE("transactions: can do rollback simple transaction", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -247,8 +247,8 @@ TEST_CASE("transactions: can get insert errors", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -287,8 +287,8 @@ TEST_CASE("transactions: can get remove errors", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -329,8 +329,8 @@ TEST_CASE("transactions: can get replace errors", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -375,8 +375,8 @@ TEST_CASE("transactions: RYOW get after insert", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -408,8 +408,8 @@ TEST_CASE("transactions: can get get errors", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -437,8 +437,8 @@ TEST_CASE("transactions: can do query", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -474,8 +474,8 @@ TEST_CASE("transactions: can see some query errors but no transactions failed", 
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
     couchbase::core::document_id id{ integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn") };
@@ -515,20 +515,18 @@ TEST_CASE("transactions: can set per transaction config", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     couchbase::transactions::transaction_options per_txn_cfg;
     per_txn_cfg.scan_consistency(couchbase::query_scan_consistency::not_bounded)
-      .expiration_time(std::chrono::milliseconds(1))
-      .kv_timeout(std::chrono::milliseconds(2))
+      .timeout(std::chrono::milliseconds(1))
       .durability_level(couchbase::durability_level::none);
     transaction_context tx(txns, per_txn_cfg);
     REQUIRE(tx.config().level == per_txn_cfg.durability_level());
-    REQUIRE(tx.config().kv_timeout == per_txn_cfg.kv_timeout());
-    REQUIRE(tx.config().expiration_time == per_txn_cfg.expiration_time());
+    REQUIRE(tx.config().timeout == per_txn_cfg.timeout());
     REQUIRE(tx.config().query_config.scan_consistency == per_txn_cfg.scan_consistency());
 }
 
@@ -537,14 +535,13 @@ TEST_CASE("transactions: can not per transactions config", "[transactions]")
     test::utils::integration_test_guard integration;
 
     auto cluster = integration.cluster;
-    couchbase::core::transactions::transactions txns(
-      cluster, couchbase::transactions::transactions_config().expiration_time(std::chrono::seconds(2)));
+    couchbase::core::transactions::transactions txns(cluster,
+                                                     couchbase::transactions::transactions_config().timeout(std::chrono::seconds(2)));
 
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     transaction_context tx(txns);
     REQUIRE(tx.config().level == txns.config().level);
-    REQUIRE(tx.config().kv_timeout == txns.config().kv_timeout);
-    REQUIRE(tx.config().expiration_time == txns.config().expiration_time);
+    REQUIRE(tx.config().timeout == txns.config().timeout);
     REQUIRE(tx.config().query_config.scan_consistency == txns.config().query_config.scan_consistency);
 }

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -28,7 +28,7 @@ couchbase::transactions::transaction_options
 async_options()
 {
     couchbase::transactions::transaction_options cfg;
-    cfg.expiration_time(std::chrono::seconds(1));
+    cfg.timeout(std::chrono::seconds(1));
     return cfg;
 }
 
@@ -305,7 +305,7 @@ TEST_CASE("transactions public async API: can set transaction options", "[transa
     REQUIRE_SUCCESS(err.ec());
 
     auto begin = std::chrono::steady_clock::now();
-    auto cfg = couchbase::transactions::transaction_options().expiration_time(std::chrono::seconds(2));
+    auto cfg = couchbase::transactions::transaction_options().timeout(std::chrono::seconds(2));
     auto barrier = std::make_shared<std::promise<void>>();
     auto f = barrier->get_future();
     c.transactions()->run(
@@ -320,10 +320,10 @@ TEST_CASE("transactions public async API: can set transaction options", "[transa
       [&begin, &cfg, barrier](auto e, auto res) {
           auto end = std::chrono::steady_clock::now();
           auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
-          // should be greater than the expiration time
-          CHECK(elapsed > *cfg.expiration_time());
+          // should be greater than the timeout
+          CHECK(elapsed > *cfg.timeout());
           // but not by too much (default is 15 seconds, we wanted 1, 2 is plenty)
-          CHECK(elapsed < (2 * *cfg.expiration_time()));
+          CHECK(elapsed < (2 * *cfg.timeout()));
           // and of course the txn should have expired
           CHECK_FALSE(res.transaction_id.empty());
           CHECK_FALSE(res.unstaging_complete);

--- a/test/test_transaction_simple.cxx
+++ b/test/test_transaction_simple.cxx
@@ -45,7 +45,7 @@ couchbase::transactions::transactions_config
 get_conf()
 {
     couchbase::transactions::transactions_config cfg{};
-    cfg.expiration_time(std::chrono::seconds(2));
+    cfg.timeout(std::chrono::seconds(2));
     return cfg;
 }
 
@@ -228,7 +228,7 @@ TEST_CASE("transactions: non existent scope in custom metadata collections", "[t
       "i_dont_exist",
       couchbase::collection::default_name,
     });
-    cfg.expiration_time(std::chrono::seconds(2));
+    cfg.timeout(std::chrono::seconds(2));
     transactions txn(cluster, cfg);
 
     // upsert initial doc
@@ -266,7 +266,7 @@ TEST_CASE("transactions: non existent collection in custom metadata collections"
       get_conf()
         .metadata_collection(couchbase::transactions::transaction_keyspace{ "secBucket", couchbase::scope::default_name, "i_dont_exist" })
         .cleanup_config(couchbase::transactions::transactions_cleanup_config().cleanup_lost_attempts(true));
-    cfg.expiration_time(std::chrono::seconds(2));
+    cfg.timeout(std::chrono::seconds(2));
     transactions txn(cluster, cfg);
 
     // upsert initial doc

--- a/test/test_transaction_simple_async.cxx
+++ b/test/test_transaction_simple_async.cxx
@@ -34,7 +34,7 @@ couchbase::transactions::transactions_config
 get_conf()
 {
     couchbase::transactions::transactions_config cfg{};
-    cfg.expiration_time(std::chrono::seconds(1));
+    cfg.timeout(std::chrono::seconds(1));
     return cfg;
 }
 

--- a/tools/utils.cxx
+++ b/tools/utils.cxx
@@ -217,10 +217,8 @@ add_options(CLI::App* app, transactions_options& options)
     group->add_option("--transactions-durability-level", options.durability_level, "Durability level of the transaction.")
       ->default_val(fmt::format("{}", defaults.transactions.level))
       ->transform(CLI::IsMember(available_durability_levels));
-    group->add_option("--transactions-expiration-time", options.expiration_time, "Expiration time of the transaction.")
-      ->default_val(defaults.transactions.expiration_time)
-      ->type_name("DURATION");
-    group->add_option("--transactions-key-value-timeout", options.key_value_timeout, "Override Key/Value timeout just for the transaction.")
+    group->add_option("--transactions-timeout", options.timeout, "Timeout of the transaction.")
+      ->default_val(defaults.transactions.timeout)
       ->type_name("DURATION");
     group->add_option("--transactions-metadata-bucket", options.metadata_bucket, "Bucket name where transaction metadata is stored.");
     group->add_option("--transactions-metadata-scope", options.metadata_scope, "Scope name where transaction metadata is stored.")
@@ -424,10 +422,7 @@ apply_options(couchbase::cluster_options& options, const transactions_options& t
     } else if (!transactions.durability_level.empty()) {
         fail(fmt::format("unexpected value '{}' for --transactions-durability-level", transactions.durability_level));
     }
-    options.transactions().expiration_time(transactions.expiration_time);
-    if (transactions.key_value_timeout > std::chrono::milliseconds::zero()) {
-        options.transactions().kv_timeout(transactions.key_value_timeout);
-    }
+    options.transactions().timeout(transactions.timeout);
     if (!transactions.metadata_bucket.empty()) {
         options.transactions().metadata_collection(
           { transactions.metadata_bucket, transactions.metadata_scope, transactions.metadata_collection });

--- a/tools/utils.hxx
+++ b/tools/utils.hxx
@@ -129,8 +129,7 @@ struct network_options {
 
 struct transactions_options {
     std::string durability_level{};
-    std::chrono::milliseconds expiration_time{};
-    std::chrono::milliseconds key_value_timeout{};
+    std::chrono::milliseconds timeout{};
     std::string metadata_bucket{};
     std::string metadata_scope{};
     std::string metadata_collection{};


### PR DESCRIPTION
## Motivation

## Changes

* In `transactions_config`, `transactions_options` and the command line arguments of tools:
    * Remove `kv_timeout`
    * Rename `expiration_time` to timeout
* Set the value `"kvTimeoutMs"` in the transactions query requests to the `key_value_durable_timeout` instead of `key_value_timeout`
