### PR TITLE
CXXCBC-431: Fix history retention bucket capability check

### DIFF
--- a/core/operations/management/collection_create.cxx
+++ b/core/operations/management/collection_create.cxx
@@ -28,7 +28,7 @@
 namespace couchbase::core::operations::management
 {
 std::error_code
-collection_create_request::encode_to(encoded_request_type& encoded, http_context& context) const
+collection_create_request::encode_to(encoded_request_type& encoded, http_context& /*context*/) const
 {
     encoded.method = "POST";
     encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections", bucket_name, scope_name);
@@ -42,11 +42,6 @@ collection_create_request::encode_to(encoded_request_type& encoded, http_context
         return couchbase::errc::common::invalid_argument;
     }
     if (history.has_value()) {
-        auto bucket_caps = context.config.bucket_capabilities;
-        if (bucket_caps.find(bucket_capability::non_deduped_history) == bucket_caps.end()) {
-            return errc::common::feature_not_available;
-        }
-
         encoded.body.append(fmt::format("&history={}", history.value()));
     }
     return {};

--- a/core/operations/management/collection_update.cxx
+++ b/core/operations/management/collection_update.cxx
@@ -28,7 +28,7 @@
 namespace couchbase::core::operations::management
 {
 std::error_code
-collection_update_request::encode_to(encoded_request_type& encoded, http_context& context) const
+collection_update_request::encode_to(encoded_request_type& encoded, http_context& /*context*/) const
 {
     encoded.method = "PATCH";
     encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections/{}", bucket_name, scope_name, collection_name);
@@ -42,11 +42,6 @@ collection_update_request::encode_to(encoded_request_type& encoded, http_context
         }
     }
     if (history.has_value()) {
-        auto bucket_caps = context.config.bucket_capabilities;
-        if (bucket_caps.find(bucket_capability::non_deduped_history) == bucket_caps.end()) {
-            return errc::common::feature_not_available;
-        }
-
         values["history"] = history.value() ? "true" : "false";
     }
     encoded.body = utils::string_codec::v2::form_encode(values);

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -1557,16 +1557,29 @@ TEST_CASE("integration: collection management history retention not supported in
 
     SECTION("create collection")
     {
-        couchbase::core::operations::management::collection_create_request req{
-            integration.ctx.bucket,
-            scope_name,
-            collection_name,
-        };
+        SECTION("core API")
+        {
+            couchbase::core::operations::management::collection_create_request req{
+                integration.ctx.bucket,
+                scope_name,
+                collection_name,
+            };
+            req.history = true;
 
-        req.history = true;
+            auto resp = test::utils::execute(integration.cluster, req);
+            REQUIRE(resp.ctx.ec == couchbase::errc::common::feature_not_available);
+        }
 
-        auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE(resp.ctx.ec == couchbase::errc::common::feature_not_available);
+        SECTION("public API")
+        {
+            auto manager = couchbase::cluster(integration.cluster).bucket(integration.ctx.bucket).collections();
+
+            couchbase::create_collection_settings settings{};
+            settings.history = true;
+
+            auto ctx = manager.create_collection(scope_name, collection_name, settings).get();
+            REQUIRE(ctx.ec() == couchbase::errc::common::feature_not_available);
+        }
     }
 
     SECTION("update collection")
@@ -1574,16 +1587,30 @@ TEST_CASE("integration: collection management history retention not supported in
         auto ec = create_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
         REQUIRE_SUCCESS(ec);
 
-        couchbase::core::operations::management::collection_update_request req{
-            integration.ctx.bucket,
-            scope_name,
-            collection_name,
-        };
+        SECTION("core API")
+        {
+            couchbase::core::operations::management::collection_update_request req{
+                integration.ctx.bucket,
+                scope_name,
+                collection_name,
+            };
 
-        req.history = true;
+            req.history = true;
 
-        auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE(resp.ctx.ec == couchbase::errc::common::feature_not_available);
+            auto resp = test::utils::execute(integration.cluster, req);
+            REQUIRE(resp.ctx.ec == couchbase::errc::common::feature_not_available);
+        }
+
+        SECTION("public API")
+        {
+            auto manager = couchbase::cluster(integration.cluster).bucket(integration.ctx.bucket).collections();
+
+            couchbase::update_collection_settings settings{};
+            settings.history = true;
+
+            auto ctx = manager.update_collection(scope_name, collection_name, settings).get();
+            REQUIRE(ctx.ec() == couchbase::errc::common::feature_not_available);
+        }
     }
 
     // Clean up the collection that was created


### PR DESCRIPTION
## Motivation
The `http_context` appears to be at the cluster level, so it wasn't clear which bucket's capabilities were being checked. This resulted in unpredictability, as seen in FIT and in the Python SDK's test suite.

## Changes
Add a new `execute_with_bucket_capability` method that after ensuring that the bucket is open, it checks for the presence of the capability using `with_bucket_configuration` and then proceeds to do the operation if successful. This is now used for `create_collection` and `update_collection`.

## Results
Tests pass (including FIT)