### PR TITLE
CXXCBC-401: Add ping & diagnostics to public API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(couchbase_cxx_client_FILES
     core/impl/date_range_facet.cxx
     core/impl/date_range_facet_result.cxx
     core/impl/date_range_query.cxx
+    core/impl/diagnostics.cxx
     core/impl/disjunction_query.cxx
     core/impl/dns_srv_tracker.cxx
     core/impl/doc_id_query.cxx

--- a/core/impl/diagnostics.cxx
+++ b/core/impl/diagnostics.cxx
@@ -1,0 +1,294 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "diagnostics.hxx"
+
+#include "core/diagnostics.hxx"
+#include "core/service_type.hxx"
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/diagnostics_result.hxx>
+#include <couchbase/endpoint_ping_report.hxx>
+#include <couchbase/ping_result.hxx>
+#include <couchbase/service_type.hxx>
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace couchbase
+{
+namespace
+{
+std::string
+service_type_as_string(service_type service_type)
+{
+    switch (service_type) {
+        case service_type::key_value:
+            return "kv";
+        case service_type::query:
+            return "query";
+        case service_type::analytics:
+            return "analytics";
+        case service_type::search:
+            return "search";
+        case service_type::view:
+            return "views";
+        case service_type::management:
+            return "mgmt";
+        case service_type::eventing:
+            return "eventing";
+    }
+    return "";
+}
+
+std::string
+ping_state_as_string(ping_state state)
+{
+    switch (state) {
+        case ping_state::ok:
+            return "ok";
+        case ping_state::timeout:
+            return "timeout";
+        case ping_state::error:
+            return "error";
+    }
+    return "";
+}
+
+std::string
+endpoint_state_as_string(endpoint_state state)
+{
+    switch (state) {
+        case endpoint_state::connected:
+            return "connected";
+        case endpoint_state::connecting:
+            return "connecting";
+        case endpoint_state::disconnected:
+            return "disconnected";
+        case endpoint_state::disconnecting:
+            return "disconnecting";
+    }
+    return "";
+}
+
+codec::tao_json_serializer::document_type
+endpoint_ping_report_as_json(const endpoint_ping_report& report)
+{
+    codec::tao_json_serializer::document_type res{
+        { "id", report.id() },       { "latency_us", report.latency().count() },        { "remote", report.remote() },
+        { "local", report.local() }, { "state", ping_state_as_string(report.state()) },
+    };
+    if (report.error()) {
+        res["error"] = report.error().value();
+    }
+    if (report.endpoint_namespace()) {
+        res["namespace"] = report.endpoint_namespace().value();
+    }
+    return res;
+}
+
+codec::tao_json_serializer::document_type
+endpoint_diagnostics_as_json(const endpoint_diagnostics& report)
+{
+    codec::tao_json_serializer::document_type res{
+        { "id", report.id() },
+        { "local", report.local() },
+        { "remote", report.remote() },
+        { "state", endpoint_state_as_string(report.state()) },
+    };
+    if (report.last_activity()) {
+        res["last_activity_us"] = report.last_activity().value().count();
+    }
+    if (report.endpoint_namespace()) {
+        res["namespace"] = report.endpoint_namespace().value();
+    }
+    if (report.details()) {
+        res["details"] = report.details();
+    }
+    return res;
+}
+} // namespace
+
+auto
+ping_result::as_json() const -> codec::tao_json_serializer::document_type
+{
+    codec::tao_json_serializer::document_type endpoints{};
+    for (const auto& [service_type, reports] : endpoints_) {
+        std::vector<codec::tao_json_serializer::document_type> json_reports{};
+        for (const auto& report : reports) {
+            json_reports.emplace_back(endpoint_ping_report_as_json(report));
+        }
+        endpoints[service_type_as_string(service_type)] = json_reports;
+    }
+    return {
+        { "version", version_ },
+        { "id", id_ },
+        { "sdk", sdk_ },
+        { "services", endpoints },
+    };
+}
+
+auto
+diagnostics_result::as_json() const -> codec::tao_json_serializer::document_type
+{
+    codec::tao_json_serializer::document_type endpoints{};
+    for (const auto& [service_type, reports] : endpoints_) {
+        std::vector<codec::tao_json_serializer::document_type> json_reports{};
+        for (const auto& report : reports) {
+            json_reports.emplace_back(endpoint_diagnostics_as_json(report));
+        }
+        endpoints[service_type_as_string(service_type)] = json_reports;
+    }
+    return {
+        { "id", id_ },
+        { "sdk", sdk_ },
+        { "version", version_ },
+        { "services", endpoints },
+    };
+}
+} // namespace couchbase
+
+namespace couchbase::core::impl
+{
+namespace
+{
+couchbase::service_type
+to_public_service_type(core::service_type service_type)
+{
+    switch (service_type) {
+        case core::service_type::key_value:
+            return couchbase::service_type::key_value;
+        case core::service_type::query:
+            return couchbase::service_type::query;
+        case core::service_type::analytics:
+            return couchbase::service_type::analytics;
+        case core::service_type::search:
+            return couchbase::service_type::search;
+        case core::service_type::view:
+            return couchbase::service_type::view;
+        case core::service_type::management:
+            return couchbase::service_type::management;
+        case core::service_type::eventing:
+            return couchbase::service_type::eventing;
+    }
+    return {};
+}
+
+couchbase::ping_state
+to_public_ping_state(core::diag::ping_state ping_state)
+{
+    switch (ping_state) {
+        case core::diag::ping_state::timeout:
+            return couchbase::ping_state::timeout;
+        case core::diag::ping_state::error:
+            return couchbase::ping_state::error;
+        case core::diag::ping_state::ok:
+            return couchbase::ping_state::ok;
+    }
+    return {};
+}
+
+couchbase::endpoint_state
+to_public_endpoint_state(core::diag::endpoint_state endpoint_state)
+{
+    switch (endpoint_state) {
+        case core::diag::endpoint_state::connected:
+            return couchbase::endpoint_state::connected;
+        case diag::endpoint_state::disconnected:
+            return couchbase::endpoint_state::disconnected;
+        case diag::endpoint_state::connecting:
+            return couchbase::endpoint_state::connecting;
+        case diag::endpoint_state::disconnecting:
+            return couchbase::endpoint_state::disconnecting;
+    }
+    return {};
+}
+} // namespace
+
+std::set<core::service_type>
+to_core_service_types(const std::set<couchbase::service_type>& service_types)
+{
+    std::set<core::service_type> res{};
+    for (auto s : service_types) {
+        switch (s) {
+            case couchbase::service_type::key_value:
+                res.emplace(core::service_type::key_value);
+                break;
+            case couchbase::service_type::query:
+                res.emplace(core::service_type::query);
+                break;
+            case couchbase::service_type::analytics:
+                res.emplace(core::service_type::analytics);
+                break;
+            case couchbase::service_type::search:
+                res.emplace(core::service_type::search);
+                break;
+            case couchbase::service_type::view:
+                res.emplace(core::service_type::view);
+                break;
+            case couchbase::service_type::management:
+                res.emplace(core::service_type::management);
+                break;
+            case couchbase::service_type::eventing:
+                res.emplace(core::service_type::eventing);
+                break;
+        }
+    }
+    return res;
+}
+
+couchbase::ping_result
+build_result(const core::diag::ping_result& result)
+{
+    std::map<couchbase::service_type, std::vector<couchbase::endpoint_ping_report>> endpoints{};
+    for (const auto& [core_service_type, core_endpoints] : result.services) {
+        auto service_type = to_public_service_type(core_service_type);
+        endpoints[service_type] = std::vector<couchbase::endpoint_ping_report>{};
+        for (const auto& info : core_endpoints) {
+            endpoints[service_type].emplace_back(
+              service_type, info.id, info.local, info.remote, to_public_ping_state(info.state), info.error, info.bucket, info.latency);
+        }
+    }
+
+    return { result.id, static_cast<std::uint16_t>(result.version), result.sdk, endpoints };
+}
+
+couchbase::diagnostics_result
+build_result(const core::diag::diagnostics_result& result)
+{
+    std::map<couchbase::service_type, std::vector<couchbase::endpoint_diagnostics>> endpoints{};
+    for (const auto& [core_service_type, core_endpoints] : result.services) {
+        auto service_type = to_public_service_type(core_service_type);
+        endpoints[service_type] = std::vector<couchbase::endpoint_diagnostics>{};
+        for (const auto& info : core_endpoints) {
+            endpoints[service_type].emplace_back(service_type,
+                                                 info.id,
+                                                 info.last_activity,
+                                                 info.local,
+                                                 info.remote,
+                                                 info.bucket,
+                                                 to_public_endpoint_state(info.state),
+                                                 info.details);
+        }
+    }
+
+    return { result.id, static_cast<std::uint16_t>(result.version), result.sdk, endpoints };
+}
+} // namespace couchbase::core::impl

--- a/core/impl/diagnostics.hxx
+++ b/core/impl/diagnostics.hxx
@@ -1,0 +1,39 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/diagnostics_result.hxx>
+#include <couchbase/ping_result.hxx>
+#include <couchbase/service_type.hxx>
+
+#include "core/diagnostics.hxx"
+#include "core/service_type.hxx"
+
+#include <set>
+
+namespace couchbase::core::impl
+{
+std::set<core::service_type>
+to_core_service_types(const std::set<couchbase::service_type>& service_types);
+
+couchbase::ping_result
+build_result(const core::diag::ping_result& result);
+
+couchbase::diagnostics_result
+build_result(const core::diag::diagnostics_result& result);
+} // namespace couchbase::core::impl

--- a/couchbase/bucket.hxx
+++ b/couchbase/bucket.hxx
@@ -19,6 +19,7 @@
 
 #include <couchbase/collection.hxx>
 #include <couchbase/collection_manager.hxx>
+#include <couchbase/ping_options.hxx>
 #include <couchbase/scope.hxx>
 
 #include <memory>
@@ -73,6 +74,34 @@ class bucket
      * @committed
      */
     [[nodiscard]] auto scope(std::string_view scope_name) const -> scope;
+
+    /**
+     * Performs application-level ping requests against services in the Couchbase cluster.
+     *
+     * @note This operation performs active I/O against services and endpoints to assess their health. If you do not
+     * wish to performs I/O, consider using @ref diagnostics() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @param handler the handler that implements @ref ping_handler.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void ping(const ping_options& options, ping_handler&& handler) const;
+
+    /**
+     * Performs application-level ping requests against services in the Couchbase cluster.
+     *
+     * @note This operation performs active I/O against services and endpoints to assess their health. If you do not
+     * wish to performs I/O, consider using @ref diagnostics() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @return future object that carries result of the operation.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto ping(const ping_options& options = {}) const -> std::future<ping_result>;
 
     /**
      * Provides access to the collection management services.

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -22,6 +22,8 @@
 #include <couchbase/bucket.hxx>
 #include <couchbase/bucket_manager.hxx>
 #include <couchbase/cluster_options.hxx>
+#include <couchbase/diagnostics_options.hxx>
+#include <couchbase/ping_options.hxx>
 #include <couchbase/query_index_manager.hxx>
 #include <couchbase/query_options.hxx>
 #include <couchbase/search_index_manager.hxx>
@@ -206,6 +208,66 @@ class cluster
      */
     [[nodiscard]] auto analytics_query(std::string statement, const analytics_options& options = {}) const
       -> std::future<std::pair<analytics_error_context, analytics_result>>;
+
+    /**
+     * Performs application-level ping requests against services in the Couchbase cluster.
+     *
+     * @note This operation performs active I/O against services and endpoints to assess their health. If you do not
+     * wish to performs I/O, consider using @ref diagnostics() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @param handler the handler that implements @ref ping_handler.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void ping(const ping_options& options, ping_handler&& handler) const;
+
+    /**
+     * Performs application-level ping requests against services in the Couchbase cluster.
+     *
+     * @note This operation performs active I/O against services and endpoints to assess their health. If you do not
+     * wish to performs I/O, consider using @ref diagnostics() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @return future object that carries result of the operation.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto ping(const ping_options& options = {}) const -> std::future<ping_result>;
+
+    /**
+     * Assembles a diagnostics report on the current state of the cluster from the SDK's point of view.
+     *
+     * @note This operation does not perform any I/O to produce the report. It will only use the current known state of
+     * the cluster to assemble the report So, if for example, no SQL++ queries have been run, the Query service's socket
+     * pool might be empty and as a result not show up in the report. If you wish to actively assess the health of the
+     * cluster by performing I/O, consider using @ref ping() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @param handler the handler that implements @ref diagnostics_handler.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void diagnostics(const diagnostics_options& options, diagnostics_handler&& handler) const;
+
+    /**
+     * Assembles a diagnostics report on the current state of the cluster from the SDK's point of view.
+     *
+     * @note This operation does not perform any I/O to produce the report. It will only use the current known state of
+     * the cluster to assemble the report So, if for example, no SQL++ queries have been run, the Query service's socket
+     * pool might be empty and as a result not show up in the report. If you wish to actively assess the health of the
+     * cluster by performing I/O, consider using @ref ping() instead.
+     *
+     * @param options custom options to change the default behavior.
+     * @return future object that carries result of the operation.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto diagnostics(const diagnostics_options& options = {}) const -> std::future<diagnostics_result>;
 
     /**
      * Provides access to the N1QL index management services.

--- a/couchbase/diagnostics_options.hxx
+++ b/couchbase/diagnostics_options.hxx
@@ -1,0 +1,75 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/diagnostics_result.hxx>
+
+#include <optional>
+#include <utility>
+
+namespace couchbase
+{
+struct diagnostics_options : public common_options<diagnostics_options> {
+    /**
+     * Sets a custom report ID that will be used in the report. If no report ID is provided, the client will generate a
+     * unique one.
+     *
+     * @param report_id the report ID that should be used.
+     * @return reference to this object, for use in chaining.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto report_id(std::string report_id) -> diagnostics_options&
+    {
+        report_id_ = std::move(report_id);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<diagnostics_options>::built {
+        std::optional<std::string> report_id;
+    };
+
+    /**
+     * Validates the options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), report_id_ };
+    }
+
+  private:
+    std::optional<std::string> report_id_{};
+};
+
+using diagnostics_handler = std::function<void(diagnostics_result)>;
+} // namespace couchbase

--- a/couchbase/diagnostics_result.hxx
+++ b/couchbase/diagnostics_result.hxx
@@ -1,0 +1,124 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/endpoint_diagnostics.hxx>
+#include <couchbase/service_type.hxx>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase
+{
+class diagnostics_result
+{
+  public:
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    diagnostics_result() = default;
+
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    diagnostics_result(std::string id,
+                       std::uint16_t version,
+                       std::string sdk,
+                       std::map<service_type, std::vector<endpoint_diagnostics>> endpoints)
+      : id_{ std::move(id) }
+      , version_{ version }
+      , sdk_{ std::move(sdk) }
+      , endpoints_{ std::move(endpoints) }
+    {
+    }
+
+    /**
+     * Returns the ID of this report.
+     *
+     * @return the report ID.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id() const -> std::string
+    {
+        return id_;
+    }
+
+    /**
+     * Returns the version of this report (useful when exporting to JSON).
+     *
+     * @return the report version
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto version() const -> std::uint16_t
+    {
+        return version_;
+    }
+
+    /**
+     * Returns the identifier of this SDK (useful when exporting to JSON).
+     *
+     * @return the SDK identifier.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto sdk() const -> std::string
+    {
+        return sdk_;
+    }
+
+    /**
+     * Returns the diagnostics for each individual endpoint, organised by service type.
+     *
+     * @return the service type to endpoint diagnostics reports map.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto endpoints() const -> std::map<service_type, std::vector<endpoint_diagnostics>>
+    {
+        return endpoints_;
+    }
+
+    /**
+     * Exports the diagnostics report as JSON.
+     *
+     * @return the JSON report.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto as_json() const -> codec::tao_json_serializer::document_type;
+
+  private:
+    std::string id_{};
+    std::uint16_t version_{};
+    std::string sdk_{};
+    std::map<service_type, std::vector<endpoint_diagnostics>> endpoints_{};
+};
+} // namespace couchbase

--- a/couchbase/endpoint_diagnostics.hxx
+++ b/couchbase/endpoint_diagnostics.hxx
@@ -1,0 +1,206 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/service_type.hxx>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace couchbase
+{
+enum class endpoint_state {
+    /**
+     * The endpoint is connected and ready.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    connected,
+
+    /**
+     * The endpoint is disconnected but trying to connect right now.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    connecting,
+
+    /**
+     * The endpoint is disconnected (not reachable) and not trying to connect.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    disconnected,
+
+    /**
+     * The endpoint is currently disconnecting.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    disconnecting,
+};
+
+class endpoint_diagnostics
+{
+  public:
+    endpoint_diagnostics() = default;
+
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    endpoint_diagnostics(service_type type,
+                         std::string id,
+                         std::optional<std::chrono::microseconds> last_activity,
+                         std::string local,
+                         std::string remote,
+                         std::optional<std::string> endpoint_namespace,
+                         endpoint_state state,
+                         std::optional<std::string> details)
+      : type_{ type }
+      , id_{ std::move(id) }
+      , last_activity_{ last_activity }
+      , local_{ std::move(local) }
+      , remote_{ std::move(remote) }
+      , namespace_{ std::move(endpoint_namespace) }
+      , state_{ state }
+      , details_{ std::move(details) }
+    {
+    }
+
+    /**
+     * Returns the service type for this endpoint.
+     *
+     * @return the service type.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto type() const -> service_type
+    {
+        return type_;
+    }
+
+    /**
+     *
+     * Returns the ID for this endpoint.
+     *
+     * @return the endpoint ID.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id() const -> std::string
+    {
+        return id_;
+    }
+
+    /**
+     * Returns the time since the last activity, if there has been one.
+     *
+     * @return the duration since the last activity.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto last_activity() const -> std::optional<std::chrono::microseconds>
+    {
+        return last_activity_;
+    }
+
+    /**
+     * Returns the local socket address for this endpoint.
+     *
+     * @return the local socket address.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto local() const -> std::string
+    {
+        return local_;
+    }
+
+    /**
+     * Returns the remote socket address for this endpoint.
+     *
+     * @return the remote socket address.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto remote() const -> std::string
+    {
+        return remote_;
+    }
+
+    /**
+     * Returns the namespace of this endpoint (likely the bucket name if present).
+     *
+     * @return the namespace.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto endpoint_namespace() const -> std::optional<std::string>
+    {
+        return namespace_;
+    }
+
+    /**
+     * Returns the current state of the endpoint.
+     *
+     * @return the endpoint state.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto state() const -> endpoint_state
+    {
+        return state_;
+    }
+
+    /**
+     * Returns any additional details about the endpoint, if available.
+     *
+     * @return endpoint details.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto details() const -> std::optional<std::string>
+    {
+        return details_;
+    }
+
+  private:
+    service_type type_{};
+    std::string id_{};
+    std::optional<std::chrono::microseconds> last_activity_{};
+    std::string local_{};
+    std::string remote_{};
+    std::optional<std::string> namespace_{};
+    endpoint_state state_{};
+    std::optional<std::string> details_{};
+};
+} // namespace couchbase

--- a/couchbase/endpoint_ping_report.hxx
+++ b/couchbase/endpoint_ping_report.hxx
@@ -1,0 +1,205 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/endpoint_ping_report.hxx>
+#include <couchbase/service_type.hxx>
+
+namespace couchbase
+{
+enum class ping_state {
+    /**
+     * Indicates that the ping operation was successful.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    ok,
+
+    /**
+     * Indicates that the ping operation timed out.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    timeout,
+
+    /**
+     * Indicates that the ping operation failed.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    error,
+};
+
+class endpoint_ping_report
+{
+  public:
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    endpoint_ping_report() = default;
+
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    endpoint_ping_report(service_type type,
+                         std::string id,
+                         std::string local,
+                         std::string remote,
+                         ping_state state,
+                         std::optional<std::string> error,
+                         std::optional<std::string> endpoint_namespace,
+                         std::chrono::microseconds latency)
+      : type_{ type }
+      , id_{ std::move(id) }
+      , local_{ std::move(local) }
+      , remote_{ std::move(remote) }
+      , state_{ state }
+      , error_{ std::move(error) }
+      , namespace_{ std::move(endpoint_namespace) }
+      , latency_{ latency }
+    {
+    }
+
+    /**
+     * Returns the service type for this endpoint.
+     *
+     * @return the service type.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto type() const -> service_type
+    {
+        return type_;
+    }
+
+    /**
+     * Returns the ID for this endpoint.
+     *
+     * @return the endpoint ID.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id() const -> std::string
+    {
+        return id_;
+    }
+
+    /**
+     * Returns the local socket address for this endpoint.
+     *
+     * @return the local socket address.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto local() const -> std::string
+    {
+        return local_;
+    }
+
+    /**
+     * Returns the remote socket address for this endpoint.
+     *
+     * @return the remote socket address.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto remote() const -> std::string
+    {
+        return remote_;
+    }
+
+    /**
+     * Returns the state of this ping when assembling the report.
+     *
+     * @return the ping state.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto state() const -> ping_state
+    {
+        return state_;
+    }
+
+    /**
+     * Returns the reason this ping did not succeed, if applicable.
+     *
+     * @return error description.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto error() const -> std::optional<std::string>
+    {
+        return error_;
+    }
+
+    /**
+     * Returns the namespace of this endpoint (likely the bucket name if present).
+     *
+     * @return the namespace.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto endpoint_namespace() const -> std::optional<std::string>
+    {
+        return namespace_;
+    }
+
+    /**
+     * Returns the latency of this ping.
+     *
+     * @return the latency in microseconds.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto latency() const -> std::chrono::microseconds
+    {
+        return latency_;
+    }
+
+  private:
+    service_type type_;
+    std::string id_;
+    std::string local_;
+    std::string remote_;
+    ping_state state_;
+    std::optional<std::string> error_{};
+    std::optional<std::string> namespace_{};
+    std::chrono::microseconds latency_;
+};
+
+} // namespace couchbase

--- a/couchbase/ping_options.hxx
+++ b/couchbase/ping_options.hxx
@@ -1,0 +1,93 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/ping_result.hxx>
+#include <couchbase/service_type.hxx>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+
+namespace couchbase
+{
+struct ping_options : public common_options<ping_options> {
+    /**
+     * Sets a custom report ID that will be used in the report. If no report ID is provided, the client will generate a
+     * unique one.
+     *
+     * @param report_id the report ID that should be used.
+     * @return reference to this object, for use in chaining.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto report_id(std::string report_id) -> ping_options&
+    {
+        report_id_ = std::move(report_id);
+        return self();
+    }
+
+    /**
+     * Customizes the set of services to ping.
+     *
+     * @param service_types the services to ping.
+     * @return reference to this object, for use in chaining.
+     */
+    auto service_types(std::set<service_type> service_types) -> ping_options&
+    {
+        service_types_ = std::move(service_types);
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<ping_options>::built {
+        std::optional<std::string> report_id;
+        std::set<service_type> service_types;
+    };
+
+    /**
+     * Validates the options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), report_id_, service_types_ };
+    }
+
+  private:
+    std::optional<std::string> report_id_{};
+    std::set<service_type> service_types_{};
+};
+
+using ping_handler = std::function<void(ping_result)>;
+} // namespace couchbase

--- a/couchbase/ping_result.hxx
+++ b/couchbase/ping_result.hxx
@@ -1,0 +1,118 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/endpoint_ping_report.hxx>
+#include <couchbase/service_type.hxx>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase
+{
+class ping_result
+{
+  public:
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    ping_result() = default;
+
+    /**
+     * @since 1.0.0
+     * @internal
+     */
+    ping_result(std::string id, std::uint16_t version, std::string sdk, std::map<service_type, std::vector<endpoint_ping_report>> endpoints)
+      : id_{ std::move(id) }
+      , version_{ version }
+      , sdk_{ std::move(sdk) }
+      , endpoints_{ std::move(endpoints) }
+    {
+    }
+
+    /**
+     * Returns the ID of this report.
+     *
+     * @return the report ID.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id() const -> std::string
+    {
+        return id_;
+    }
+
+    /**
+     * Returns the version of this report (useful when exporting to JSON).
+     *
+     * @return the report version.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto version() const -> std::uint16_t
+    {
+        return version_;
+    }
+
+    /**
+     * Returns the identifier of this SDK (useful when exporting to JSON).
+     *
+     * @return the SDK identifier.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto sdk() const -> std::string
+    {
+        return sdk_;
+    }
+
+    /**
+     * Returns the ping reports for each individual endpoint, organised by service type.
+     *
+     * @return the service type to ping reports map.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto endpoints() const -> std::map<service_type, std::vector<endpoint_ping_report>>
+    {
+        return endpoints_;
+    }
+
+    /**
+     * Exports the ping report as JSON.
+     *
+     * @return the JSON report.
+     */
+    [[nodiscard]] auto as_json() const -> codec::tao_json_serializer::document_type;
+
+  private:
+    std::string id_{};
+    std::uint16_t version_{};
+    std::string sdk_{};
+    std::map<service_type, std::vector<endpoint_ping_report>> endpoints_{};
+};
+} // namespace couchbase

--- a/couchbase/service_type.hxx
+++ b/couchbase/service_type.hxx
@@ -1,0 +1,58 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+namespace couchbase
+{
+enum class service_type {
+    /**
+     * The Key-Value service (KV)
+     */
+    key_value,
+
+    /**
+     * The Query service (SQL++)
+     */
+    query,
+
+    /**
+     * The Analytics service
+     */
+    analytics,
+
+    /**
+     * The Search service (FTS)
+     */
+    search,
+
+    /**
+     * The View service
+     */
+    view,
+
+    /**
+     * The Cluster Manager service (ns_server)
+     */
+    management,
+
+    /**
+     * The Eventing service
+     */
+    eventing,
+};
+} // namespace couchbase

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ unit_test(config_profiles)
 unit_test(options)
 unit_test(search)
 unit_test(query)
+unit_test(diagnostics)
 target_link_libraries(test_unit_jsonsl jsonsl)
 
 integration_benchmark(get)

--- a/test/test_integration_diagnostics.cxx
+++ b/test/test_integration_diagnostics.cxx
@@ -18,305 +18,9 @@
 #include "test_helper_integration.hxx"
 
 #include "core/diagnostics.hxx"
-#include "core/diagnostics_json.hxx"
 #include "core/operations/document_query.hxx"
 
 using namespace std::literals::chrono_literals;
-
-TEST_CASE("unit: serializing diagnostics report", "[unit]")
-{
-    couchbase::core::diag::diagnostics_result res{
-        "0xdeadbeef",
-        "cxx/1.0.0",
-        {
-          {
-            {
-              couchbase::core::service_type::search,
-              {
-                {
-                  couchbase::core::service_type::search,
-                  "0x1415F11",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:8094",
-                  "127.0.0.1:54669",
-                  couchbase::core::diag::endpoint_state::connecting,
-                  std::nullopt,
-                  "RECONNECTING, backoff for 4096ms from Fri Sep  1 00:03:44 PDT 2017",
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::key_value,
-              {
-                {
-                  couchbase::core::service_type::key_value,
-                  "0x1415F12",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:11210",
-                  "127.0.0.1:54670",
-                  couchbase::core::diag::endpoint_state::connected,
-                  "bucketname",
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::query,
-              {
-                {
-                  couchbase::core::service_type::query,
-                  "0x1415F13",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:8093",
-                  "127.0.0.1:54671",
-                  couchbase::core::diag::endpoint_state::connected,
-                },
-                {
-                  couchbase::core::service_type::query,
-                  "0x1415F14",
-                  1182000us,
-                  "centos7-lx2.home.ingenthron.org:8095",
-                  "127.0.0.1:54682",
-                  couchbase::core::diag::endpoint_state::disconnected,
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::analytics,
-              {
-                {
-                  couchbase::core::service_type::analytics,
-                  "0x1415F15",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:8095",
-                  "127.0.0.1:54675",
-                  couchbase::core::diag::endpoint_state::connected,
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::view,
-              {
-                {
-                  couchbase::core::service_type::view,
-                  "0x1415F16",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:8092",
-                  "127.0.0.1:54672",
-                  couchbase::core::diag::endpoint_state::connected,
-                },
-              },
-            },
-          },
-        },
-    };
-
-    auto expected = couchbase::core::utils::json::parse(R"(
-{
-  "version": 2,
-  "id": "0xdeadbeef",
-  "sdk": "cxx/1.0.0",
-  "services": {
-    "kv": [
-      {
-        "id": "0x1415F12",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:11210",
-        "local": "127.0.0.1:54670",
-        "state": "connected",
-        "namespace": "bucketname"
-      }
-    ],
-    "search": [
-      {
-        "id": "0x1415F11",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:8094",
-        "local": "127.0.0.1:54669",
-        "state": "connecting",
-        "details": "RECONNECTING, backoff for 4096ms from Fri Sep  1 00:03:44 PDT 2017"
-      }
-    ],
-    "query": [
-      {
-        "id": "0x1415F13",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:8093",
-        "local": "127.0.0.1:54671",
-        "state": "connected"
-      },
-      {
-        "id": "0x1415F14",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx2.home.ingenthron.org:8095",
-        "local": "127.0.0.1:54682",
-        "state": "disconnected"
-      }
-    ],
-    "analytics": [
-      {
-        "id": "0x1415F15",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:8095",
-        "local": "127.0.0.1:54675",
-        "state": "connected"
-      }
-    ],
-    "views": [
-      {
-        "id": "0x1415F16",
-        "last_activity_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:8092",
-        "local": "127.0.0.1:54672",
-        "state": "connected"
-      }
-    ]
-  }
-}
-)");
-    auto report = tao::json::value(res);
-    REQUIRE(report == expected);
-}
-
-TEST_CASE("integration: serializing ping report", "[integration]")
-{
-    test::utils::integration_test_guard integration;
-
-    couchbase::core::diag::ping_result res{
-        "0xdeadbeef",
-        "cxx/1.0.0",
-        {
-          {
-            {
-              couchbase::core::service_type::search,
-              {
-                {
-                  couchbase::core::service_type::search,
-                  "0x1415F11",
-                  877909us,
-                  "centos7-lx1.home.ingenthron.org:8094",
-                  "127.0.0.1:54669",
-                  couchbase::core::diag::ping_state::ok,
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::key_value,
-              {
-                {
-                  couchbase::core::service_type::key_value,
-                  "0x1415F12",
-                  1182000us,
-                  "centos7-lx1.home.ingenthron.org:11210",
-                  "127.0.0.1:54670",
-                  couchbase::core::diag::ping_state::ok,
-                  "bucketname",
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::query,
-              {
-                {
-                  couchbase::core::service_type::query,
-                  "0x1415F14",
-                  2213us,
-                  "centos7-lx2.home.ingenthron.org:8095",
-                  "127.0.0.1:54682",
-                  couchbase::core::diag::ping_state::timeout,
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::analytics,
-              {
-                {
-                  couchbase::core::service_type::analytics,
-                  "0x1415F15",
-                  2213us,
-                  "centos7-lx1.home.ingenthron.org:8095",
-                  "127.0.0.1:54675",
-                  couchbase::core::diag::ping_state::error,
-                  std::nullopt,
-                  "endpoint returned HTTP code 500!",
-                },
-              },
-            },
-            {
-              couchbase::core::service_type::view,
-              {
-                {
-                  couchbase::core::service_type::view,
-                  "0x1415F16",
-                  45585us,
-                  "centos7-lx1.home.ingenthron.org:8092",
-                  "127.0.0.1:54672",
-                  couchbase::core::diag::ping_state::ok,
-                },
-              },
-            },
-          },
-        },
-    };
-
-    auto expected = couchbase::core::utils::json::parse(R"(
-{
-  "version": 2,
-  "id": "0xdeadbeef",
-  "sdk": "cxx/1.0.0",
-  "services": {
-    "search": [
-      {
-        "id": "0x1415F11",
-        "latency_us": 877909,
-        "remote": "centos7-lx1.home.ingenthron.org:8094",
-        "local": "127.0.0.1:54669",
-        "state": "ok"
-      }
-    ],
-    "kv": [
-      {
-        "id": "0x1415F12",
-        "latency_us": 1182000,
-        "remote": "centos7-lx1.home.ingenthron.org:11210",
-        "local": "127.0.0.1:54670",
-        "state": "ok",
-        "namespace": "bucketname"
-      }
-    ],
-    "query": [
-      {
-        "id": "0x1415F14",
-        "latency_us": 2213,
-        "remote": "centos7-lx2.home.ingenthron.org:8095",
-        "local": "127.0.0.1:54682",
-        "state": "timeout"
-      }
-    ],
-    "analytics": [
-      {
-        "id": "0x1415F15",
-        "latency_us": 2213,
-        "remote": "centos7-lx1.home.ingenthron.org:8095",
-        "local": "127.0.0.1:54675",
-        "state": "error",
-        "error": "endpoint returned HTTP code 500!"
-      }
-    ],
-    "views": [
-      {
-        "id": "0x1415F16",
-        "latency_us": 45585,
-        "remote": "centos7-lx1.home.ingenthron.org:8092",
-        "local": "127.0.0.1:54672",
-        "state": "ok"
-      }
-    ]
-  }
-}
-)");
-    auto report = tao::json::value(res);
-    REQUIRE(report == expected);
-}
 
 TEST_CASE("integration: fetch diagnostics after N1QL query", "[integration]")
 {
@@ -327,26 +31,51 @@ TEST_CASE("integration: fetch diagnostics after N1QL query", "[integration]")
     }
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
+
+    SECTION("Core API")
     {
-        couchbase::core::operations::query_request req{ "SELECT 'hello, couchbase' AS greetings" };
-        auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE_SUCCESS(resp.ctx.ec);
-        INFO("rows.size() =" << resp.rows.size());
-        REQUIRE(resp.rows.size() == 1);
-        INFO("row=" << resp.rows[0]);
-        REQUIRE(resp.rows[0] == R"({"greetings":"hello, couchbase"})");
+        {
+            couchbase::core::operations::query_request req{ "SELECT 'hello, couchbase' AS greetings" };
+            auto resp = test::utils::execute(integration.cluster, req);
+            REQUIRE_SUCCESS(resp.ctx.ec);
+            INFO("rows.size() =" << resp.rows.size());
+            REQUIRE(resp.rows.size() == 1);
+            INFO("row=" << resp.rows[0]);
+            REQUIRE(resp.rows[0] == R"({"greetings":"hello, couchbase"})");
+        }
+        {
+            auto barrier = std::make_shared<std::promise<couchbase::core::diag::diagnostics_result>>();
+            auto f = barrier->get_future();
+            integration.cluster.diagnostics(
+              "my_report_id", [barrier](couchbase::core::diag::diagnostics_result&& resp) mutable { barrier->set_value(std::move(resp)); });
+            auto res = f.get();
+            REQUIRE(res.id == "my_report_id");
+            REQUIRE(res.sdk.find("cxx/") == 0);
+            REQUIRE(res.services[couchbase::core::service_type::key_value].size() > 1);
+            REQUIRE(res.services[couchbase::core::service_type::query].size() == 1);
+            REQUIRE(res.services[couchbase::core::service_type::query][0].state == couchbase::core::diag::endpoint_state::connected);
+        }
     }
+
+    SECTION("Public API")
     {
-        auto barrier = std::make_shared<std::promise<couchbase::core::diag::diagnostics_result>>();
-        auto f = barrier->get_future();
-        integration.cluster.diagnostics(
-          "my_report_id", [barrier](couchbase::core::diag::diagnostics_result&& resp) mutable { barrier->set_value(std::move(resp)); });
-        auto res = f.get();
-        REQUIRE(res.id == "my_report_id");
-        REQUIRE(res.sdk.find("cxx/") == 0);
-        REQUIRE(res.services[couchbase::core::service_type::key_value].size() > 1);
-        REQUIRE(res.services[couchbase::core::service_type::query].size() == 1);
-        REQUIRE(res.services[couchbase::core::service_type::query][0].state == couchbase::core::diag::endpoint_state::connected);
+        auto cluster = couchbase::cluster(integration.cluster);
+        {
+            auto [ctx, res] = cluster.query("SELECT 'hello, couchbase' AS greetings", {}).get();
+            REQUIRE_SUCCESS(ctx.ec());
+            INFO("rows.size() =" << res.rows_as_binary().size());
+            REQUIRE(res.rows_as_binary().size() == 1);
+            INFO("row=" << couchbase::core::utils::json::generate(res.rows_as_json()[0]));
+            REQUIRE(res.rows_as_json()[0] == couchbase::core::utils::json::parse(R"({"greetings":"hello, couchbase"})"));
+        }
+        {
+            auto res = cluster.diagnostics(couchbase::diagnostics_options().report_id("my_report_id")).get();
+            REQUIRE(res.id() == "my_report_id");
+            REQUIRE(res.sdk().find("cxx/") == 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::key_value].size() > 1);
+            REQUIRE(res.endpoints()[couchbase::service_type::query].size() == 1);
+            REQUIRE(res.endpoints()[couchbase::service_type::query][0].state() == couchbase::endpoint_state::connected);
+        }
     }
 }
 
@@ -356,6 +85,7 @@ TEST_CASE("integration: ping", "[integration]")
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
 
+    SECTION("Core API")
     {
         auto barrier = std::make_shared<std::promise<couchbase::core::diag::ping_result>>();
         auto f = barrier->get_future();
@@ -396,6 +126,45 @@ TEST_CASE("integration: ping", "[integration]")
         INFO(res.sdk);
         REQUIRE(res.sdk.find("cxx/") == 0);
     }
+
+    SECTION("Public API")
+    {
+        auto cluster = couchbase::cluster(integration.cluster);
+
+        auto res = cluster.ping(couchbase::ping_options().report_id("my_report_id")).get();
+        REQUIRE(res.endpoints().size() > 0);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::key_value) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value].size() > 0);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::management) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::management].size() > 0);
+
+        if (integration.ctx.deployment != test::utils::deployment_type::elixir) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::view) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::view].size() > 0);
+        }
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::query) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::query].size() > 0);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::search) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::search].size() > 0);
+
+        if (integration.ctx.version.supports_analytics()) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::analytics) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::analytics].size() > 0);
+        }
+
+        if (integration.ctx.version.supports_eventing_functions()) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::eventing) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::eventing].size() > 0);
+        }
+
+        REQUIRE(res.id() == "my_report_id");
+        INFO(res.sdk());
+        REQUIRE(res.sdk().find("cxx/") == 0);
+    }
 }
 
 TEST_CASE("integration: ping allows to select services", "[integration]")
@@ -404,6 +173,7 @@ TEST_CASE("integration: ping allows to select services", "[integration]")
 
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
 
+    SECTION("Core API")
     {
         auto barrier = std::make_shared<std::promise<couchbase::core::diag::ping_result>>();
         auto f = barrier->get_future();
@@ -421,12 +191,29 @@ TEST_CASE("integration: ping allows to select services", "[integration]")
         REQUIRE(res.services.count(couchbase::core::service_type::query) > 0);
         REQUIRE(res.services[couchbase::core::service_type::query].size() > 0);
     }
+
+    SECTION("Public API")
+    {
+        auto cluster = couchbase::cluster(integration.cluster);
+
+        auto opts = couchbase::ping_options().service_types({ couchbase::service_type::key_value, couchbase::service_type::query });
+        auto res = cluster.ping(opts).get();
+
+        REQUIRE(res.endpoints().size() == 2);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::key_value) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value].size() > 0);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::query) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::query].size() > 0);
+    }
 }
 
 TEST_CASE("integration: ping allows to select bucket and opens it automatically", "[integration]")
 {
     test::utils::integration_test_guard integration;
 
+    SECTION("Core API")
     {
         auto barrier = std::make_shared<std::promise<couchbase::core::diag::ping_result>>();
         auto f = barrier->get_future();
@@ -436,12 +223,26 @@ TEST_CASE("integration: ping allows to select bucket and opens it automatically"
                                  {},
                                  [barrier](couchbase::core::diag::ping_result&& resp) mutable { barrier->set_value(std::move(resp)); });
         auto res = f.get();
-        REQUIRE(res.services.size() == 1);
 
+        REQUIRE(res.services.size() == 1);
         REQUIRE(res.services.count(couchbase::core::service_type::key_value) > 0);
         REQUIRE(res.services[couchbase::core::service_type::key_value].size() > 0);
         REQUIRE(res.services[couchbase::core::service_type::key_value][0].bucket.has_value());
         REQUIRE(res.services[couchbase::core::service_type::key_value][0].bucket.value() == integration.ctx.bucket);
+    }
+
+    SECTION("Public API")
+    {
+        auto cluster = couchbase::cluster(integration.cluster);
+        auto bucket = cluster.bucket(integration.ctx.bucket);
+
+        auto res = bucket.ping(couchbase::ping_options().service_types({ couchbase::service_type::key_value })).get();
+
+        REQUIRE(res.endpoints().size() == 1);
+        REQUIRE(res.endpoints().count(couchbase::service_type::key_value) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value].size() > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value][0].endpoint_namespace().has_value());
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value][0].endpoint_namespace().value() == integration.ctx.bucket);
     }
 }
 
@@ -449,6 +250,7 @@ TEST_CASE("integration: ping allows setting timeout", "[integration]")
 {
     test::utils::integration_test_guard integration;
 
+    SECTION("Core API")
     {
         auto barrier = std::make_shared<std::promise<couchbase::core::diag::ping_result>>();
         auto f = barrier->get_future();
@@ -497,6 +299,56 @@ TEST_CASE("integration: ping allows setting timeout", "[integration]")
             REQUIRE(res.services[couchbase::core::service_type::eventing].size() > 0);
             REQUIRE(res.services[couchbase::core::service_type::eventing][0].error.has_value());
             REQUIRE(res.services[couchbase::core::service_type::eventing][0].state == couchbase::core::diag::ping_state::timeout);
+        }
+    }
+
+    SECTION("Public API")
+    {
+        auto cluster = couchbase::cluster(integration.cluster);
+
+        auto res = cluster.ping(couchbase::ping_options().timeout(std::chrono::milliseconds{ 1 })).get();
+
+        REQUIRE(res.endpoints().size() > 0);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::key_value) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value].size() > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value][0].error().has_value());
+        REQUIRE(res.endpoints()[couchbase::service_type::key_value][0].state() == couchbase::ping_state::timeout);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::management) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::management].size() > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::management][0].error().has_value());
+        REQUIRE(res.endpoints()[couchbase::service_type::management][0].state() == couchbase::ping_state::timeout);
+
+        if (integration.ctx.deployment != test::utils::deployment_type::elixir) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::view) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::view].size() > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::view][0].error().has_value());
+            REQUIRE(res.endpoints()[couchbase::service_type::view][0].state() == couchbase::ping_state::timeout);
+        }
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::query) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::query].size() > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::query][0].error().has_value());
+        REQUIRE(res.endpoints()[couchbase::service_type::query][0].state() == couchbase::ping_state::timeout);
+
+        REQUIRE(res.endpoints().count(couchbase::service_type::search) > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::search].size() > 0);
+        REQUIRE(res.endpoints()[couchbase::service_type::search][0].error().has_value());
+        REQUIRE(res.endpoints()[couchbase::service_type::search][0].state() == couchbase::ping_state::timeout);
+
+        if (integration.ctx.version.supports_analytics()) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::analytics) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::analytics].size() > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::analytics][0].error().has_value());
+            REQUIRE(res.endpoints()[couchbase::service_type::analytics][0].state() == couchbase::ping_state::timeout);
+        }
+
+        if (integration.ctx.version.supports_eventing_functions()) {
+            REQUIRE(res.endpoints().count(couchbase::service_type::eventing) > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::eventing].size() > 0);
+            REQUIRE(res.endpoints()[couchbase::service_type::eventing][0].error().has_value());
+            REQUIRE(res.endpoints()[couchbase::service_type::eventing][0].state() == couchbase::ping_state::timeout);
         }
     }
 }

--- a/test/test_unit_diagnostics.cxx
+++ b/test/test_unit_diagnostics.cxx
@@ -1,0 +1,516 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2023-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include <couchbase/diagnostics_result.hxx>
+#include <couchbase/ping_result.hxx>
+
+#include "core/diagnostics.hxx"
+#include "core/diagnostics_json.hxx"
+
+using namespace std::literals::chrono_literals;
+
+TEST_CASE("unit: serializing diagnostics report", "[unit]")
+{
+    auto expected = couchbase::core::utils::json::parse(R"(
+{
+  "version": 2,
+  "id": "0xdeadbeef",
+  "sdk": "cxx/1.0.0",
+  "services": {
+    "kv": [
+      {
+        "id": "0x1415F12",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:11210",
+        "local": "127.0.0.1:54670",
+        "state": "connected",
+        "namespace": "bucketname"
+      }
+    ],
+    "search": [
+      {
+        "id": "0x1415F11",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:8094",
+        "local": "127.0.0.1:54669",
+        "state": "connecting",
+        "details": "RECONNECTING, backoff for 4096ms from Fri Sep  1 00:03:44 PDT 2017"
+      }
+    ],
+    "query": [
+      {
+        "id": "0x1415F13",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:8093",
+        "local": "127.0.0.1:54671",
+        "state": "connected"
+      },
+      {
+        "id": "0x1415F14",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx2.home.ingenthron.org:8095",
+        "local": "127.0.0.1:54682",
+        "state": "disconnected"
+      }
+    ],
+    "analytics": [
+      {
+        "id": "0x1415F15",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:8095",
+        "local": "127.0.0.1:54675",
+        "state": "connected"
+      }
+    ],
+    "views": [
+      {
+        "id": "0x1415F16",
+        "last_activity_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:8092",
+        "local": "127.0.0.1:54672",
+        "state": "connected"
+      }
+    ]
+  }
+}
+)");
+
+    SECTION("Core API")
+    {
+        couchbase::core::diag::diagnostics_result res{
+            "0xdeadbeef",
+            "cxx/1.0.0",
+            {
+              {
+                {
+                  couchbase::core::service_type::search,
+                  {
+                    {
+                      couchbase::core::service_type::search,
+                      "0x1415F11",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:8094",
+                      "127.0.0.1:54669",
+                      couchbase::core::diag::endpoint_state::connecting,
+                      std::nullopt,
+                      "RECONNECTING, backoff for 4096ms from Fri Sep  1 00:03:44 PDT 2017",
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::key_value,
+                  {
+                    {
+                      couchbase::core::service_type::key_value,
+                      "0x1415F12",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:11210",
+                      "127.0.0.1:54670",
+                      couchbase::core::diag::endpoint_state::connected,
+                      "bucketname",
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::query,
+                  {
+                    {
+                      couchbase::core::service_type::query,
+                      "0x1415F13",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:8093",
+                      "127.0.0.1:54671",
+                      couchbase::core::diag::endpoint_state::connected,
+                    },
+                    {
+                      couchbase::core::service_type::query,
+                      "0x1415F14",
+                      1182000us,
+                      "centos7-lx2.home.ingenthron.org:8095",
+                      "127.0.0.1:54682",
+                      couchbase::core::diag::endpoint_state::disconnected,
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::analytics,
+                  {
+                    {
+                      couchbase::core::service_type::analytics,
+                      "0x1415F15",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:8095",
+                      "127.0.0.1:54675",
+                      couchbase::core::diag::endpoint_state::connected,
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::view,
+                  {
+                    {
+                      couchbase::core::service_type::view,
+                      "0x1415F16",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:8092",
+                      "127.0.0.1:54672",
+                      couchbase::core::diag::endpoint_state::connected,
+                    },
+                  },
+                },
+              },
+            },
+        };
+
+        auto report = tao::json::value(res);
+        REQUIRE(report == expected);
+    }
+
+    SECTION("Public API")
+    {
+        couchbase::diagnostics_result res{
+            "0xdeadbeef",
+            2,
+            "cxx/1.0.0",
+            {
+              {
+                couchbase::service_type::search,
+                {
+                  {
+                    couchbase::service_type::search,
+                    "0x1415F11",
+                    1182000us,
+                    "127.0.0.1:54669",
+                    "centos7-lx1.home.ingenthron.org:8094",
+                    std::nullopt,
+                    couchbase::endpoint_state::connecting,
+                    "RECONNECTING, backoff for 4096ms from Fri Sep  1 00:03:44 PDT 2017",
+                  },
+                },
+              },
+              {
+                couchbase::service_type::key_value,
+                {
+                  {
+                    couchbase::service_type::key_value,
+                    "0x1415F12",
+                    1182000us,
+                    "127.0.0.1:54670",
+                    "centos7-lx1.home.ingenthron.org:11210",
+                    "bucketname",
+                    couchbase::endpoint_state::connected,
+                    std::nullopt,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::query,
+                {
+                  {
+                    couchbase::service_type::query,
+                    "0x1415F13",
+                    1182000us,
+                    "127.0.0.1:54671",
+                    "centos7-lx1.home.ingenthron.org:8093",
+                    std::nullopt,
+                    couchbase::endpoint_state::connected,
+                    std::nullopt,
+                  },
+                  {
+                    couchbase::service_type::query,
+                    "0x1415F14",
+                    1182000us,
+                    "127.0.0.1:54682",
+                    "centos7-lx2.home.ingenthron.org:8095",
+                    std::nullopt,
+                    couchbase::endpoint_state::disconnected,
+                    std::nullopt,
+                  },
+                },
+
+              },
+              {
+                couchbase::service_type::analytics,
+                {
+                  {
+                    couchbase::service_type::analytics,
+                    "0x1415F15",
+                    1182000us,
+                    "127.0.0.1:54675",
+                    "centos7-lx1.home.ingenthron.org:8095",
+                    std::nullopt,
+                    couchbase::endpoint_state::connected,
+                    std::nullopt,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::view,
+                {
+                  {
+                    couchbase::service_type::view,
+                    "0x1415F16",
+                    1182000us,
+                    "127.0.0.1:54672",
+                    "centos7-lx1.home.ingenthron.org:8092",
+                    std::nullopt,
+                    couchbase::endpoint_state::connected,
+                    std::nullopt,
+                  },
+                },
+              },
+            },
+        };
+
+        auto report = res.as_json();
+        REQUIRE(report == expected);
+    }
+}
+
+TEST_CASE("unit: serializing ping report", "[integration]")
+{
+    auto expected = couchbase::core::utils::json::parse(R"(
+{
+  "version": 2,
+  "id": "0xdeadbeef",
+  "sdk": "cxx/1.0.0",
+  "services": {
+    "search": [
+      {
+        "id": "0x1415F11",
+        "latency_us": 877909,
+        "remote": "centos7-lx1.home.ingenthron.org:8094",
+        "local": "127.0.0.1:54669",
+        "state": "ok"
+      }
+    ],
+    "kv": [
+      {
+        "id": "0x1415F12",
+        "latency_us": 1182000,
+        "remote": "centos7-lx1.home.ingenthron.org:11210",
+        "local": "127.0.0.1:54670",
+        "state": "ok",
+        "namespace": "bucketname"
+      }
+    ],
+    "query": [
+      {
+        "id": "0x1415F14",
+        "latency_us": 2213,
+        "remote": "centos7-lx2.home.ingenthron.org:8095",
+        "local": "127.0.0.1:54682",
+        "state": "timeout"
+      }
+    ],
+    "analytics": [
+      {
+        "id": "0x1415F15",
+        "latency_us": 2213,
+        "remote": "centos7-lx1.home.ingenthron.org:8095",
+        "local": "127.0.0.1:54675",
+        "state": "error",
+        "error": "endpoint returned HTTP code 500!"
+      }
+    ],
+    "views": [
+      {
+        "id": "0x1415F16",
+        "latency_us": 45585,
+        "remote": "centos7-lx1.home.ingenthron.org:8092",
+        "local": "127.0.0.1:54672",
+        "state": "ok"
+      }
+    ]
+  }
+}
+)");
+
+    SECTION("Core API")
+    {
+        couchbase::core::diag::ping_result res{
+            "0xdeadbeef",
+            "cxx/1.0.0",
+            {
+              {
+                {
+                  couchbase::core::service_type::search,
+                  {
+                    {
+                      couchbase::core::service_type::search,
+                      "0x1415F11",
+                      877909us,
+                      "centos7-lx1.home.ingenthron.org:8094",
+                      "127.0.0.1:54669",
+                      couchbase::core::diag::ping_state::ok,
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::key_value,
+                  {
+                    {
+                      couchbase::core::service_type::key_value,
+                      "0x1415F12",
+                      1182000us,
+                      "centos7-lx1.home.ingenthron.org:11210",
+                      "127.0.0.1:54670",
+                      couchbase::core::diag::ping_state::ok,
+                      "bucketname",
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::query,
+                  {
+                    {
+                      couchbase::core::service_type::query,
+                      "0x1415F14",
+                      2213us,
+                      "centos7-lx2.home.ingenthron.org:8095",
+                      "127.0.0.1:54682",
+                      couchbase::core::diag::ping_state::timeout,
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::analytics,
+                  {
+                    {
+                      couchbase::core::service_type::analytics,
+                      "0x1415F15",
+                      2213us,
+                      "centos7-lx1.home.ingenthron.org:8095",
+                      "127.0.0.1:54675",
+                      couchbase::core::diag::ping_state::error,
+                      std::nullopt,
+                      "endpoint returned HTTP code 500!",
+                    },
+                  },
+                },
+                {
+                  couchbase::core::service_type::view,
+                  {
+                    {
+                      couchbase::core::service_type::view,
+                      "0x1415F16",
+                      45585us,
+                      "centos7-lx1.home.ingenthron.org:8092",
+                      "127.0.0.1:54672",
+                      couchbase::core::diag::ping_state::ok,
+                    },
+                  },
+                },
+              },
+            },
+        };
+
+        auto report = tao::json::value(res);
+        REQUIRE(report == expected);
+    }
+
+    SECTION("Public API")
+    {
+        couchbase::ping_result res{
+            "0xdeadbeef",
+            2,
+            "cxx/1.0.0",
+            {
+              {
+                couchbase::service_type::search,
+                {
+                  {
+                    couchbase::service_type::search,
+                    "0x1415F11",
+                    "127.0.0.1:54669",
+                    "centos7-lx1.home.ingenthron.org:8094",
+                    couchbase::ping_state::ok,
+                    std::nullopt,
+                    std::nullopt,
+                    877909us,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::key_value,
+                {
+                  {
+                    couchbase::service_type::key_value,
+                    "0x1415F12",
+                    "127.0.0.1:54670",
+                    "centos7-lx1.home.ingenthron.org:11210",
+                    couchbase::ping_state::ok,
+                    std::nullopt,
+                    "bucketname",
+                    1182000us,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::query,
+                {
+                  {
+                    couchbase::service_type::query,
+                    "0x1415F14",
+                    "127.0.0.1:54682",
+                    "centos7-lx2.home.ingenthron.org:8095",
+                    couchbase::ping_state::timeout,
+                    std::nullopt,
+                    std::nullopt,
+                    2213us,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::analytics,
+                {
+                  {
+                    couchbase::service_type::analytics,
+                    "0x1415F15",
+                    "127.0.0.1:54675",
+                    "centos7-lx1.home.ingenthron.org:8095",
+                    couchbase::ping_state::error,
+                    "endpoint returned HTTP code 500!",
+                    std::nullopt,
+                    2213us,
+                  },
+                },
+              },
+              {
+                couchbase::service_type::view,
+                {
+                  {
+                    couchbase::service_type::view,
+                    "0x1415F16",
+                    "127.0.0.1:54672",
+                    "centos7-lx1.home.ingenthron.org:8092",
+                    couchbase::ping_state::ok,
+                    std::nullopt,
+                    std::nullopt,
+                    45585us,
+                  },
+                },
+              },
+            },
+        };
+
+        auto report = res.as_json();
+        REQUIRE(report == expected);
+    }
+}


### PR DESCRIPTION
## Motivation

The `ping` and `diagnostics` operations currently only exist in the Core API, they also need to be exposed in the Public API

## Changes

* Add `ping()` to public `Cluster` and `Bucket` APIs
* Add `diagnostics() to the public `Cluster` API
* Add any relevant options & results to Public API (`diagnostics_options`, `ping_options`, `diagnostics_result`, `ping_result`, `endpoint_diagnostics`, `endpoint_ping_report`, `service_type`, `ping_state`, `endpoint_state`)
* Add tests (the public API equivalents of the existing core diagnostics tests)
* Moved the existing core diagnostics unit tests to a file separate from the integration tests

## Results

All tests pass