### PR TITLE
CXXCBC-447: Use addresses from the config to bootstrap bucket

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -238,10 +238,14 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
             auto ptr = buckets_.find(bucket_name);
             if (ptr == buckets_.end()) {
                 std::vector<protocol::hello_feature> known_features;
+
+                auto origin = origin_;
                 if (session_ && session_->has_config()) {
                     known_features = session_->supported_features();
+                    origin = { origin_, session_->config().value() };
                 }
-                b = std::make_shared<bucket>(id_, ctx_, tls_, tracer_, meter_, bucket_name, origin_, known_features, dns_srv_tracker_);
+
+                b = std::make_shared<bucket>(id_, ctx_, tls_, tracer_, meter_, bucket_name, origin, known_features, dns_srv_tracker_);
                 buckets_.try_emplace(bucket_name, b);
             }
         }

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -1139,6 +1139,11 @@ class mcbp_session_impl
         return supports_gcccp_;
     }
 
+    std::optional<topology::configuration> config() const
+    {
+        return config_;
+    }
+
     [[nodiscard]] bool has_config() const
     {
         return configured_;
@@ -1816,6 +1821,12 @@ std::size_t
 mcbp_session::index() const
 {
     return impl_->index();
+}
+
+std::optional<topology::configuration>
+mcbp_session::config() const
+{
+    return impl_->config();
 }
 
 bool

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -118,6 +118,7 @@ class mcbp_session
     void stop(retry_reason reason);
     [[nodiscard]] std::size_t index() const;
     [[nodiscard]] bool has_config() const;
+    [[nodiscard]] std::optional<topology::configuration> config() const;
     [[nodiscard]] diag::endpoint_diag_info diag_info() const;
     void on_configuration_update(std::shared_ptr<config_listener> handler);
     void ping(std::shared_ptr<diag::ping_reporter> handler, std::optional<std::chrono::milliseconds> = {}) const;

--- a/core/origin.cxx
+++ b/core/origin.cxx
@@ -18,6 +18,7 @@
 #include "origin.hxx"
 
 #include "core/utils/connection_string.hxx"
+#include "topology/configuration.hxx"
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
@@ -281,6 +282,19 @@ couchbase::core::origin::origin(const couchbase::core::origin& other)
   , next_node_(nodes_.begin())
 {
 }
+
+couchbase::core::origin::origin(const origin& other, const topology::configuration& config)
+  : origin(other)
+{
+    nodes_.clear();
+    for (const auto& node : config.nodes) {
+        if (auto port = options_.enable_tls ? node.services_tls.key_value : node.services_plain.key_value; port.has_value()) {
+            nodes_.emplace_back(node.hostname, std::to_string(port.value()));
+        }
+    }
+    next_node_ = nodes_.begin();
+}
+
 couchbase::core::origin::origin(couchbase::core::cluster_credentials auth,
                                 const std::string& hostname,
                                 std::uint16_t port,

--- a/core/origin.hxx
+++ b/core/origin.hxx
@@ -40,6 +40,11 @@ struct cluster_credentials {
     [[nodiscard]] bool uses_certificate() const;
 };
 
+namespace topology
+{
+struct configuration;
+}
+
 struct origin {
     using node_entry = std::pair<std::string, std::string>;
     using node_list = std::vector<node_entry>;
@@ -49,6 +54,7 @@ struct origin {
 
     origin(origin&& other) = default;
     origin(const origin& other);
+    origin(const origin& other, const topology::configuration& config);
     origin(cluster_credentials auth, const std::string& hostname, std::uint16_t port, cluster_options options);
     origin(cluster_credentials auth, const std::string& hostname, const std::string& port, cluster_options options);
     origin(cluster_credentials auth, const utils::connection_string& connstr);


### PR DESCRIPTION
Use hostnames from the cluster configuration to bootstrap bucket connections instead of original list from the connection string.

It is possible that connection string does not have any node that has KV service, and in this case the SDK will fail to open bucket.