### PR TITLE
CXXCBC-431: Add check for history retention bucket capability in collection create/update

### DIFF
--- a/core/operations/management/collection_update.cxx
+++ b/core/operations/management/collection_update.cxx
@@ -28,7 +28,7 @@
 namespace couchbase::core::operations::management
 {
 std::error_code
-collection_update_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+collection_update_request::encode_to(encoded_request_type& encoded, http_context& context) const
 {
     encoded.method = "PATCH";
     encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections/{}", bucket_name, scope_name, collection_name);
@@ -42,6 +42,11 @@ collection_update_request::encode_to(encoded_request_type& encoded, http_context
         }
     }
     if (history.has_value()) {
+        auto bucket_caps = context.config.bucket_capabilities;
+        if (bucket_caps.find(bucket_capability::non_deduped_history) == bucket_caps.end()) {
+            return errc::common::feature_not_available;
+        }
+
         values["history"] = history.value() ? "true" : "false";
     }
     encoded.body = utils::string_codec::v2::form_encode(values);
@@ -55,12 +60,7 @@ collection_update_request::make_response(error_context::http&& ctx, const encode
     if (!response.ctx.ec) {
         switch (encoded.status_code) {
             case 400: {
-                if (encoded.body.data().find("Not allowed on this version of cluster") != std::string::npos ||
-                    encoded.body.data().find("Bucket must have storage_mode=magma") != std::string::npos) {
-                    response.ctx.ec = errc::common::feature_not_available;
-                } else {
-                    response.ctx.ec = errc::common::invalid_argument;
-                }
+                response.ctx.ec = errc::common::invalid_argument;
             } break;
             case 404: {
                 std::regex scope_not_found("Scope with name .+ is not found");


### PR DESCRIPTION
The error message when the bucket does not support history retention has changed in newer server versions. Replace the error message checks for `feature_not_available` with a bucket capability check before sending the collection create/update request.