### PR TITLE
CXXCBC-421: Return `feature_not_available` when query preserve expiry is not supported

### DIFF
--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -327,7 +327,12 @@ query_request::make_response(error_context::query&& ctx, const encoded_response_
                 response.ctx.first_error_message = response.meta.errors->front().message;
                 switch (response.ctx.first_error_code) {
                     case 1065: /* IKey: "service.io.request.unrecognized_parameter" */
-                        response.ctx.ec = errc::common::invalid_argument;
+                        if ((response.ctx.first_error_message.find("Unrecognized parameter in request") != std::string::npos) &&
+                            (response.ctx.first_error_message.find("preserve_expiry") != std::string::npos)) {
+                            response.ctx.ec = errc::common::feature_not_available;
+                        } else {
+                            response.ctx.ec = errc::common::invalid_argument;
+                        }
                         break;
                     case 1080: /* IKey: "timeout" */
                         response.ctx.ec = errc::common::unambiguous_timeout;


### PR DESCRIPTION
This was caught by a failing FIT test. Now checking the error message to return `feature_not_available` instead of `invalid_argument` when the server reports that it does not recognise the `preserve_expiry` parameter.