### PR TITLE
CXXCBC-405 Return type for touch is 'result' instead of 'mutation_result'

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -144,7 +144,7 @@ class collection_impl : public std::enable_shared_from_this<collection_impl>
             options.timeout,
             { options.retry_strategy },
           },
-          [handler = std::move(handler)](auto resp) mutable { return handler(std::move(resp.ctx), result{ resp.cas }); });
+          [handler = std::move(handler)](auto resp) mutable { return handler(std::move(resp.ctx), mutation_result{ resp.cas }); });
     }
 
     void get_any_replica(std::string document_key,
@@ -1103,9 +1103,9 @@ collection::touch(std::string document_id, std::chrono::seconds duration, const 
 
 auto
 collection::touch(std::string document_id, std::chrono::seconds duration, const touch_options& options) const
-  -> std::future<std::pair<key_value_error_context, result>>
+  -> std::future<std::pair<key_value_error_context, mutation_result>>
 {
-    auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, result>>>();
+    auto barrier = std::make_shared<std::promise<std::pair<key_value_error_context, mutation_result>>>();
     auto future = barrier->get_future();
     touch(std::move(document_id), duration, options, [barrier](auto ctx, auto result) {
         barrier->set_value({ std::move(ctx), std::move(result) });

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -259,7 +259,7 @@ class collection
      * @committed
      */
     [[nodiscard]] auto touch(std::string document_id, std::chrono::seconds duration, const touch_options& options = {}) const
-      -> std::future<std::pair<key_value_error_context, result>>;
+      -> std::future<std::pair<key_value_error_context, mutation_result>>;
 
     /**
      * Updates the expiration a document given an id, without modifying or returning its value.

--- a/couchbase/mutation_result.hxx
+++ b/couchbase/mutation_result.hxx
@@ -41,7 +41,7 @@ class mutation_result : public result
     mutation_result() = default;
 
     /**
-     * Constructs result for get_any_replica operation, or an entry for get_all_replicas operation.
+     * Constructs result for all mutation operations.
      *
      * @param cas
      * @param token mutation token returned by the server
@@ -52,6 +52,19 @@ class mutation_result : public result
     mutation_result(couchbase::cas cas, mutation_token token)
       : result{ cas }
       , mutation_token_{ std::move(token) }
+    {
+    }
+
+    /**
+     * Constructs result for all mutation operations
+     *
+     * @param cas
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    explicit mutation_result(couchbase::cas cas)
+      : result{ cas }
     {
     }
 

--- a/couchbase/touch_options.hxx
+++ b/couchbase/touch_options.hxx
@@ -66,5 +66,5 @@ struct touch_options : public common_options<touch_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using touch_handler = std::function<void(couchbase::key_value_error_context, result)>;
+using touch_handler = std::function<void(couchbase::key_value_error_context, mutation_result)>;
 } // namespace couchbase


### PR DESCRIPTION
Changes: 
- Change return type of touch to mutation_result
- Add additional mutation_result constructor 