### PR TITLE
CXXCBC-284: Use round-robin for config polling

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -28,6 +28,7 @@
 #include "mcbp/queue_response.hxx"
 #include "origin.hxx"
 #include "ping_collector.hxx"
+#include "protocol/cmd_get_cluster_config.hxx"
 #include "retry_orchestrator.hxx"
 
 #include <couchbase/metrics/meter.hxx>
@@ -67,6 +68,10 @@ class bucket_impl
       , codec_{ { known_features_.begin(), known_features_.end() } }
       , ctx_{ ctx }
       , tls_{ tls }
+      , heartbeat_timer_(ctx_)
+      , heartbeat_interval_{ origin_.options().config_poll_floor > origin_.options().config_poll_interval
+                               ? origin_.options().config_poll_floor
+                               : origin_.options().config_poll_interval }
     {
     }
 
@@ -421,6 +426,7 @@ class bucket_impl
                 }
                 self->update_config(cfg);
                 self->drain_deferred_queue();
+                self->fetch_config({});
             }
             asio::post(asio::bind_executor(self->ctx_, [h = std::move(h), ec, cfg = std::move(cfg)]() mutable { h(ec, cfg); }));
         });
@@ -476,12 +482,52 @@ class bucket_impl
         }
     }
 
-    void close()
+    void fetch_config(std::error_code ec)
     {
-        if (closed_) {
+        if (ec == asio::error::operation_aborted || closed_) {
             return;
         }
-        closed_ = true;
+        if (heartbeat_timer_.expiry() > std::chrono::steady_clock::now()) {
+            return;
+        }
+
+        std::optional<io::mcbp_session> session{};
+        {
+            std::scoped_lock lock(sessions_mutex_);
+
+            std::size_t start = heartbeat_next_index_.fetch_add(1);
+            std::size_t i = start;
+            do {
+                auto ptr = sessions_.find(i % sessions_.size());
+                if (ptr != sessions_.end() && ptr->second.supports_gcccp()) {
+                    session = ptr->second;
+                }
+                i = heartbeat_next_index_.fetch_add(1);
+            } while (start % sessions_.size() != i % sessions_.size());
+        }
+        if (session) {
+            protocol::client_request<protocol::get_cluster_config_request_body> req;
+            req.opaque(session->next_opaque());
+            session->write_and_flush(req.data());
+        } else {
+            CB_LOG_WARNING(R"({} unable to find session with GCCCP support, retry in {})", log_prefix_, heartbeat_interval_);
+        }
+        heartbeat_timer_.expires_after(heartbeat_interval_);
+        return heartbeat_timer_.async_wait([self = shared_from_this()](std::error_code e) {
+            if (e == asio::error::operation_aborted) {
+                return;
+            }
+            self->fetch_config(e);
+        });
+    }
+
+    void close()
+    {
+        if (bool expected_state{ false }; !closed_.compare_exchange_strong(expected_state, true)) {
+            return;
+        }
+
+        heartbeat_timer_.cancel();
 
         drain_deferred_queue();
 
@@ -773,6 +819,10 @@ class bucket_impl
     asio::io_context& ctx_;
     asio::ssl::context& tls_;
 
+    asio::steady_timer heartbeat_timer_;
+    std::chrono::milliseconds heartbeat_interval_;
+    std::atomic_size_t heartbeat_next_index_{ 0 };
+
     std::atomic_bool closed_{ false };
     std::atomic_bool configured_{ false };
 
@@ -790,15 +840,16 @@ class bucket_impl
     std::atomic_size_t round_robin_next_{ 0 };
 };
 
-bucket::bucket(std::string client_id,
-               asio::io_context& ctx,
-               asio::ssl::context& tls,
-               std::shared_ptr<couchbase::tracing::request_tracer> tracer,
-               std::shared_ptr<couchbase::metrics::meter> meter,
-               std::string name,
-               couchbase::core::origin origin,
-               std::vector<protocol::hello_feature> known_features,
-               std::shared_ptr<impl::bootstrap_state_listener> state_listener)
+bucket::
+bucket(std::string client_id,
+       asio::io_context& ctx,
+       asio::ssl::context& tls,
+       std::shared_ptr<couchbase::tracing::request_tracer> tracer,
+       std::shared_ptr<couchbase::metrics::meter> meter,
+       std::string name,
+       couchbase::core::origin origin,
+       std::vector<protocol::hello_feature> known_features,
+       std::shared_ptr<impl::bootstrap_state_listener> state_listener)
 
   : ctx_(ctx)
   , impl_{ std::make_shared<bucket_impl>(std::move(client_id),
@@ -813,7 +864,8 @@ bucket::bucket(std::string client_id,
 {
 }
 
-bucket::~bucket()
+bucket::~
+bucket()
 {
     impl_->close();
 }

--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -840,16 +840,15 @@ class bucket_impl
     std::atomic_size_t round_robin_next_{ 0 };
 };
 
-bucket::
-bucket(std::string client_id,
-       asio::io_context& ctx,
-       asio::ssl::context& tls,
-       std::shared_ptr<couchbase::tracing::request_tracer> tracer,
-       std::shared_ptr<couchbase::metrics::meter> meter,
-       std::string name,
-       couchbase::core::origin origin,
-       std::vector<protocol::hello_feature> known_features,
-       std::shared_ptr<impl::bootstrap_state_listener> state_listener)
+bucket::bucket(std::string client_id,
+               asio::io_context& ctx,
+               asio::ssl::context& tls,
+               std::shared_ptr<couchbase::tracing::request_tracer> tracer,
+               std::shared_ptr<couchbase::metrics::meter> meter,
+               std::string name,
+               couchbase::core::origin origin,
+               std::vector<protocol::hello_feature> known_features,
+               std::shared_ptr<impl::bootstrap_state_listener> state_listener)
 
   : ctx_(ctx)
   , impl_{ std::make_shared<bucket_impl>(std::move(client_id),
@@ -864,8 +863,7 @@ bucket(std::string client_id,
 {
 }
 
-bucket::~
-bucket()
+bucket::~bucket()
 {
     impl_->close();
 }

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -109,6 +109,7 @@ class mcbp_session
     [[nodiscard]] const std::string& bootstrap_hostname() const;
     [[nodiscard]] const std::string& bootstrap_port() const;
     [[nodiscard]] std::uint16_t bootstrap_port_number() const;
+    void write_and_flush(std::vector<std::byte>&& buffer);
     void write_and_subscribe(std::shared_ptr<mcbp::queue_request>, std::shared_ptr<response_handler> handler);
     void write_and_subscribe(std::uint32_t opaque, std::vector<std::byte>&& data, command_handler&& handler);
     void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler,


### PR DESCRIPTION
Instead of letting each MCBP session to poll for configuration automatically, make bucket object responsible for the polling orchestration and iterate over the list of known session to use only one socket to fetch configuration.