### PR TITLE
CXXCBC-346: Support for maxTTL value of -1 for collection 'no expiry'

### DIFF
--- a/core/operations/management/collection_create.cxx
+++ b/core/operations/management/collection_create.cxx
@@ -34,8 +34,12 @@ collection_create_request::encode_to(encoded_request_type& encoded, http_context
     encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections", bucket_name, scope_name);
     encoded.headers["content-type"] = "application/x-www-form-urlencoded";
     encoded.body = fmt::format("name={}", utils::string_codec::form_encode(collection_name));
-    if (max_expiry > 0) {
-        encoded.body.append(fmt::format("&maxTTL={}", max_expiry));
+    if (max_expiry >= -1) {
+        if (max_expiry != 0) {
+            encoded.body.append(fmt::format("&maxTTL={}", max_expiry));
+        }
+    } else {
+        return couchbase::errc::common::invalid_argument;
     }
     if (history.has_value()) {
         encoded.body.append(fmt::format("&history={}", history.value()));

--- a/core/operations/management/collection_create.hxx
+++ b/core/operations/management/collection_create.hxx
@@ -41,7 +41,7 @@ struct collection_create_request {
     std::string bucket_name;
     std::string scope_name;
     std::string collection_name;
-    std::uint32_t max_expiry{ 0 };
+    std::int32_t max_expiry{ 0 };
     std::optional<bool> history{};
 
     std::optional<std::string> client_context_id{};

--- a/core/operations/management/collection_update.cxx
+++ b/core/operations/management/collection_update.cxx
@@ -35,7 +35,11 @@ collection_update_request::encode_to(encoded_request_type& encoded, http_context
     encoded.headers["content-type"] = "application/x-www-form-urlencoded";
     std::map<std::string, std::string> values{};
     if (max_expiry.has_value()) {
-        values["maxTTL"] = std::to_string(max_expiry.value());
+        if (max_expiry.value() >= -1) {
+            values["maxTTL"] = std::to_string(max_expiry.value());
+        } else {
+            return errc::common::invalid_argument;
+        }
     }
     if (history.has_value()) {
         values["history"] = history.value() ? "true" : "false";

--- a/core/operations/management/collection_update.hxx
+++ b/core/operations/management/collection_update.hxx
@@ -41,7 +41,7 @@ struct collection_update_request {
     std::string bucket_name;
     std::string scope_name;
     std::string collection_name;
-    std::optional<std::uint32_t> max_expiry{};
+    std::optional<std::int32_t> max_expiry{};
     std::optional<bool> history{};
 
     std::optional<std::string> client_context_id{};

--- a/core/topology/collections_manifest.hxx
+++ b/core/topology/collections_manifest.hxx
@@ -28,7 +28,7 @@ struct collections_manifest {
     struct collection {
         std::uint64_t uid;
         std::string name;
-        std::uint32_t max_expiry{ 0 };
+        std::int32_t max_expiry{ 0 };
         std::optional<bool> history{};
     };
 

--- a/core/topology/collections_manifest_json.hxx
+++ b/core/topology/collections_manifest_json.hxx
@@ -41,7 +41,7 @@ struct traits<couchbase::core::topology::collections_manifest> {
                 collection.uid = std::stoull(c.at("uid").get_string(), nullptr, 16);
                 collection.name = c.at("name").get_string();
                 if (const auto* max_ttl = c.find("maxTTL"); max_ttl != nullptr) {
-                    collection.max_expiry = max_ttl->template as<std::uint32_t>();
+                    collection.max_expiry = max_ttl->template as<std::int32_t>();
                 }
                 if (const auto* history = c.find("history"); history != nullptr) {
                     collection.history = history->template as<std::optional<bool>>();

--- a/couchbase/create_collection_options.hxx
+++ b/couchbase/create_collection_options.hxx
@@ -20,6 +20,7 @@
 #include <couchbase/common_options.hxx>
 #include <couchbase/manager_error_context.hxx>
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 
@@ -27,17 +28,44 @@ namespace couchbase
 {
 struct create_collection_options : public common_options<create_collection_options> {
   public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
     struct built : public common_options<create_collection_options>::built {
     };
 
+    /**
+     * Validates the options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
     [[nodiscard]] auto build() const -> built
     {
         return { build_common_options() };
     }
 };
 
+/**
+ * The settings to use when creating the collection
+ */
 struct create_collection_settings {
-    std::uint32_t max_expiry{ 0 };
+    /**
+     * The maximum expiry, in seconds, for documents in this collection. Values greater than or equal to -1 are valid.
+     * Value of 0 sets max_expiry to the bucket-level setting and value of -1 to set it as no-expiry.
+     */
+    std::int32_t max_expiry{ 0 };
+
+    /**
+     * Whether history retention should be enabled. If unset, the bucket-level setting is used.
+     */
     std::optional<bool> history{};
 };
 

--- a/couchbase/management/collection_spec.hxx
+++ b/couchbase/management/collection_spec.hxx
@@ -22,7 +22,7 @@ namespace couchbase::management::bucket
 struct collection_spec {
     std::string name;
     std::string scope_name;
-    std::uint32_t max_expiry{};
+    std::int32_t max_expiry{};
     std::optional<bool> history{};
 };
 

--- a/couchbase/update_collection_options.hxx
+++ b/couchbase/update_collection_options.hxx
@@ -17,26 +17,55 @@
 
 #pragma once
 
-#include <functional>
+#include <couchbase/common_options.hxx>
+#include <couchbase/manager_error_context.hxx>
+
+#include <cstdint>
 #include <memory>
 #include <optional>
-#include <string>
 
 namespace couchbase
 {
 struct update_collection_options : public common_options<update_collection_options> {
   public:
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
     struct built : public common_options<update_collection_options>::built {
     };
 
+    /**
+     * Validates the options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value
+     *
+     * @exception std::system_error with code errc::common::invalid_argument if the options are not valid
+     *
+     * @since 1.0.0
+     * @internal
+     */
     [[nodiscard]] auto build() const -> built
     {
         return { build_common_options() };
     }
 };
 
+/**
+ * The settings that should be updated for the collection
+ */
 struct update_collection_settings {
-    std::optional<std::uint32_t> max_expiry{};
+    /**
+     * The maximum expiry, in seconds, for documents in this collection. Values greater than or equal to -1 are valid.
+     * Value of 0 sets max_expiry to the bucket-level setting and value of -1 to set it as no-expiry.
+     */
+    std::optional<std::int32_t> max_expiry{};
+
+    /**
+     * Whether history retention should be enabled.
+     */
     std::optional<bool> history{};
 };
 

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -226,6 +226,16 @@ struct server_version {
         return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
     }
 
+    [[nodiscard]] bool supports_collection_update_max_expiry() const
+    {
+        return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
+    }
+
+    [[nodiscard]] bool supports_collection_set_max_expiry_to_no_expiry() const
+    {
+        return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
+    }
+
     [[nodiscard]] bool is_capella() const
     {
         return deployment == deployment_type::capella;


### PR DESCRIPTION
## Motivation

The server has added support for the maxTTL value of -1 which is used to denote 'no expiry'

## Changes

* Change the type of `max_expiry` in the collection management APIs (both core and public) from `uint32_t` to `int32_t` to allow setting it to -1. The server accepts values in the range [-1, 2,147,483,647] which can be represented by a 32-bit signed integer.
* Return `errc::invalid_argument` when a value less than -1 is provided
* Add tests for `create_collection` and `update_collection` with different values for `max_expiry`