### PR TITLE
CXXCBC-308: Add analytics index manager in the public API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(couchbase_cxx_client_FILES
     core/free_form_http_request.cxx
     core/impl/analytics.cxx
     core/impl/analytics_error_category.cxx
+    core/impl/analytics_index_manager.cxx
     core/impl/best_effort_retry_strategy.cxx
     core/impl/binary_collection.cxx
     core/impl/boolean_field_query.cxx

--- a/core/impl/analytics_index_manager.cxx
+++ b/core/impl/analytics_index_manager.cxx
@@ -1,0 +1,820 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "core/cluster.hxx"
+#include "core/logger/logger.hxx"
+
+#include "core/operations/management/analytics_dataset_create.hxx"
+#include "core/operations/management/analytics_dataset_drop.hxx"
+#include "core/operations/management/analytics_dataset_get_all.hxx"
+#include "core/operations/management/analytics_dataverse_create.hxx"
+#include "core/operations/management/analytics_dataverse_drop.hxx"
+#include "core/operations/management/analytics_get_pending_mutations.hxx"
+#include "core/operations/management/analytics_index_create.hxx"
+#include "core/operations/management/analytics_index_drop.hxx"
+#include "core/operations/management/analytics_index_get_all.hxx"
+#include "core/operations/management/analytics_link_connect.hxx"
+#include "core/operations/management/analytics_link_create.hxx"
+#include "core/operations/management/analytics_link_disconnect.hxx"
+#include "core/operations/management/analytics_link_drop.hxx"
+#include "core/operations/management/analytics_link_get_all.hxx"
+#include "core/operations/management/analytics_link_replace.hxx"
+#include "internal_manager_error_context.hxx"
+
+#include <couchbase/analytics_index_manager.hxx>
+#include <couchbase/management/analytics_link.hxx>
+
+namespace couchbase
+{
+namespace
+{
+template<typename Response>
+manager_error_context
+build_context(Response& resp)
+{
+    return manager_error_context{ internal_manager_error_context{ resp.ctx.ec,
+                                                                  resp.ctx.last_dispatched_to,
+                                                                  resp.ctx.last_dispatched_from,
+                                                                  resp.ctx.retry_attempts,
+                                                                  std::move(resp.ctx.retry_reasons),
+                                                                  std::move(resp.ctx.client_context_id),
+                                                                  resp.ctx.http_status,
+                                                                  std::move(resp.ctx.http_body),
+                                                                  std::move(resp.ctx.path) } };
+}
+
+core::management::analytics::couchbase_remote_link
+to_core_couchbase_remote_link(const management::analytics_link& link)
+{
+    auto cb_link = dynamic_cast<const management::couchbase_remote_analytics_link&>(link);
+    core::management::analytics::couchbase_remote_link core_link{ cb_link.name,
+                                                                  cb_link.dataverse_name,
+                                                                  cb_link.hostname,
+                                                                  cb_link.username,
+                                                                  cb_link.password,
+                                                                  core::management::analytics::couchbase_link_encryption_settings{
+                                                                    {},
+                                                                    cb_link.encryption.certificate,
+                                                                    cb_link.encryption.client_certificate,
+                                                                    cb_link.encryption.client_key,
+                                                                  } };
+    switch (cb_link.encryption.encryption_level) {
+        case management::analytics_encryption_level::none:
+            core_link.encryption.level = core::management::analytics::couchbase_link_encryption_level::none;
+            break;
+        case management::analytics_encryption_level::half:
+            core_link.encryption.level = core::management::analytics::couchbase_link_encryption_level::half;
+            break;
+        case management::analytics_encryption_level::full:
+            core_link.encryption.level = core::management::analytics::couchbase_link_encryption_level::full;
+            break;
+    }
+    return core_link;
+}
+
+core::management::analytics::azure_blob_external_link
+to_core_azure_blob_external_link(const management::analytics_link& link)
+{
+    auto azure_link = dynamic_cast<const management::azure_blob_external_analytics_link&>(link);
+    return core::management::analytics::azure_blob_external_link{
+        azure_link.name,        azure_link.dataverse_name,          azure_link.connection_string, azure_link.account_name,
+        azure_link.account_key, azure_link.shared_access_signature, azure_link.blob_endpoint,     azure_link.endpoint_suffix,
+    };
+}
+
+core::management::analytics::s3_external_link
+to_core_s3_external_link(const management::analytics_link& link)
+{
+    auto s3_link = dynamic_cast<const management::s3_external_analytics_link&>(link);
+    return core::management::analytics::s3_external_link{
+        s3_link.name,          s3_link.dataverse_name, s3_link.access_key_id,    s3_link.secret_access_key,
+        s3_link.session_token, s3_link.region,         s3_link.service_endpoint,
+    };
+}
+} // namespace
+
+class analytics_index_manager_impl : public std::enable_shared_from_this<analytics_index_manager_impl>
+{
+  public:
+    explicit analytics_index_manager_impl(core::cluster core)
+      : core_{ std::move(core) }
+    {
+    }
+
+    void create_dataverse(const std::string& dataverse_name,
+                          const create_dataverse_analytics_options::built& options,
+                          create_dataverse_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_dataverse_create_request{
+            dataverse_name,
+            options.ignore_if_exists,
+            {},
+            options.timeout,
+          },
+          [dataverse_name, handler = std::move(handler)](auto resp) {
+              CB_LOG_DEBUG("Dataverse create for {} error code = {}", dataverse_name, resp.ctx.ec.value());
+              handler(build_context(resp));
+          });
+    }
+
+    void drop_dataverse(const std::string& dataverse_name,
+                        const drop_dataverse_analytics_options::built& options,
+                        drop_dataverse_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_dataverse_drop_request{
+            dataverse_name,
+            options.ignore_if_not_exists,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void create_dataset(const std::string& dataset_name,
+                        const std::string& bucket_name,
+                        const create_dataset_analytics_options::built& options,
+                        create_dataset_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_dataset_create_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            dataset_name,
+            bucket_name,
+            options.condition,
+            {},
+            options.timeout,
+            options.ignore_if_exists,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void drop_dataset(const std::string& dataset_name,
+                      const drop_dataset_analytics_options::built& options,
+                      drop_dataset_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_dataset_drop_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            dataset_name,
+            options.ignore_if_not_exists,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void get_all_datasets(const get_all_datasets_analytics_options::built& options, get_all_datasets_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_dataset_get_all_request{
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](core::operations::management::analytics_dataset_get_all_response resp) {
+              if (resp.ctx.ec) {
+                  return handler(build_context(resp), {});
+              }
+              std::vector<management::analytics_dataset> datasets{};
+              datasets.reserve(resp.datasets.size());
+              for (const auto& d : resp.datasets) {
+                  datasets.push_back(management::analytics_dataset{
+                    d.name,
+                    d.dataverse_name,
+                    d.link_name,
+                    d.bucket_name,
+                  });
+              }
+              handler(build_context(resp), datasets);
+          });
+    }
+
+    void create_index(const std::string& index_name,
+                      const std::string& dataset_name,
+                      const std::map<std::string, std::string>& fields,
+                      const create_index_analytics_options::built& options,
+                      create_index_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_index_create_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            dataset_name,
+            index_name,
+            fields,
+            options.ignore_if_exists,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void drop_index(const std::string& index_name,
+                    const std::string& dataset_name,
+                    const drop_index_analytics_options::built& options,
+                    drop_index_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_index_drop_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            dataset_name,
+            index_name,
+            options.ignore_if_not_exists,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void get_all_indexes(const get_all_indexes_analytics_options::built& options, get_all_indexes_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_index_get_all_request{
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](core::operations::management::analytics_index_get_all_response resp) {
+              if (resp.ctx.ec) {
+                  return handler(build_context(resp), {});
+              }
+              std::vector<management::analytics_index> indexes{};
+              indexes.reserve(resp.indexes.size());
+              for (const auto& idx : resp.indexes) {
+                  indexes.push_back(management::analytics_index{
+                    idx.name,
+                    idx.dataset_name,
+                    idx.dataverse_name,
+                    idx.is_primary,
+                  });
+              }
+              handler(build_context(resp), indexes);
+          });
+    }
+
+    void connect_link(const connect_link_analytics_options::built& options, connect_link_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_link_connect_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            options.link_name.value_or(DEFAULT_LINK_NAME),
+            options.force,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void disconnect_link(const disconnect_link_analytics_options::built& options, disconnect_link_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_link_disconnect_request{
+            options.dataverse_name.value_or(DEFAULT_DATAVERSE_NAME),
+            options.link_name.value_or(DEFAULT_LINK_NAME),
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void get_pending_mutations(const get_pending_mutations_analytics_options::built& options,
+                               get_pending_mutations_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_get_pending_mutations_request{
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](core::operations::management::analytics_get_pending_mutations_response resp) {
+              if (resp.ctx.ec) {
+                  return handler(build_context(resp), {});
+              }
+              std::map<std::string, std::map<std::string, std::int64_t>> pending_mutations{};
+              const std::string separator{ "." };
+              for (const auto& [key, mutation_count] : resp.stats) {
+                  // Keys are encoded as `dataverse.dataset`
+                  auto separator_pos = key.find(separator);
+                  auto dataverse_name = key.substr(0, separator_pos);
+                  auto dataset_name = key.substr(separator_pos + 1, key.size() - separator_pos - 1);
+                  if (pending_mutations.count(dataverse_name) == 0) {
+                      pending_mutations.insert({ dataverse_name, {} });
+                  }
+                  pending_mutations.at(dataverse_name).insert({ dataset_name, mutation_count });
+              }
+              handler(build_context(resp), pending_mutations);
+          });
+    }
+
+    void create_link(const management::analytics_link& link,
+                     const create_link_analytics_options::built& options,
+                     create_link_analytics_handler&& handler) const
+    {
+        switch (link.link_type()) {
+            case management::s3_external:
+                return core_.execute(
+                  core::operations::management::analytics_link_create_request<core::management::analytics::s3_external_link>{
+                    to_core_s3_external_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+
+            case management::azure_external:
+                return core_.execute(
+                  core::operations::management::analytics_link_create_request<core::management::analytics::azure_blob_external_link>{
+                    to_core_azure_blob_external_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+
+            case management::couchbase_remote:
+                return core_.execute(
+                  core::operations::management::analytics_link_create_request<core::management::analytics::couchbase_remote_link>{
+                    to_core_couchbase_remote_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+        }
+    }
+
+    void replace_link(const management::analytics_link& link,
+                      const replace_link_analytics_options::built& options,
+                      replace_link_analytics_handler&& handler) const
+    {
+        switch (link.link_type()) {
+            case management::s3_external:
+                return core_.execute(
+                  core::operations::management::analytics_link_replace_request<core::management::analytics::s3_external_link>{
+                    to_core_s3_external_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+
+            case management::azure_external:
+                return core_.execute(
+                  core::operations::management::analytics_link_replace_request<core::management::analytics::azure_blob_external_link>{
+                    to_core_azure_blob_external_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+
+            case management::couchbase_remote:
+                return core_.execute(
+                  core::operations::management::analytics_link_replace_request<core::management::analytics::couchbase_remote_link>{
+                    to_core_couchbase_remote_link(link),
+                    {},
+                    options.timeout,
+                  },
+                  [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+        }
+    }
+
+    void drop_link(const std::string& link_name,
+                   const std::string& dataverse_name,
+                   const drop_link_analytics_options::built& options,
+                   drop_link_analytics_handler&& handler) const
+    {
+        return core_.execute(
+          core::operations::management::analytics_link_drop_request{
+            link_name,
+            dataverse_name,
+            {},
+            options.timeout,
+          },
+          [handler = std::move(handler)](auto resp) { handler(build_context(resp)); });
+    }
+
+    void get_links(const get_links_analytics_options::built& options, get_links_analytics_handler&& handler) const
+    {
+        core::operations::management::analytics_link_get_all_request req{
+            {}, {}, {}, {}, options.timeout,
+        };
+        if (options.name.has_value()) {
+            req.link_name = options.name.value();
+        }
+        if (options.dataverse_name.has_value()) {
+            req.dataverse_name = options.dataverse_name.value();
+        }
+        if (options.link_type.has_value()) {
+            switch (options.link_type.value()) {
+                case management::s3_external:
+                    req.link_type = "s3";
+                    break;
+                case management::azure_external:
+                    req.link_type = "azureblob";
+                    break;
+                case management::couchbase_remote:
+                    req.link_type = "couchbase";
+                    break;
+            }
+        }
+        return core_.execute(req, [handler = std::move(handler)](core::operations::management::analytics_link_get_all_response resp) {
+            if (resp.ctx.ec) {
+                return handler(build_context(resp), {});
+            }
+            std::vector<std::unique_ptr<management::analytics_link>> links{};
+
+            for (const auto& link : resp.couchbase) {
+                auto cb_link = std::make_unique<management::couchbase_remote_analytics_link>();
+                cb_link->name = link.link_name;
+                cb_link->dataverse_name = link.dataverse;
+                cb_link->hostname = link.hostname;
+                switch (link.encryption.level) {
+                    case core::management::analytics::couchbase_link_encryption_level::none:
+                        cb_link->encryption.encryption_level = management::analytics_encryption_level::none;
+                        break;
+                    case core::management::analytics::couchbase_link_encryption_level::half:
+                        cb_link->encryption.encryption_level = management::analytics_encryption_level::half;
+                        break;
+                    case core::management::analytics::couchbase_link_encryption_level::full:
+                        cb_link->encryption.encryption_level = management::analytics_encryption_level::full;
+                        break;
+                }
+                cb_link->encryption.certificate = link.encryption.certificate;
+                cb_link->encryption.client_certificate = link.encryption.client_certificate;
+                cb_link->username = link.username;
+                links.push_back(std::move(cb_link));
+            }
+
+            for (const auto& link : resp.s3) {
+                auto s3_link = std::make_unique<management::s3_external_analytics_link>();
+                s3_link->name = link.link_name;
+                s3_link->dataverse_name = link.dataverse;
+                s3_link->access_key_id = link.access_key_id;
+                s3_link->region = link.region;
+                s3_link->service_endpoint = link.service_endpoint;
+                links.push_back(std::move(s3_link));
+            }
+
+            for (const auto& link : resp.azure_blob) {
+                auto azure_link = std::make_unique<management::azure_blob_external_analytics_link>();
+                azure_link->name = link.link_name;
+                azure_link->dataverse_name = link.dataverse;
+                azure_link->account_name = link.account_name;
+                azure_link->blob_endpoint = link.blob_endpoint;
+                azure_link->endpoint_suffix = link.endpoint_suffix;
+                links.push_back(std::move(azure_link));
+            }
+
+            handler(build_context(resp), std::move(links));
+        });
+    }
+
+  private:
+    static const inline std::string DEFAULT_DATAVERSE_NAME = "Default";
+    static const inline std::string DEFAULT_LINK_NAME = "Local";
+
+    core::cluster core_;
+};
+
+analytics_index_manager::analytics_index_manager(core::cluster core)
+  : impl_(std::make_shared<analytics_index_manager_impl>(std::move(core)))
+{
+}
+
+void
+analytics_index_manager::create_dataverse(std::string dataverse_name,
+                                          const create_dataverse_analytics_options& options,
+                                          create_dataverse_analytics_handler&& handler) const
+{
+    return impl_->create_dataverse(dataverse_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::create_dataverse(std::string dataverse_name, const create_dataverse_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    create_dataverse(std::move(dataverse_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::drop_dataverse(std::string dataverse_name,
+                                        const drop_dataverse_analytics_options& options,
+                                        drop_dataverse_analytics_handler&& handler) const
+{
+    return impl_->drop_dataverse(dataverse_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::drop_dataverse(std::string dataverse_name, const drop_dataverse_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    drop_dataverse(std::move(dataverse_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::create_dataset(std::string dataset_name,
+                                        std::string bucket_name,
+                                        const create_dataset_analytics_options& options,
+                                        create_dataset_analytics_handler&& handler) const
+{
+    return impl_->create_dataset(dataset_name, bucket_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::create_dataset(std::string dataset_name,
+                                        std::string bucket_name,
+                                        const create_dataset_analytics_options& options) const -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    create_dataset(
+      std::move(dataset_name), std::move(bucket_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::drop_dataset(std::string dataset_name,
+                                      const drop_dataset_analytics_options& options,
+                                      drop_dataset_analytics_handler&& handler) const
+{
+    return impl_->drop_dataset(dataset_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::drop_dataset(std::string dataset_name, const drop_dataset_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    drop_dataset(std::move(dataset_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::get_all_datasets(const get_all_datasets_analytics_options& options,
+                                          get_all_datasets_analytics_handler&& handler) const
+{
+    return impl_->get_all_datasets(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::get_all_datasets(const get_all_datasets_analytics_options& options) const
+  -> std::future<std::pair<manager_error_context, std::vector<management::analytics_dataset>>>
+{
+    auto barrier = std::make_shared<std::promise<std::pair<manager_error_context, std::vector<management::analytics_dataset>>>>();
+    auto future = barrier->get_future();
+    get_all_datasets(options, [barrier](auto ctx, auto resp) mutable { barrier->set_value({ std::move(ctx), std::move(resp) }); });
+    return future;
+}
+
+void
+analytics_index_manager::create_index(std::string index_name,
+                                      std::string dataset_name,
+                                      std::map<std::string, std::string> fields,
+                                      const create_index_analytics_options& options,
+                                      create_index_analytics_handler&& handler) const
+{
+    return impl_->create_index(index_name, dataset_name, fields, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::create_index(std::string index_name,
+                                      std::string dataset_name,
+                                      std::map<std::string, std::string> fields,
+                                      const create_index_analytics_options& options) const -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    create_index(std::move(index_name), std::move(dataset_name), std::move(fields), options, [barrier](auto ctx) mutable {
+        barrier->set_value({ std::move(ctx) });
+    });
+    return future;
+}
+
+void
+analytics_index_manager::drop_index(std::string index_name,
+                                    std::string dataset_name,
+                                    const drop_index_analytics_options& options,
+                                    drop_index_analytics_handler&& handler) const
+{
+    return impl_->drop_index(index_name, dataset_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::drop_index(std::string index_name, std::string dataset_name, const drop_index_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    drop_index(
+      std::move(index_name), std::move(dataset_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::get_all_indexes(const get_all_indexes_analytics_options& options,
+                                         get_all_indexes_analytics_handler&& handler) const
+{
+    return impl_->get_all_indexes(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::get_all_indexes(const get_all_indexes_analytics_options& options) const
+  -> std::future<std::pair<manager_error_context, std::vector<management::analytics_index>>>
+{
+    auto barrier = std::make_shared<std::promise<std::pair<manager_error_context, std::vector<management::analytics_index>>>>();
+    auto future = barrier->get_future();
+    get_all_indexes(options, [barrier](auto ctx, auto resp) mutable { barrier->set_value({ std::move(ctx), std::move(resp) }); });
+    return future;
+}
+
+void
+analytics_index_manager::connect_link(const connect_link_analytics_options& options, connect_link_analytics_handler&& handler) const
+{
+    return impl_->connect_link(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::connect_link(const connect_link_analytics_options& options) const -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    connect_link(options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::disconnect_link(const disconnect_link_analytics_options& options,
+                                         disconnect_link_analytics_handler&& handler) const
+{
+    return impl_->disconnect_link(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::disconnect_link(const disconnect_link_analytics_options& options) const -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    disconnect_link(options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::get_pending_mutations(const get_pending_mutations_analytics_options& options,
+                                               get_pending_mutations_analytics_handler&& handler) const
+{
+    return impl_->get_pending_mutations(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::get_pending_mutations(const get_pending_mutations_analytics_options& options) const
+  -> std::future<std::pair<couchbase::manager_error_context, std::map<std::string, std::map<std::string, std::int64_t>>>>
+{
+    auto barrier = std::make_shared<
+      std::promise<std::pair<couchbase::manager_error_context, std::map<std::string, std::map<std::string, std::int64_t>>>>>();
+    auto future = barrier->get_future();
+    get_pending_mutations(options, [barrier](auto ctx, auto resp) mutable { barrier->set_value({ std::move(ctx), std::move(resp) }); });
+    return future;
+}
+
+void
+analytics_index_manager::create_link(const management::analytics_link& link,
+                                     const create_link_analytics_options& options,
+                                     create_link_analytics_handler&& handler) const
+{
+    return impl_->create_link(link, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::create_link(const management::analytics_link& link, const create_link_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    create_link(link, options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::replace_link(const management::analytics_link& link,
+                                      const replace_link_analytics_options& options,
+                                      replace_link_analytics_handler&& handler) const
+{
+    return impl_->replace_link(link, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::replace_link(const management::analytics_link& link, const replace_link_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    replace_link(link, options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::drop_link(std::string link_name,
+                                   std::string dataverse_name,
+                                   const drop_link_analytics_options& options,
+                                   drop_link_analytics_handler&& handler) const
+{
+    return impl_->drop_link(link_name, dataverse_name, options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::drop_link(std::string link_name, std::string dataverse_name, const drop_link_analytics_options& options) const
+  -> std::future<manager_error_context>
+{
+    auto barrier = std::make_shared<std::promise<manager_error_context>>();
+    auto future = barrier->get_future();
+    drop_link(
+      std::move(link_name), std::move(dataverse_name), options, [barrier](auto ctx) mutable { barrier->set_value({ std::move(ctx) }); });
+    return future;
+}
+
+void
+analytics_index_manager::get_links(const get_links_analytics_options& options, get_links_analytics_handler&& handler) const
+{
+    return impl_->get_links(options.build(), std::move(handler));
+}
+
+auto
+analytics_index_manager::get_links(const get_links_analytics_options& options) const
+  -> std::future<std::pair<manager_error_context, std::vector<std::unique_ptr<management::analytics_link>>>>
+{
+    auto barrier =
+      std::make_shared<std::promise<std::pair<manager_error_context, std::vector<std::unique_ptr<management::analytics_link>>>>>();
+    auto future = barrier->get_future();
+    get_links(options, [barrier](auto ctx, auto resp) mutable { barrier->set_value({ std::move(ctx), std::move(resp) }); });
+    return future;
+}
+
+management::analytics_link::analytics_link(std::string name, std::string dataverse_name)
+  : name(std::move(name))
+  , dataverse_name(std::move(dataverse_name))
+{
+}
+
+management::couchbase_remote_analytics_link::couchbase_remote_analytics_link(std::string name,
+                                                                             std::string dataverse_name,
+                                                                             std::string hostname,
+                                                                             couchbase_analytics_encryption_settings encryption,
+                                                                             std::optional<std::string> username,
+                                                                             std::optional<std::string> password)
+  : analytics_link(std::move(name), std::move(dataverse_name))
+  , hostname(std::move(hostname))
+  , encryption(std::move(encryption))
+  , username(std::move(username))
+  , password(std::move(password))
+{
+}
+
+management::s3_external_analytics_link::s3_external_analytics_link(std::string name,
+                                                                   std::string dataverse_name,
+                                                                   std::string access_key_id,
+                                                                   std::string secret_access_key,
+                                                                   std::string region,
+                                                                   std::optional<std::string> session_token,
+                                                                   std::optional<std::string> service_endpoint)
+  : analytics_link(std::move(name), std::move(dataverse_name))
+  , access_key_id(std::move(access_key_id))
+  , secret_access_key(std::move(secret_access_key))
+  , region(std::move(region))
+  , session_token(std::move(session_token))
+  , service_endpoint(std::move(service_endpoint))
+{
+}
+
+management::azure_blob_external_analytics_link::azure_blob_external_analytics_link(std::string name,
+                                                                                   std::string dataverse_name,
+                                                                                   std::optional<std::string> connection_string,
+                                                                                   std::optional<std::string> account_name,
+                                                                                   std::optional<std::string> account_key,
+                                                                                   std::optional<std::string> shared_access_signature,
+                                                                                   std::optional<std::string> blob_endpoint,
+                                                                                   std::optional<std::string> endpoint_suffix)
+  : analytics_link(std::move(name), std::move(dataverse_name))
+  , connection_string(std::move(connection_string))
+  , account_name(std::move(account_name))
+  , account_key(std::move(account_key))
+  , shared_access_signature(std::move(shared_access_signature))
+  , blob_endpoint(std::move(blob_endpoint))
+  , endpoint_suffix(std::move(endpoint_suffix))
+{
+}
+} // namespace couchbase

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -325,6 +325,12 @@ cluster::query_indexes() const -> query_index_manager
 }
 
 auto
+cluster::analytics_indexes() const -> analytics_index_manager
+{
+    return analytics_index_manager{ impl_->core() };
+}
+
+auto
 cluster::bucket(std::string_view bucket_name) const -> couchbase::bucket
 {
     return { impl_->core(), bucket_name };

--- a/couchbase/analytics_index_manager.hxx
+++ b/couchbase/analytics_index_manager.hxx
@@ -1,0 +1,463 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/connect_link_analytics_options.hxx>
+#include <couchbase/create_dataset_analytics_options.hxx>
+#include <couchbase/create_dataverse_analytics_options.hxx>
+#include <couchbase/create_index_analytics_options.hxx>
+#include <couchbase/create_link_analytics_options.hxx>
+#include <couchbase/disconnect_link_analytics_options.hxx>
+#include <couchbase/drop_dataset_analytics_options.hxx>
+#include <couchbase/drop_dataverse_analytics_options.hxx>
+#include <couchbase/drop_index_analytics_options.hxx>
+#include <couchbase/drop_link_analytics_options.hxx>
+#include <couchbase/get_all_datasets_analytics_options.hxx>
+#include <couchbase/get_all_indexes_analytics_options.hxx>
+#include <couchbase/get_links_analytics_options.hxx>
+#include <couchbase/get_pending_mutations_analytics_options.hxx>
+#include <couchbase/management/analytics_dataset.hxx>
+#include <couchbase/management/analytics_index.hxx>
+#include <couchbase/management/analytics_link.hxx>
+#include <couchbase/manager_error_context.hxx>
+#include <couchbase/replace_link_analytics_options.hxx>
+
+#include <future>
+#include <string>
+#include <utility>
+
+namespace couchbase
+{
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
+namespace core
+{
+class cluster;
+} // namespace core
+class analytics_index_manager_impl;
+#endif
+
+class analytics_index_manager
+{
+  public:
+    /**
+     * Creates a new dataset (analytics scope).
+     *
+     * @param dataverse_name the name of the dataverse to create
+     * @param options optional parameters
+     * @param handler the handler that implements @ref create_dataverse_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void create_dataverse(std::string dataverse_name,
+                          const create_dataverse_analytics_options& options,
+                          create_dataverse_analytics_handler&& handler) const;
+
+    /**
+     * Creates a new dataset (analytics scope).
+     *
+     * @param dataverse_name the name of the dataverse to create
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto create_dataverse(std::string dataverse_name, const create_dataverse_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Drops (deletes) a dataverse.
+     *
+     * @param dataverse_name the name of the dataverse to drop
+     * @param options optional parameters
+     * @param handler the handler that implements @ref drop_dataverse_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void drop_dataverse(std::string dataverse_name,
+                        const drop_dataverse_analytics_options& options,
+                        drop_dataverse_analytics_handler&& handler) const;
+
+    /**
+     * Drops (deletes) a dataverse.
+     *
+     * @param dataverse_name the name of the dataverse to drop
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto drop_dataverse(std::string dataverse_name, const drop_dataverse_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Creates a new dataset (analytics collection).
+     *
+     * @param dataset_name the name of the dataset to create
+     * @param bucket_name the name of the bucket where the dataset should be stored into
+     * @param options optional parameters
+     * @param handler the handler that implements @ref create_dataset_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void create_dataset(std::string dataset_name,
+                        std::string bucket_name,
+                        const create_dataset_analytics_options& options,
+                        create_dataset_analytics_handler&& handler) const;
+
+    /**
+     * Creates a new dataset (analytics collection).
+     *
+     * @param dataset_name the name of the dataset to create
+     * @param bucket_name the name of the bucket where the dataset should be stored into
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto create_dataset(std::string dataset_name,
+                                      std::string bucket_name,
+                                      const create_dataset_analytics_options& options) const -> std::future<manager_error_context>;
+
+    /**
+     * Drops (deletes) a dataset.
+     *
+     * @param dataset_name the name of the dataset to drop
+     * @param options optional parameters
+     * @param handler the handler that implements @ref drop_dataset_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void drop_dataset(std::string dataset_name,
+                      const drop_dataset_analytics_options& options,
+                      drop_dataset_analytics_handler&& handler) const;
+
+    /**
+     * Drops (deletes) a dataset.
+     *
+     * @param dataset_name the name of the dataset to drop
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto drop_dataset(std::string dataset_name, const drop_dataset_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Fetches all datasets (analytics collections) from the analytics service.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implements @ref get_all_datasets_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void get_all_datasets(const get_all_datasets_analytics_options& options, get_all_datasets_analytics_handler&& handler) const;
+
+    /**
+     * Fetches all datasets (analytics collections) from the analytics service.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto get_all_datasets(const get_all_datasets_analytics_options& options) const
+      -> std::future<std::pair<manager_error_context, std::vector<management::analytics_dataset>>>;
+
+    /**
+     * Creates a new analytics index.
+     *
+     * @param index_name the name of the index to create
+     * @param dataset_name the name of the dataset where the index should be created
+     * @param fields the fields that should be indexed
+     * @param options optional parameters
+     * @param handler the handler that implements @ref create_index_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void create_index(std::string index_name,
+                      std::string dataset_name,
+                      std::map<std::string, std::string> fields,
+                      const create_index_analytics_options& options,
+                      create_index_analytics_handler&& handler) const;
+
+    /**
+     * Creates a new analytics index.
+     *
+     * @param index_name the name of the index to create
+     * @param dataset_name the name of the dataset where the index should be created
+     * @param fields the fields that should be indexed
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto create_index(std::string index_name,
+                                    std::string dataset_name,
+                                    std::map<std::string, std::string> fields,
+                                    const create_index_analytics_options& options) const -> std::future<manager_error_context>;
+
+    /**
+     * Drops (removes) an analytics index.
+     *
+     * @param index_name the name of the index to drop
+     * @param dataset_name the dataset where the index exists
+     * @param options optional parameters
+     * @param handler the handler that implements @ref drop_index_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void drop_index(std::string index_name,
+                    std::string dataset_name,
+                    const drop_index_analytics_options& options,
+                    drop_index_analytics_handler&& handler) const;
+
+    /**
+     * Drops (removes) an analytics index.
+     *
+     * @param index_name the name of the index to drop
+     * @param dataset_name the dataset where the index exists
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto drop_index(std::string index_name, std::string dataset_name, const drop_index_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Fetches all analytics indexes.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implements @ref get_all_indexes_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void get_all_indexes(const get_all_indexes_analytics_options& options, get_all_indexes_analytics_handler&& handler) const;
+
+    /**
+     * Fetches all analytics indexes.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto get_all_indexes(const get_all_indexes_analytics_options& options) const
+      -> std::future<std::pair<manager_error_context, std::vector<management::analytics_index>>>;
+
+    /**
+     * Connects a not yet connected link.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implements @ref connect_link_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void connect_link(const connect_link_analytics_options& options, connect_link_analytics_handler&& handler) const;
+
+    /**
+     * Connects a not yet connected link.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto connect_link(const connect_link_analytics_options& options) const -> std::future<manager_error_context>;
+
+    /**
+     * Disconnects a currently connected link.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implements @ref disconnect_link_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void disconnect_link(const disconnect_link_analytics_options& options, disconnect_link_analytics_handler&& handler) const;
+
+    /**
+     * Disconnects a currently connected link.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto disconnect_link(const disconnect_link_analytics_options& options) const -> std::future<manager_error_context>;
+
+    /**
+     * Returns the pending mutations for different dataverses.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implements @ref get_pending_mutations_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void get_pending_mutations(const get_pending_mutations_analytics_options& options,
+                               get_pending_mutations_analytics_handler&& handler) const;
+
+    /**
+     * Returns the pending mutations for different dataverses.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto get_pending_mutations(const get_pending_mutations_analytics_options& options) const
+      -> std::future<std::pair<couchbase::manager_error_context, std::map<std::string, std::map<std::string, std::int64_t>>>>;
+
+    /**
+     * Creates a new analytics remote link.
+     *
+     * @param link the settings for the link to be created
+     * @param options optional parameters
+     * @param handler the handler that implements @ref create_link_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void create_link(const management::analytics_link& link,
+                     const create_link_analytics_options& options,
+                     create_link_analytics_handler&& handler) const;
+
+    /**
+     * Creates a new analytics remote link.
+     *
+     * @param link the settings for the link to be created
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto create_link(const management::analytics_link& link, const create_link_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Replaces an existing analytics remote link.
+     *
+     * @param link the settings for the updated link
+     * @param options optional parameters
+     * @param handler the handler that implements @ref replace_link_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void replace_link(const management::analytics_link& link,
+                      const replace_link_analytics_options& options,
+                      replace_link_analytics_handler&& handler) const;
+
+    /**
+     * Replaces an existing analytics remote link.
+     *
+     * @param link the settings for the updated link
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto replace_link(const management::analytics_link& link, const replace_link_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Drops an existing analytics remote link.
+     *
+     * @param link_name the name of the link to drop
+     * @param dataverse_name the name of the dataverse containing the link to be dropped
+     * @param options optional parameters
+     * @param handler the handler that implements @ref drop_link_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void drop_link(std::string link_name,
+                   std::string dataverse_name,
+                   const drop_link_analytics_options& options,
+                   drop_link_analytics_handler&& handler) const;
+
+    /**
+     * Drops an existing analytics remote link.
+     *
+     * @param link_name the name of the link to drop
+     * @param dataverse_name the name of the dataverse containing the link to be dropped
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto drop_link(std::string link_name, std::string dataverse_name, const drop_link_analytics_options& options) const
+      -> std::future<manager_error_context>;
+
+    /**
+     * Fetches the existing analytics remote links.
+     *
+     * @param options optional parameters
+     * @param handler the handler that implemenets @ref get_links_analytics_handler
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void get_links(const get_links_analytics_options& options, get_links_analytics_handler&& handler) const;
+
+    /**
+     * Fetches the existing analytics remote links.
+     *
+     * @param options optional parameters
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto get_links(const get_links_analytics_options& options) const
+      -> std::future<std::pair<manager_error_context, std::vector<std::unique_ptr<management::analytics_link>>>>;
+
+  private:
+    friend class cluster;
+
+    explicit analytics_index_manager(core::cluster core);
+
+    std::shared_ptr<analytics_index_manager_impl> impl_;
+};
+
+} // namespace couchbase

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <couchbase/analytics_index_manager.hxx>
 #include <couchbase/analytics_options.hxx>
 #include <couchbase/bucket.hxx>
 #include <couchbase/bucket_manager.hxx>
@@ -215,6 +216,16 @@ class cluster
      * @committed
      */
     [[nodiscard]] auto query_indexes() const -> query_index_manager;
+
+    /**
+     * Provides access ot the Analytics index management services.
+     *
+     * @return a manager instance
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto analytics_indexes() const -> analytics_index_manager;
 
     /**
      * Provides access to the bucket management services.

--- a/couchbase/connect_link_analytics_options.hxx
+++ b/couchbase/connect_link_analytics_options.hxx
@@ -1,0 +1,116 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class connect_link_analytics_options : public common_options<connect_link_analytics_options>
+{
+  public:
+    /**
+     * The name of the dataverse in which the link should be disconnected.
+     *
+     * defaults to `Default`
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> connect_link_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * The name of the link
+     *
+     * defaults to `Local`
+     *
+     * @param link_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto link_name(std::string link_name) -> connect_link_analytics_options&
+    {
+        link_name_ = std::move(link_name);
+        return self();
+    }
+
+    /**
+     * Whether to force link creation even if the bucket UUID changed, for example, due to the bucket being deleted and recreated.
+     */
+    auto force(bool force) -> connect_link_analytics_options&
+    {
+        force_ = force;
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<connect_link_analytics_options>::built {
+        std::optional<std::string> dataverse_name{};
+        std::optional<std::string> link_name{};
+        bool force{ false };
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), dataverse_name_, link_name_, force_ };
+    }
+
+  private:
+    bool force_{ false };
+    std::optional<std::string> dataverse_name_{};
+    std::optional<std::string> link_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#connect_link() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using connect_link_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/create_dataset_analytics_options.hxx
+++ b/couchbase/create_dataset_analytics_options.hxx
@@ -1,0 +1,120 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class create_dataset_analytics_options : public common_options<create_dataset_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the dataset already exists.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_exists(bool ignore_if_exists) -> create_dataset_analytics_options&
+    {
+        ignore_if_exists_ = ignore_if_exists;
+        return self();
+    }
+
+    /**
+     * WHERE clause to use for creating the dataset
+     *
+     * @param condition
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto condition(std::string condition) -> create_dataset_analytics_options&
+    {
+        condition_ = std::move(condition);
+        return self();
+    }
+
+    /**
+     * The name of the dataverse the dataset should be created into
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> create_dataset_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<create_dataset_analytics_options>::built {
+        bool ignore_if_exists{};
+        std::optional<std::string> condition{};
+        std::optional<std::string> dataverse_name{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_exists_, condition_, dataverse_name_ };
+    }
+
+  private:
+    bool ignore_if_exists_{ false };
+    std::optional<std::string> condition_{};
+    std::optional<std::string> dataverse_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#create_dataset() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using create_dataset_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/create_dataverse_analytics_options.hxx
+++ b/couchbase/create_dataverse_analytics_options.hxx
@@ -1,0 +1,85 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+
+namespace couchbase
+{
+class create_dataverse_analytics_options : public common_options<create_dataverse_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the dataverse already exists.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_exists(bool ignore_if_exists) -> create_dataverse_analytics_options&
+    {
+        ignore_if_exists_ = ignore_if_exists;
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<create_dataverse_analytics_options>::built {
+        bool ignore_if_exists{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_exists_ };
+    }
+
+  private:
+    bool ignore_if_exists_{ false };
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#create_dataverse() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+
+using create_dataverse_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/create_index_analytics_options.hxx
+++ b/couchbase/create_index_analytics_options.hxx
@@ -1,0 +1,103 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class create_index_analytics_options : public common_options<create_index_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the index already exists.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_exists(bool ignore_if_exists) -> create_index_analytics_options&
+    {
+        ignore_if_exists_ = ignore_if_exists;
+        return self();
+    }
+
+    /**
+     * The name of the dataverse the index should be created into
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> create_index_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<create_index_analytics_options>::built {
+        bool ignore_if_exists{};
+        std::optional<std::string> dataverse_name{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_exists_, dataverse_name_ };
+    }
+
+  private:
+    bool ignore_if_exists_{ false };
+    std::optional<std::string> dataverse_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#create_index() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using create_index_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/create_link_analytics_options.hxx
+++ b/couchbase/create_link_analytics_options.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+
+namespace couchbase
+{
+class create_link_analytics_options : public common_options<create_link_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<create_link_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#create_link() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using create_link_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/disconnect_link_analytics_options.hxx
+++ b/couchbase/disconnect_link_analytics_options.hxx
@@ -1,0 +1,105 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class disconnect_link_analytics_options : public common_options<disconnect_link_analytics_options>
+{
+  public:
+    /**
+     * The name of the dataverse to connect to.
+     *
+     * defaults to `Default`
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> disconnect_link_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * The name of the link
+     *
+     * defaults to `Local`
+     *
+     * @param link_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto link_name(std::string link_name) -> disconnect_link_analytics_options&
+    {
+        link_name_ = std::move(link_name);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<disconnect_link_analytics_options>::built {
+        std::optional<std::string> dataverse_name{};
+        std::optional<std::string> link_name{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), dataverse_name_, link_name_ };
+    }
+
+  private:
+    std::optional<std::string> dataverse_name_{};
+    std::optional<std::string> link_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#disconnect_link() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using disconnect_link_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/drop_dataset_analytics_options.hxx
+++ b/couchbase/drop_dataset_analytics_options.hxx
@@ -1,0 +1,103 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class drop_dataset_analytics_options : public common_options<drop_dataset_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the dataset does not exist.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_not_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_not_exists(bool ignore_if_not_exists) -> drop_dataset_analytics_options&
+    {
+        ignore_if_not_exists_ = ignore_if_not_exists;
+        return self();
+    }
+
+    /**
+     * The name of the dataverse the dataset should be dropped from
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> drop_dataset_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<drop_dataset_analytics_options>::built {
+        bool ignore_if_not_exists{};
+        std::optional<std::string> dataverse_name{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_not_exists_, dataverse_name_ };
+    }
+
+  private:
+    bool ignore_if_not_exists_{ false };
+    std::optional<std::string> dataverse_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#drop_dataset() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using drop_dataset_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/drop_dataverse_analytics_options.hxx
+++ b/couchbase/drop_dataverse_analytics_options.hxx
@@ -1,0 +1,84 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+
+namespace couchbase
+{
+class drop_dataverse_analytics_options : public common_options<drop_dataverse_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the dataverse does not exist.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_not_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_not_exists(bool ignore_if_not_exists) -> drop_dataverse_analytics_options&
+    {
+        ignore_if_not_exists_ = ignore_if_not_exists;
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<drop_dataverse_analytics_options>::built {
+        bool ignore_if_not_exists{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_not_exists_ };
+    }
+
+  private:
+    bool ignore_if_not_exists_{ false };
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#drop_dataverse() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using drop_dataverse_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/drop_index_analytics_options.hxx
+++ b/couchbase/drop_index_analytics_options.hxx
@@ -1,0 +1,103 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class drop_index_analytics_options : public common_options<drop_index_analytics_options>
+{
+  public:
+    /**
+     * Ignore error if the index does not exist.
+     *
+     * defaults to `false`
+     *
+     * @param ignore_if_not_exists
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ignore_if_not_exists(bool ignore_if_not_exists) -> drop_index_analytics_options&
+    {
+        ignore_if_not_exists_ = ignore_if_not_exists;
+        return self();
+    }
+
+    /**
+     * The name of the dataverse the index should be dropped from
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> drop_index_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<drop_index_analytics_options>::built {
+        bool ignore_if_not_exists{};
+        std::optional<std::string> dataverse_name{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ignore_if_not_exists_, dataverse_name_ };
+    }
+
+  private:
+    bool ignore_if_not_exists_{ false };
+    std::optional<std::string> dataverse_name_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#drop_index() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using drop_index_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/drop_link_analytics_options.hxx
+++ b/couchbase/drop_link_analytics_options.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+
+namespace couchbase
+{
+class drop_link_analytics_options : public common_options<drop_link_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<drop_link_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#drop_link() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using drop_link_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/couchbase/get_all_datasets_analytics_options.hxx
+++ b/couchbase/get_all_datasets_analytics_options.hxx
@@ -1,0 +1,66 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/management/analytics_dataset.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <vector>
+
+namespace couchbase
+{
+class get_all_datasets_analytics_options : public common_options<get_all_datasets_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<get_all_datasets_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#get_all_datasets() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using get_all_datasets_analytics_handler =
+  std::function<void(couchbase::manager_error_context, std::vector<management::analytics_dataset>)>;
+} // namespace couchbase

--- a/couchbase/get_all_indexes_analytics_options.hxx
+++ b/couchbase/get_all_indexes_analytics_options.hxx
@@ -1,0 +1,65 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/management/analytics_index.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <vector>
+
+namespace couchbase
+{
+class get_all_indexes_analytics_options : public common_options<get_all_indexes_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<get_all_indexes_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#get_all_indexes() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using get_all_indexes_analytics_handler = std::function<void(couchbase::manager_error_context, std::vector<management::analytics_index>)>;
+} // namespace couchbase

--- a/couchbase/get_links_analytics_options.hxx
+++ b/couchbase/get_links_analytics_options.hxx
@@ -1,0 +1,121 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/management/analytics_link.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace couchbase
+{
+class get_links_analytics_options : public common_options<get_links_analytics_options>
+{
+  public:
+    /**
+     * The name of the dataverse to restrict returned links to.
+     *
+     * @param dataverse_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto dataverse_name(std::string dataverse_name) -> get_links_analytics_options&
+    {
+        dataverse_name_ = std::move(dataverse_name);
+        return self();
+    }
+
+    /**
+     * The name of the link to fetch.
+     *
+     * @param link_name
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto name(std::string name) -> get_links_analytics_options&
+    {
+        name_ = std::move(name);
+        return self();
+    }
+
+    /**
+     * The type of links to restrict returned links to.
+     *
+     * @param link_type
+     * @return reference to this object, for use in chaining
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto link_type(management::analytics_link_type link_type) -> get_links_analytics_options&
+    {
+        link_type_ = link_type;
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<get_links_analytics_options>::built {
+        std::optional<std::string> dataverse_name{};
+        std::optional<std::string> name{};
+        std::optional<management::analytics_link_type> link_type{};
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), dataverse_name_, name_, link_type_ };
+    }
+
+  private:
+    std::optional<std::string> dataverse_name_{};
+    std::optional<std::string> name_{};
+    std::optional<management::analytics_link_type> link_type_{};
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#get_links() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using get_links_analytics_handler =
+  std::function<void(couchbase::manager_error_context, std::vector<std::unique_ptr<management::analytics_link>>)>;
+} // namespace couchbase

--- a/couchbase/get_pending_mutations_analytics_options.hxx
+++ b/couchbase/get_pending_mutations_analytics_options.hxx
@@ -1,0 +1,67 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace couchbase
+{
+class get_pending_mutations_analytics_options : public common_options<get_pending_mutations_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<get_pending_mutations_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#get_pending_mutations() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using get_pending_mutations_analytics_handler =
+  std::function<void(couchbase::manager_error_context, std::map<std::string, std::map<std::string, std::int64_t>>)>;
+} // namespace couchbase

--- a/couchbase/management/analytics_dataset.hxx
+++ b/couchbase/management/analytics_dataset.hxx
@@ -1,0 +1,48 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace couchbase::management
+{
+/**
+ * Represents a dataset (collection) in the analytics service
+ */
+struct analytics_dataset {
+    /**
+     * The name of the dataset (collection)
+     */
+    std::string name;
+
+    /**
+     * The name of the dataverse (scope) the dataset is stored in
+     */
+    std::string dataverse_name;
+
+    /**
+     * The name of the analytics link that is associated with the dataset
+     */
+    std::string link_name;
+
+    /**
+     * The name of the bucket that the dataset includes
+     */
+    std::string bucket_name;
+};
+} // namespace couchbase::management

--- a/couchbase/management/analytics_index.hxx
+++ b/couchbase/management/analytics_index.hxx
@@ -1,0 +1,48 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace couchbase::management
+{
+/**
+ * Represents an index in the analytics service.
+ */
+struct analytics_index {
+    /**
+     * The name of the analytics index
+     */
+    std::string name;
+
+    /**
+     * The name of the dataset (collection) this index is part of
+     */
+    std::string dataset_name;
+
+    /**
+     * The name of the dataverse (scope) this index is part of
+     */
+    std::string dataverse_name;
+
+    /**
+     * Whether this index is a primary index
+     */
+    bool is_primary;
+};
+} // namespace couchbase::management

--- a/couchbase/management/analytics_link.hxx
+++ b/couchbase/management/analytics_link.hxx
@@ -1,0 +1,239 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace couchbase::management
+{
+
+enum analytics_link_type {
+    /**
+     * S3 external analytics link. Corresponds to a @ref s3_external_analytics_link
+     */
+    s3_external,
+
+    /**
+     * Azure external analytics link. Corresponds to a @ref azure_blob_external_analytics_link
+     */
+    azure_external,
+
+    /**
+     * A remote analytics link that uses a Couchbase data service that is not part of the same cluster as the Analytics service.
+     * Corresponds to a @ref couchbase_remote_analytics_link
+     */
+    couchbase_remote,
+};
+
+enum analytics_encryption_level {
+    /**
+     * Connect to the remote Couchbase cluster using an unsecured channel. Send the password in plaintext.
+     */
+    none,
+
+    /**
+     * Connect to the remote Couchbase cluster using an unsecured channel. Send the password securely using SASL.
+     */
+    half,
+
+    /**
+     * Connect to the remote Couchbase cluster using a channel secured by TLS. If a password is used, it is sent over the secure channel.
+     *
+     * Requires specifying the certificate to trust.
+     */
+    full
+};
+
+struct analytics_link {
+    std::string name;
+    std::string dataverse_name;
+
+    virtual ~analytics_link() = default;
+
+    /**
+     * Returns the type of this analytics link
+     *
+     * @return the link type
+     */
+    [[nodiscard]] virtual analytics_link_type link_type() const = 0;
+
+    analytics_link() = default;
+    analytics_link(std::string name, std::string dataverse_name);
+};
+
+struct couchbase_analytics_encryption_settings {
+    /**
+     * Specifies what level of encryption should be applied
+     */
+    analytics_encryption_level encryption_level{ analytics_encryption_level::none };
+
+    /**
+     * The certificate to use for encryption when the encryption level is set to 'full'.
+     */
+    std::optional<std::string> certificate{};
+
+    /**
+     * The certificate to use for authenticating when the encryption level is set to 'full'. Cannot be set if a username and password are
+     * provided
+     */
+    std::optional<std::string> client_certificate{};
+
+    /**
+     * The client key to use for authenticating when the encryption level is set to 'full'.  Cannot be set if a username and password are
+     * provided
+     */
+    std::optional<std::string> client_key{};
+};
+
+struct couchbase_remote_analytics_link : analytics_link {
+    std::string hostname;
+    couchbase_analytics_encryption_settings encryption{};
+    std::optional<std::string> username{};
+    std::optional<std::string> password{};
+
+    [[nodiscard]] analytics_link_type link_type() const override
+    {
+        return analytics_link_type::couchbase_remote;
+    }
+
+    /**
+     * Constructs an empty remote Couchbase analytics link.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    couchbase_remote_analytics_link() = default;
+
+    /**
+     * Constructs and initializes a remote Couchbase analytics link with the given parameters. A remote analytics link uses a Couchbase data
+     * service that is not part of the same cluster as the Analytics service.
+     *
+     * @param name the name of the link
+     * @param dataverse_name the dataverse that the link belongs to. Its format can be one part `dataversename` or two parts
+     * `bucket_name/scope_name`
+     * @param hostname the hostname of the target Couchbase cluster
+     * @param encryption the encryption settings for the link
+     * @param username the username to use for authentication with the remote cluster. Optional if client certificate authentication is
+     * being used
+     * @param password the password to use for authentication with the remote cluster. Optional if client-certificate authentication is
+     * being used
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    couchbase_remote_analytics_link(std::string name,
+                                    std::string dataverse_name,
+                                    std::string hostname,
+                                    couchbase_analytics_encryption_settings encryption = {},
+                                    std::optional<std::string> username = {},
+                                    std::optional<std::string> password = {});
+};
+
+struct s3_external_analytics_link : analytics_link {
+    std::string access_key_id;
+    std::string secret_access_key;
+    std::string region;
+    std::optional<std::string> session_token{};
+    std::optional<std::string> service_endpoint{};
+
+    [[nodiscard]] analytics_link_type link_type() const override
+    {
+        return analytics_link_type::s3_external;
+    }
+
+    /**
+     * Constructs an empty external S3 analytics link
+     *
+     * @committed
+     * @since 1.0.0
+     */
+    s3_external_analytics_link() = default;
+
+    /**
+     * Constructs and initializes an external S3 analytics link with the given parameters.
+     *
+     * @param name the name of the link
+     * @param dataverse_name the name of the dataverse the link belongs to
+     * @param access_key_id the AWS S3 access key
+     * @param secret_access_key the AWS S3 secret key
+     * @param region the AWS S3 region
+     * @param session_token the AWS S3 token if temporary credentials are provided
+     * @param service_endpoint the AWS S3 service endpoint
+     *
+     * @committed
+     * @since 1.0.0
+     */
+    s3_external_analytics_link(std::string name,
+                               std::string dataverse_name,
+                               std::string access_key_id,
+                               std::string secret_access_key,
+                               std::string region,
+                               std::optional<std::string> session_token = {},
+                               std::optional<std::string> service_endpoint = {});
+};
+
+struct azure_blob_external_analytics_link : analytics_link {
+    std::optional<std::string> connection_string{};
+    std::optional<std::string> account_name{};
+    std::optional<std::string> account_key{};
+    std::optional<std::string> shared_access_signature{};
+    std::optional<std::string> blob_endpoint{};
+    std::optional<std::string> endpoint_suffix{};
+
+    [[nodiscard]] analytics_link_type link_type() const override
+    {
+        return analytics_link_type::azure_external;
+    }
+
+    /**
+     * Constructs an empty external Azure blob analytics link.
+     *
+     * @committed
+     * @since 1.0.0
+     */
+    azure_blob_external_analytics_link() = default;
+
+    /**
+     * Constructs and initializes an external Azure blob analytics link.
+     *
+     * @param name the name of the link
+     * @param dataverse_name the name of the dataverse the link belongs to
+     * @param connection_string the connection string that can be used as an authentication method. It contains other authentication methods
+     * embedded inside the string. Only a single authentication method can be used (e.g.
+     * "AccountName=myAccountName;AccountKey=myAccountKey").
+     * @param account_name the Azure blob storage account name
+     * @param account_key the Azure blob storage account key
+     * @param shared_access_signature token that can be used for authentication
+     * @param blob_endpoint the Azure blob storage endpoint
+     * @param endpoint_suffix the Azure blob endpoint suffix
+     *
+     * @committed
+     * @since 1.0.0
+     */
+    azure_blob_external_analytics_link(std::string name,
+                                       std::string dataverse_name,
+                                       std::optional<std::string> connection_string = {},
+                                       std::optional<std::string> account_name = {},
+                                       std::optional<std::string> account_key = {},
+                                       std::optional<std::string> shared_access_signature = {},
+                                       std::optional<std::string> blob_endpoint = {},
+                                       std::optional<std::string> endpoint_suffix = {});
+};
+
+} // namespace couchbase::management

--- a/couchbase/replace_link_analytics_options.hxx
+++ b/couchbase/replace_link_analytics_options.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <functional>
+
+namespace couchbase
+{
+class replace_link_analytics_options : public common_options<replace_link_analytics_options>
+{
+  public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<replace_link_analytics_options>::built {
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options() };
+    }
+};
+
+/**
+ * The signature for the handler of the @ref analytics_index_manager#replace_link() operation
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+using replace_link_analytics_handler = std::function<void(couchbase::manager_error_context)>;
+} // namespace couchbase

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -2863,7 +2863,8 @@ TEST_CASE("integration: analytics index management with core API", "[integration
             REQUIRE_FALSE(index->is_primary);
         }
 
-        if (integration.cluster_version().supports_analytics_pending_mutations()) {
+        if (integration.cluster_version().supports_analytics_pending_mutations() && integration.cluster_version().major >= 7) {
+            // Getting unexpected result in 6.6
             couchbase::core::operations::management::analytics_get_pending_mutations_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
             REQUIRE_SUCCESS(resp.ctx.ec);
@@ -3486,14 +3487,13 @@ TEST_CASE("integration: analytics index management with public API", "[integrati
             REQUIRE_FALSE(index->is_primary);
         }
 
-        if (integration.cluster_version().supports_analytics_pending_mutations()) {
-            {
-                auto [ctx, res] = mgr.get_pending_mutations({}).get();
-                REQUIRE_SUCCESS(ctx.ec());
-                REQUIRE(res.count(dataverse_name) == 1);
-                REQUIRE(res[dataverse_name].count(dataset_name) == 1);
-                REQUIRE(res[dataverse_name][dataset_name] >= 0);
-            }
+        if (integration.cluster_version().supports_analytics_pending_mutations() && integration.cluster_version().major >= 7) {
+            // Getting unexpected result in 6.6
+            auto [ctx, res] = mgr.get_pending_mutations({}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+            REQUIRE(res.count(dataverse_name) == 1);
+            REQUIRE(res[dataverse_name].count(dataset_name) == 1);
+            REQUIRE(res[dataverse_name][dataset_name] >= 0);
         }
 
         {
@@ -3657,8 +3657,6 @@ run_s3_link_test_public_api(test::utils::integration_test_guard& integration,
         REQUIRE(s3_link.region == "us-east-1");
         REQUIRE(s3_link.service_endpoint.value() == "service_endpoint");
     }
-
-    return;
 
     {
         auto opts = couchbase::get_links_analytics_options()

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -44,6 +44,7 @@
 #include "couchbase/create_primary_query_index_options.hxx"
 #include "couchbase/create_query_index_options.hxx"
 #include "couchbase/drop_query_index_options.hxx"
+#include "couchbase/management/analytics_link.hxx"
 #include "couchbase/watch_query_indexes_options.hxx"
 
 using Catch::Approx;
@@ -2728,7 +2729,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
 }
 
-TEST_CASE("integration: analytics index management", "[integration]")
+TEST_CASE("integration: analytics index management with core API", "[integration]")
 {
     test::utils::integration_test_guard integration;
 
@@ -2866,7 +2867,10 @@ TEST_CASE("integration: analytics index management", "[integration]")
             couchbase::core::operations::management::analytics_get_pending_mutations_request req{};
             auto resp = test::utils::execute(integration.cluster, req);
             REQUIRE_SUCCESS(resp.ctx.ec);
-            REQUIRE(resp.stats[index_name] == 0);
+            // In the Core API the key has the `dataverse.dataset` format
+            auto key = fmt::format("{}.{}", dataverse_name, dataset_name);
+            REQUIRE(resp.stats.count(key) == 1);
+            REQUIRE(resp.stats[key] >= 0);
         }
 
         {
@@ -3026,7 +3030,7 @@ TEST_CASE("integration: analytics index management", "[integration]")
 }
 
 void
-run_s3_link_test(test::utils::integration_test_guard& integration, const std::string& dataverse_name, const std::string& link_name)
+run_s3_link_test_core_api(test::utils::integration_test_guard& integration, const std::string& dataverse_name, const std::string& link_name)
 {
     {
         couchbase::core::operations::management::analytics_dataverse_create_request req{};
@@ -3143,7 +3147,9 @@ run_s3_link_test(test::utils::integration_test_guard& integration, const std::st
 }
 
 void
-run_azure_link_test(test::utils::integration_test_guard& integration, const std::string& dataverse_name, const std::string& link_name)
+run_azure_link_test_core_api(test::utils::integration_test_guard& integration,
+                             const std::string& dataverse_name,
+                             const std::string& link_name)
 {
     {
         couchbase::core::operations::management::analytics_dataverse_create_request req{};
@@ -3261,7 +3267,7 @@ run_azure_link_test(test::utils::integration_test_guard& integration, const std:
     }
 }
 
-TEST_CASE("integration: analytics external link management", "[integration]")
+TEST_CASE("integration: analytics external link management with core API", "[integration]")
 {
     test::utils::integration_test_guard integration;
 
@@ -3319,13 +3325,13 @@ TEST_CASE("integration: analytics external link management", "[integration]")
 
         SECTION("s3")
         {
-            run_s3_link_test(integration, dataverse_name, link_name);
+            run_s3_link_test_core_api(integration, dataverse_name, link_name);
         }
 
         if (integration.cluster_version().supports_analytics_link_azure_blob()) {
             SECTION("azure")
             {
-                run_azure_link_test(integration, dataverse_name, link_name);
+                run_azure_link_test_core_api(integration, dataverse_name, link_name);
             }
         }
     }
@@ -3348,13 +3354,561 @@ TEST_CASE("integration: analytics external link management", "[integration]")
 
             SECTION("s3")
             {
-                run_s3_link_test(integration, dataverse_name, link_name);
+                run_s3_link_test_core_api(integration, dataverse_name, link_name);
             }
 
             if (integration.cluster_version().supports_analytics_link_azure_blob()) {
                 SECTION("azure")
                 {
-                    run_azure_link_test(integration, dataverse_name, link_name);
+                    run_azure_link_test_core_api(integration, dataverse_name, link_name);
+                }
+            }
+
+            {
+                couchbase::core::operations::management::scope_drop_request req{ integration.ctx.bucket, scope_name };
+                auto resp = test::utils::execute(integration.cluster, req);
+                REQUIRE_SUCCESS(resp.ctx.ec);
+            }
+        }
+    }
+}
+
+TEST_CASE("integration: analytics index management with public API", "[integration]")
+{
+    test::utils::integration_test_guard integration;
+
+    if (!integration.cluster_version().supports_analytics()) {
+        SKIP("cluster does not support analytics service");
+    }
+    if (!integration.has_analytics_service()) {
+        SKIP("cluster does not have analytics service");
+    }
+    if (integration.storage_backend() == couchbase::core::management::cluster::bucket_storage_backend::magma) {
+        SKIP("analytics does not work with magma storage backend, see MB-47718");
+    }
+
+    couchbase::cluster cluster{ integration.cluster };
+    auto mgr = cluster.analytics_indexes();
+
+    SECTION("crud")
+    {
+        auto dataverse_name = test::utils::uniq_id("dataverse");
+        auto dataset_name = test::utils::uniq_id("dataset");
+        auto index_name = test::utils::uniq_id("index");
+
+        {
+            auto ctx = mgr.create_dataverse(dataverse_name, {}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto ctx = mgr.create_dataverse(dataverse_name, {}).get();
+            REQUIRE(ctx.ec() == couchbase::errc::analytics::dataverse_exists);
+        }
+
+        {
+            auto opts = couchbase::create_dataverse_analytics_options().ignore_if_exists(true);
+            auto ctx = mgr.create_dataverse(dataverse_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::create_dataset_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.create_dataset(dataset_name, integration.ctx.bucket, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::create_dataset_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.create_dataset(dataset_name, integration.ctx.bucket, opts).get();
+            REQUIRE(ctx.ec() == couchbase::errc::analytics::dataset_exists);
+        }
+
+        {
+            auto opts = couchbase::create_dataset_analytics_options().dataverse_name(dataverse_name).ignore_if_exists(true);
+            auto ctx = mgr.create_dataset(dataset_name, integration.ctx.bucket, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::create_index_analytics_options().dataverse_name(dataverse_name);
+            std::map<std::string, std::string> fields{};
+            fields["testkey"] = "string";
+            auto ctx = mgr.create_index(index_name, dataset_name, fields, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::create_index_analytics_options().dataverse_name(dataverse_name);
+            std::map<std::string, std::string> fields{};
+            fields["testkey"] = "string";
+            auto ctx = mgr.create_index(index_name, dataset_name, fields, opts).get();
+            REQUIRE(ctx.ec() == couchbase::errc::common::index_exists);
+        }
+
+        {
+            auto opts = couchbase::create_index_analytics_options().dataverse_name(dataverse_name).ignore_if_exists(true);
+            std::map<std::string, std::string> fields{};
+            fields["testkey"] = "string";
+            auto ctx = mgr.create_index(index_name, dataset_name, fields, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto ctx = mgr.connect_link({}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto [ctx, res] = mgr.get_all_datasets({}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+            REQUIRE_FALSE(res.empty());
+
+            auto dataset = std::find_if(res.begin(), res.end(), [&dataset_name](const couchbase::management::analytics_dataset& d) {
+                return d.name == dataset_name;
+            });
+            REQUIRE(dataset != res.end());
+            REQUIRE(dataset->dataverse_name == dataverse_name);
+            REQUIRE(dataset->link_name == "Local");
+            REQUIRE(dataset->bucket_name == integration.ctx.bucket);
+        }
+
+        {
+            auto [ctx, res] = mgr.get_all_indexes({}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+            REQUIRE_FALSE(res.empty());
+
+            auto index = std::find_if(
+              res.begin(), res.end(), [&index_name](const couchbase::management::analytics_index& idx) { return idx.name == index_name; });
+            REQUIRE(index != res.end());
+            REQUIRE(index->dataverse_name == dataverse_name);
+            REQUIRE(index->dataset_name == dataset_name);
+            REQUIRE_FALSE(index->is_primary);
+        }
+
+        if (integration.cluster_version().supports_analytics_pending_mutations()) {
+            {
+                auto [ctx, res] = mgr.get_pending_mutations({}).get();
+                REQUIRE_SUCCESS(ctx.ec());
+                REQUIRE(res.count(dataverse_name) == 1);
+                REQUIRE(res[dataverse_name].count(dataset_name) == 1);
+                REQUIRE(res[dataverse_name][dataset_name] >= 0);
+            }
+        }
+
+        {
+            auto ctx = mgr.disconnect_link({}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::drop_index_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.drop_index(index_name, dataset_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::drop_index_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.drop_index(index_name, dataset_name, opts).get();
+            REQUIRE(ctx.ec() == couchbase::errc::common::index_not_found);
+        }
+
+        {
+            auto opts = couchbase::drop_index_analytics_options().dataverse_name(dataverse_name).ignore_if_not_exists(true);
+            auto ctx = mgr.drop_index(index_name, dataset_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::drop_dataset_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.drop_dataset(dataset_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto opts = couchbase::drop_dataset_analytics_options().dataverse_name(dataverse_name);
+            auto ctx = mgr.drop_dataset(dataset_name, opts).get();
+            REQUIRE(ctx.ec() == couchbase::errc::analytics::dataset_not_found);
+        }
+
+        {
+            auto opts = couchbase::drop_dataset_analytics_options().dataverse_name(dataverse_name).ignore_if_not_exists(true);
+            auto ctx = mgr.drop_dataset(dataset_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto ctx = mgr.drop_dataverse(dataverse_name, {}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+
+        {
+            auto ctx = mgr.drop_dataverse(dataverse_name, {}).get();
+            REQUIRE(ctx.ec() == couchbase::errc::analytics::dataverse_not_found);
+        }
+
+        {
+            auto opts = couchbase::drop_dataverse_analytics_options().ignore_if_not_exists(true);
+            auto ctx = mgr.drop_dataverse(dataverse_name, opts).get();
+            REQUIRE_SUCCESS(ctx.ec());
+        }
+    }
+
+    if (integration.cluster_version().supports_collections()) {
+        SECTION("compound names")
+        {
+            auto dataverse_name = fmt::format("{}/{}", test::utils::uniq_id("dataverse"), test::utils::uniq_id("dataverse"));
+            auto dataset_name = test::utils::uniq_id("dataset");
+            auto index_name = test::utils::uniq_id("index");
+
+            {
+                auto ctx = mgr.create_dataverse(dataverse_name, {}).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto opts = couchbase::create_dataset_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.create_dataset(dataset_name, integration.ctx.bucket, opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                std::map<std::string, std::string> fields{};
+                fields["testkey"] = "string";
+                auto opts = couchbase::create_index_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.create_index(index_name, dataset_name, fields, opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto opts = couchbase::connect_link_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.connect_link(opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto opts = couchbase::disconnect_link_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.disconnect_link(opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto opts = couchbase::drop_index_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.drop_index(index_name, dataset_name, opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto opts = couchbase::drop_dataset_analytics_options().dataverse_name(dataverse_name);
+                auto ctx = mgr.drop_dataset(dataset_name, opts).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+
+            {
+                auto ctx = mgr.drop_dataverse(dataverse_name, {}).get();
+                REQUIRE_SUCCESS(ctx.ec());
+            }
+        }
+    }
+}
+
+void
+run_s3_link_test_public_api(test::utils::integration_test_guard& integration,
+                            const std::string& dataverse_name,
+                            const std::string& link_name)
+{
+    couchbase::cluster cluster{ integration.cluster };
+    auto mgr = cluster.analytics_indexes();
+
+    {
+        auto ctx = mgr.create_dataverse(dataverse_name, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto s3_link = couchbase::management::s3_external_analytics_link{
+            link_name, dataverse_name, "access_key", "secret_access_key", "us-east-1", {}, "service_endpoint",
+        };
+        auto ctx = mgr.create_link(s3_link, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto s3_link = couchbase::management::s3_external_analytics_link{
+            link_name, dataverse_name, "access_key", "secret_access_key", "us-east-1", {}, "service_endpoint",
+        };
+        auto ctx = mgr.create_link(s3_link, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::analytics::link_exists);
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options().dataverse_name(dataverse_name);
+        auto [ctx, res] = mgr.get_links(opts).get();
+
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::s3_external);
+
+        auto s3_link = dynamic_cast<const couchbase::management::s3_external_analytics_link&>(*res[0].get());
+        REQUIRE(s3_link.name == link_name);
+        REQUIRE(s3_link.dataverse_name == dataverse_name);
+        REQUIRE(s3_link.access_key_id == "access_key");
+        REQUIRE(s3_link.secret_access_key.empty());
+        REQUIRE(s3_link.region == "us-east-1");
+        REQUIRE(s3_link.service_endpoint.value() == "service_endpoint");
+    }
+
+    return;
+
+    {
+        auto opts = couchbase::get_links_analytics_options()
+                      .dataverse_name(dataverse_name)
+                      .link_type(couchbase::management::analytics_link_type::s3_external);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::s3_external);
+
+        auto s3_link = dynamic_cast<const couchbase::management::s3_external_analytics_link&>(*res[0].get());
+        REQUIRE(s3_link.name == link_name);
+        REQUIRE(s3_link.dataverse_name == dataverse_name);
+        REQUIRE(s3_link.access_key_id == "access_key");
+        REQUIRE(s3_link.secret_access_key.empty());
+        REQUIRE(s3_link.region == "us-east-1");
+        REQUIRE(s3_link.service_endpoint.value() == "service_endpoint");
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options()
+                      .dataverse_name(dataverse_name)
+                      .link_type(couchbase::management::analytics_link_type::couchbase_remote);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.empty());
+    }
+
+    {
+        auto s3_link = couchbase::management::s3_external_analytics_link{
+            link_name, dataverse_name, "access_key", "secret_access_key", "eu-west-1", {}, "service_endpoint",
+        };
+        auto ctx = mgr.replace_link(s3_link, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options().dataverse_name(dataverse_name);
+        auto [ctx, res] = mgr.get_links(opts).get();
+
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::s3_external);
+
+        auto s3_link = dynamic_cast<const couchbase::management::s3_external_analytics_link&>(*res[0].get());
+        REQUIRE(s3_link.name == link_name);
+        REQUIRE(s3_link.dataverse_name == dataverse_name);
+        REQUIRE(s3_link.access_key_id == "access_key");
+        REQUIRE(s3_link.secret_access_key.empty());
+        REQUIRE(s3_link.region == "eu-west-1");
+        REQUIRE(s3_link.service_endpoint.value() == "service_endpoint");
+    }
+
+    {
+        auto ctx = mgr.drop_link(link_name, dataverse_name, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto ctx = mgr.drop_link(link_name, dataverse_name, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::analytics::link_not_found);
+    }
+}
+
+void
+run_azure_link_test_public_api(test::utils::integration_test_guard& integration,
+                               const std::string& dataverse_name,
+                               const std::string& link_name)
+{
+    couchbase::cluster cluster{ integration.cluster };
+    auto mgr = cluster.analytics_indexes();
+
+    {
+        auto ctx = mgr.create_dataverse(dataverse_name, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto azure_link = couchbase::management::azure_blob_external_analytics_link{
+            link_name, dataverse_name, "connection_string", {}, {}, {}, "blob_endpoint", "endpoint_suffix",
+        };
+        auto ctx = mgr.create_link(azure_link, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto azure_link = couchbase::management::azure_blob_external_analytics_link{
+            link_name, dataverse_name, "connection_string", {}, {}, {}, "blob_endpoint", "endpoint_suffix",
+        };
+        auto ctx = mgr.create_link(azure_link, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::analytics::link_exists);
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options().dataverse_name(dataverse_name);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::azure_external);
+
+        auto azure_link = dynamic_cast<const couchbase::management::azure_blob_external_analytics_link&>(*res[0].get());
+        REQUIRE(azure_link.name == link_name);
+        REQUIRE(azure_link.dataverse_name == dataverse_name);
+        REQUIRE_FALSE(azure_link.connection_string.has_value());
+        REQUIRE_FALSE(azure_link.account_name.has_value());
+        REQUIRE_FALSE(azure_link.account_key.has_value());
+        REQUIRE_FALSE(azure_link.shared_access_signature.has_value());
+        REQUIRE(azure_link.blob_endpoint == "blob_endpoint");
+        REQUIRE(azure_link.endpoint_suffix == "endpoint_suffix");
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options()
+                      .dataverse_name(dataverse_name)
+                      .link_type(couchbase::management::analytics_link_type::azure_external);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::azure_external);
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options()
+                      .dataverse_name(dataverse_name)
+                      .link_type(couchbase::management::analytics_link_type::couchbase_remote);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.empty());
+    }
+
+    {
+        auto azure_link = couchbase::management::azure_blob_external_analytics_link{
+            link_name, dataverse_name, "connection_string", {}, {}, {}, "new_blob_endpoint", "endpoint_suffix",
+        };
+        auto ctx = mgr.replace_link(azure_link, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto opts = couchbase::get_links_analytics_options().dataverse_name(dataverse_name);
+        auto [ctx, res] = mgr.get_links(opts).get();
+        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE(res.size() == 1);
+        REQUIRE(res[0]->link_type() == couchbase::management::analytics_link_type::azure_external);
+
+        auto azure_link = dynamic_cast<const couchbase::management::azure_blob_external_analytics_link&>(*res[0].get());
+        REQUIRE(azure_link.name == link_name);
+        REQUIRE(azure_link.dataverse_name == dataverse_name);
+        REQUIRE_FALSE(azure_link.connection_string.has_value());
+        REQUIRE_FALSE(azure_link.account_name.has_value());
+        REQUIRE_FALSE(azure_link.account_key.has_value());
+        REQUIRE_FALSE(azure_link.shared_access_signature.has_value());
+        REQUIRE(azure_link.blob_endpoint == "new_blob_endpoint");
+        REQUIRE(azure_link.endpoint_suffix == "endpoint_suffix");
+    }
+
+    {
+        auto ctx = mgr.drop_link(link_name, dataverse_name, {}).get();
+        REQUIRE_SUCCESS(ctx.ec());
+    }
+
+    {
+        auto ctx = mgr.drop_link(link_name, dataverse_name, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::analytics::link_not_found);
+    }
+}
+
+TEST_CASE("integration: analytics external link management with public API", "[integration]")
+{
+    test::utils::integration_test_guard integration;
+
+    if (!integration.cluster_version().supports_analytics()) {
+        SKIP("cluster does not support analytics service");
+    }
+    if (!integration.has_analytics_service()) {
+        SKIP("cluster does not have analytics service");
+    }
+    if (!integration.cluster_version().supports_analytics_links()) {
+        SKIP("analytics does not support analytics links");
+    }
+    if (integration.storage_backend() == couchbase::core::management::cluster::bucket_storage_backend::magma) {
+        SKIP("analytics does not work with magma storage backend, see MB-47718");
+    }
+    if (!integration.cluster_version().supports_analytics_links_cert_auth() && integration.origin.credentials().uses_certificate()) {
+        SKIP("certificate credentials selected, but analytics service does not support cert auth, see MB-40198");
+    }
+
+    couchbase::cluster cluster{ integration.cluster };
+    auto mgr = cluster.analytics_indexes();
+
+    auto link_name = test::utils::uniq_id("link");
+
+    SECTION("missing dataverse")
+    {
+        auto s3_link = couchbase::management::s3_external_analytics_link{
+            link_name, "missing_dataverse", "access_key", "secret_access_key", "us-east-1", {}, "service_endpoint",
+        };
+        auto ctx = mgr.create_link(s3_link, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::analytics::dataverse_not_found);
+    }
+
+    SECTION("missing argument")
+    {
+        auto s3_link = couchbase::management::s3_external_analytics_link{};
+        auto ctx = mgr.create_link(s3_link, {}).get();
+        REQUIRE(ctx.ec() == couchbase::errc::common::invalid_argument);
+    }
+
+    SECTION("link crud")
+    {
+        auto dataverse_name = test::utils::uniq_id("dataverse");
+
+        SECTION("s3")
+        {
+            run_s3_link_test_public_api(integration, dataverse_name, link_name);
+        }
+
+        if (integration.cluster_version().supports_analytics_link_azure_blob()) {
+            SECTION("azure")
+            {
+                run_azure_link_test_public_api(integration, dataverse_name, link_name);
+            }
+        }
+    }
+
+    if (integration.cluster_version().supports_collections()) {
+        SECTION("link crud scopes")
+        {
+            auto scope_name = test::utils::uniq_id("scope");
+
+            {
+                couchbase::core::operations::management::scope_create_request req{ integration.ctx.bucket, scope_name };
+                auto resp = test::utils::execute(integration.cluster, req);
+                REQUIRE_SUCCESS(resp.ctx.ec);
+                auto created =
+                  test::utils::wait_until_collection_manifest_propagated(integration.cluster, integration.ctx.bucket, resp.uid);
+                REQUIRE(created);
+            }
+
+            auto dataverse_name = fmt::format("{}/{}", integration.ctx.bucket, scope_name);
+
+            SECTION("s3")
+            {
+                run_s3_link_test_public_api(integration, dataverse_name, link_name);
+            }
+
+            if (integration.cluster_version().supports_analytics_link_azure_blob()) {
+                SECTION("azure")
+                {
+                    run_azure_link_test_public_api(integration, dataverse_name, link_name);
                 }
             }
 


### PR DESCRIPTION
## Changes

* Add `analytics_index_manager` in the public API and all associated options classes
* Add `management::analytics_index`, `management::analytics_dataset` and `management::analytics_link` (with its three concrete implementations as per the RFC) in the public API
* Add relevant tests
* Fix the assertions for `get_pending_mutations` in the Core API test