### PR TITLE
CXXCBC-412: Support document_not_locked

### DIFF
--- a/core/impl/key_value_error_category.cxx
+++ b/core/impl/key_value_error_category.cxx
@@ -80,10 +80,12 @@ struct key_value_error_category : std::error_category {
                 return "xattr_unknown_virtual_attribute (127)";
             case errc::key_value::xattr_cannot_modify_virtual_attribute:
                 return "xattr_cannot_modify_virtual_attribute (128)";
-            case errc::key_value::cannot_revive_living_document:
-                return "cannot_revive_living_document (131)";
             case errc::key_value::xattr_no_access:
                 return "xattr_no_access (130)";
+            case errc::key_value::document_not_locked:
+                return "document_not_locked (131)";
+            case errc::key_value::cannot_revive_living_document:
+                return "cannot_revive_living_document (132)";
             case errc::key_value::mutation_token_outdated:
                 return "mutation_token_outdated (133)";
             case errc::key_value::range_scan_completed:

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -96,3 +96,8 @@
  * couchbase::cluster::search_query() and couchbase::scope::search_query() support
  */
 #define COUCHBASE_CXX_CLIENT_HAS_PUBLIC_SEARCH 1
+
+/**
+ * The document not locked (couchbase::errc::key_value::document_not_locked) error code is supported
+ */
+#define COUCHBASE_CXX_CLIENT_HAS_DOCUMENT_NOT_LOCKED

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -100,4 +100,4 @@
 /**
  * The document not locked (couchbase::errc::key_value::document_not_locked) error code is supported
  */
-#define COUCHBASE_CXX_CLIENT_HAS_DOCUMENT_NOT_LOCKED
+#define COUCHBASE_CXX_CLIENT_HAS_ERRC_DOCUMENT_NOT_LOCKED 1

--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -80,6 +80,9 @@ map_status_code(protocol::client_opcode opcode, std::uint16_t status)
             }
             return errc::key_value::document_locked;
 
+        case key_value_status_code::not_locked:
+            return errc::key_value::document_not_locked;
+
         case key_value_status_code::auth_stale:
         case key_value_status_code::auth_error:
         case key_value_status_code::no_access:

--- a/core/protocol/status.hxx
+++ b/core/protocol/status.hxx
@@ -41,6 +41,7 @@ is_valid_status(std::uint16_t code)
         case key_value_status_code::not_my_vbucket:
         case key_value_status_code::no_bucket:
         case key_value_status_code::locked:
+        case key_value_status_code::not_locked:
         case key_value_status_code::auth_stale:
         case key_value_status_code::auth_error:
         case key_value_status_code::auth_continue:

--- a/couchbase/error_codes.hxx
+++ b/couchbase/error_codes.hxx
@@ -591,15 +591,36 @@ enum class key_value {
     xattr_no_access = 130,
 
     /**
+     * The document is already locked - generally returned when an unlocking operation is being performed.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    // KV Code: 0x0e
+    document_not_locked = 131,
+
+    /**
      * Only deleted document could be revived
      *
      * @since 1.0.0
      * @committed
      */
     // KV Code: 0xd6
-    cannot_revive_living_document = 131,
+    cannot_revive_living_document = 132,
 
+    /**
+     * The provided mutation token is outdated compared to the current state of the server.
+     *
+     * @since 1.0.0
+     * @uncommitted
+     */
+    // KV Code: 0xa8
     mutation_token_outdated = 133,
+
+    /**
+     * @internal
+     */
+    // KV Code: 0xa7
     range_scan_completed = 134,
 };
 

--- a/couchbase/fmt/key_value_status_code.hxx
+++ b/couchbase/fmt/key_value_status_code.hxx
@@ -71,6 +71,9 @@ struct fmt::formatter<couchbase::key_value_status_code> {
             case key_value_status_code::locked:
                 name = "locked (0x09)";
                 break;
+            case key_value_status_code::not_locked:
+                name = "not_locked (0x0e)";
+                break;
             case key_value_status_code::auth_stale:
                 name = "auth_stale (0x1f)";
                 break;

--- a/couchbase/key_value_status_code.hxx
+++ b/couchbase/key_value_status_code.hxx
@@ -34,6 +34,7 @@ enum class key_value_status_code : std::uint16_t {
     dcp_stream_not_found = 0x0a,
     opaque_no_match = 0x0b,
     locked = 0x09,
+    not_locked = 0x0e,
     auth_stale = 0x1f,
     auth_error = 0x20,
     auth_continue = 0x21,

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -221,6 +221,11 @@ struct server_version {
         return supports_search() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
     }
 
+    [[nodiscard]] bool supports_document_not_locked_status() const
+    {
+        return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
+    }
+
     [[nodiscard]] bool is_capella() const
     {
         return deployment == deployment_type::capella;


### PR DESCRIPTION
* Support the `not_locked` (0x0e) KV status and map it to the `errc::key_value::document_not_locked` error code
* Added relevant tests