### PR TITLE
CXXCBC-409: Add handling for 'index does not exist' query error

### DIFF
--- a/core/operations/management/query_index_create.cxx
+++ b/core/operations/management/query_index_create.cxx
@@ -23,6 +23,7 @@
 #include "error_utils.hxx"
 
 #include <fmt/core.h>
+#include <regex>
 
 namespace couchbase::core::operations::management
 {
@@ -97,7 +98,7 @@ query_index_create_request::make_response(error_context::http&& ctx, const encod
                 error.message = entry.at("msg").get_string();
                 switch (error.code) {
                     case 5000: /* IKey: "Internal Error" */
-                        if (error.message.find(" already exists") != std::string::npos) {
+                        if (std::regex_search(error.message, std::regex{ ".*[iI]ndex .*already exist.*" })) {
                             index_already_exists = true;
                         }
                         if (error.message.find("Bucket Not Found") != std::string::npos) {

--- a/core/operations/management/query_index_drop.cxx
+++ b/core/operations/management/query_index_drop.cxx
@@ -22,6 +22,7 @@
 #include "error_utils.hxx"
 
 #include <fmt/core.h>
+#include <regex>
 
 namespace couchbase::core::operations::management
 {
@@ -80,7 +81,7 @@ query_index_drop_request::make_response(error_context::http&& ctx, const encoded
                 error.message = entry.at("msg").get_string();
                 switch (error.code) {
                     case 5000: /* IKey: "Internal Error" */
-                        if (error.message.find("not found.") != std::string::npos) {
+                        if (std::regex_search(error.message, std::regex{ ".*[iI]ndex .*[nN]ot [fF]ound.*" })) {
                             index_not_found = true;
                         }
                         break;


### PR DESCRIPTION
## Changes

* Handle `"Index does not exist"` query error
* Add handling for the 5000 error code in `document_query` (copied the one from the query management operations)
* Handle the possibility of `"status"` not being included in the query response - an example where this happens is with the query `drop index notfound on default;`

## Results

All query FIT tests pass