### PR TITLE
CXXCBC-426 Get with very large projection test is returning fields outside of the projection

### DIFF
--- a/couchbase/get_options.hxx
+++ b/couchbase/get_options.hxx
@@ -46,8 +46,6 @@ struct get_options : public common_options<get_options> {
         const std::vector<std::string> projections;
     };
 
-    static constexpr std::size_t maximum_number_of_projections{ 16U };
-
     /**
      * Validates options and returns them as an immutable value.
      *
@@ -60,9 +58,6 @@ struct get_options : public common_options<get_options> {
      */
     [[nodiscard]] auto build() const -> built
     {
-        if (projections_.size() + (with_expiry_ ? 2 : 1) < maximum_number_of_projections) {
-            return { build_common_options(), with_expiry_, projections_ };
-        }
         return { build_common_options(), with_expiry_, {} };
     }
 

--- a/couchbase/get_options.hxx
+++ b/couchbase/get_options.hxx
@@ -58,7 +58,7 @@ struct get_options : public common_options<get_options> {
      */
     [[nodiscard]] auto build() const -> built
     {
-        return { build_common_options(), with_expiry_, {} };
+        return { build_common_options(), with_expiry_, projections_ };
     }
 
     /**

--- a/tools/get.cxx
+++ b/tools/get.cxx
@@ -50,8 +50,7 @@ class get_app : public CLI::App
         add_option(
           "--project",
           projections_,
-          fmt::format("Return only part of the document, that corresponds given JSON-pointer (could be used multiple times, up to {}).",
-                      couchbase::get_options::maximum_number_of_projections))
+          fmt::format("Return only part of the document, that corresponds given JSON-pointer (could be used multiple times)."))
           ->allow_extra_args(false);
         add_flag("--hexdump", hexdump_, "Print value using hexdump encoding (safe for binary data on STDOUT).");
         add_flag("--pretty-json", pretty_json_, "Try to pretty-print as JSON value (prints AS-IS if the document is not a JSON).");

--- a/tools/get.cxx
+++ b/tools/get.cxx
@@ -47,10 +47,9 @@ class get_app : public CLI::App
                  inlined_keyspace_,
                  "Extract bucket, scope, collection and key from the IDs (captures will be done with /^(.*?):(.*?)\\.(.*?):(.*)$/).");
         add_flag("--with-expiry", with_expiry_, "Return document expiry time, if set.");
-        add_option(
-          "--project",
-          projections_,
-          fmt::format("Return only part of the document, that corresponds given JSON-pointer (could be used multiple times)."))
+        add_option("--project",
+                   projections_,
+                   fmt::format("Return only part of the document, that corresponds given JSON-pointer (could be used multiple times)."))
           ->allow_extra_args(false);
         add_flag("--hexdump", hexdump_, "Print value using hexdump encoding (safe for binary data on STDOUT).");
         add_flag("--pretty-json", pretty_json_, "Try to pretty-print as JSON value (prints AS-IS if the document is not a JSON).");


### PR DESCRIPTION
When an excessive number of projections is set in the options, the projections are not set at all, but the SDK should fall back to a full-doc fetch and return a valid projected result.