### PR TITLE
CXXCBC-191: Create Index Key Encoding

### DIFF
--- a/core/impl/query_index_manager.cxx
+++ b/core/impl/query_index_manager.cxx
@@ -215,7 +215,7 @@ class query_index_manager_impl : public std::enable_shared_from_this<query_index
                       const std::string& scope_name,
                       const std::string& collection_name,
                       std::string index_name,
-                      std::vector<std::string> fields,
+                      std::vector<std::string> keys,
                       const create_query_index_options::built& options,
                       create_query_index_handler&& handler) const
     {
@@ -225,7 +225,7 @@ class query_index_manager_impl : public std::enable_shared_from_this<query_index
             scope_name,
             collection_name,
             std::move(index_name),
-            std::move(fields),
+            std::move(keys),
             {},
             false /* is_primary */,
             options.ignore_if_exists,
@@ -521,22 +521,22 @@ collection_query_index_manager::get_all_indexes(const get_all_query_indexes_opti
 
 void
 collection_query_index_manager::create_index(std::string index_name,
-                                             std::vector<std::string> fields,
+                                             std::vector<std::string> keys,
                                              const create_query_index_options& options,
                                              create_query_index_handler&& handler) const
 {
     return impl_->create_index(
-      bucket_name_, scope_name_, collection_name_, std::move(index_name), std::move(fields), options.build(), std::move(handler));
+      bucket_name_, scope_name_, collection_name_, std::move(index_name), std::move(keys), options.build(), std::move(handler));
 }
 
 auto
 collection_query_index_manager::create_index(std::string index_name,
-                                             std::vector<std::string> fields,
+                                             std::vector<std::string> keys,
                                              const create_query_index_options& options) const -> std::future<manager_error_context>
 {
     auto barrier = std::make_shared<std::promise<manager_error_context>>();
     auto future = barrier->get_future();
-    create_index(std::move(index_name), std::move(fields), options, [barrier](auto ctx) { barrier->set_value(std::move(ctx)); });
+    create_index(std::move(index_name), std::move(keys), options, [barrier](auto ctx) { barrier->set_value(std::move(ctx)); });
     return future;
 }
 

--- a/core/operations/management/query_index_create.hxx
+++ b/core/operations/management/query_index_create.hxx
@@ -49,7 +49,7 @@ struct query_index_create_request {
     std::string scope_name;
     std::string collection_name;
     std::string index_name{};
-    std::vector<std::string> fields;
+    std::vector<std::string> keys;
     query_context query_ctx;
     bool is_primary{ false };
     bool ignore_if_exists{ false };

--- a/couchbase/collection_query_index_manager.hxx
+++ b/couchbase/collection_query_index_manager.hxx
@@ -53,8 +53,7 @@ class collection_query_index_manager
 {
   public:
     /**
-     * Get all indexes within a collection.
-     *
+     * Get all indexes within the collection.
      *
      * @param options optional parameters
      * @param handler the handler that implements @ref get_all_query_indexes_handler
@@ -64,13 +63,23 @@ class collection_query_index_manager
      */
     void get_all_indexes(const get_all_query_indexes_options& options, get_all_query_indexes_handler&& handler) const;
 
+    /**
+     * Get all indexes within the collection..
+     *
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto get_all_indexes(const get_all_query_indexes_options& options) const
       -> std::future<std::pair<manager_error_context, std::vector<couchbase::management::query_index>>>;
+
     /**
      * Create an index on the collection.
      *
      * @param index_name name of the index
-     * @param fields the fields to create the index over
+     * @param keys the keys to create the index over
      * @param options optional parameters
      * @param handler the handler that implements @ref create_query_index_handler
      *
@@ -78,16 +87,26 @@ class collection_query_index_manager
      * @committed
      */
     void create_index(std::string index_name,
-                      std::vector<std::string> fields,
+                      std::vector<std::string> keys,
                       const create_query_index_options& options,
                       create_query_index_handler&& handler) const;
 
-    [[nodiscard]] auto create_index(std::string index_name,
-                                    std::vector<std::string> fields,
-                                    const create_query_index_options& options) const -> std::future<manager_error_context>;
+    /**
+     * Create an index on the collection.
+     *
+     * @param index_name name of the index
+     * @param keys the keys to create the index over
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto create_index(std::string index_name, std::vector<std::string> keys, const create_query_index_options& options) const
+      -> std::future<manager_error_context>;
 
     /**
-     * Create a primary index on a collection.
+     * Create a primary index on the collection.
      *
      * @param options optional parameters
      * @param handler the handler that implements @ref create_query_index_handler
@@ -97,10 +116,19 @@ class collection_query_index_manager
      */
     void create_primary_index(const create_primary_query_index_options& options, create_query_index_handler&& handler) const;
 
+    /**
+     * Create a primary index on the collection.
+     *
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto create_primary_index(const create_primary_query_index_options& options) const -> std::future<manager_error_context>;
 
     /**
-     * Drop primary index on a collection.
+     * Drop primary index on the collection.
      *
      * @param options optional parameters
      * @param handler the handler that implements @ref drop_query_index_handler
@@ -110,10 +138,19 @@ class collection_query_index_manager
      */
     void drop_primary_index(const drop_primary_query_index_options& options, drop_query_index_handler&& handler) const;
 
+    /**
+     * Drop primary index on the collection.
+     *
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto drop_primary_index(const drop_primary_query_index_options& options) const -> std::future<manager_error_context>;
 
     /**
-     * Drop index in collection.
+     * Drop specified query index in the collection.
      *
      * @param index_name name of the index to drop
      * @param options optional parameters
@@ -124,14 +161,25 @@ class collection_query_index_manager
      */
     void drop_index(std::string index_name, const drop_query_index_options& options, drop_query_index_handler&& handler) const;
 
+    /**
+     * Drop specified query index in the collection.
+     *
+     * @param index_name name of the index to drop
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto drop_index(std::string index_name, const drop_query_index_options& options) const
       -> std::future<manager_error_context>;
+
     /**
      * Builds all currently deferred indexes in this collection.
      *
      * By default, this method will build the indexes on the collection.
      *
-     * @param options the custom options
+     * @param options optional parameters
      * @param handler the handler that implements @ref build_deferred_query_indexes_handler
      *
      * @since 1.0.0
@@ -139,6 +187,17 @@ class collection_query_index_manager
      */
     void build_deferred_indexes(const build_query_index_options& options, build_deferred_query_indexes_handler&& handler) const;
 
+    /**
+     * Builds all currently deferred indexes in this collection.
+     *
+     * By default, this method will build the indexes on the collection.
+     *
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto build_deferred_indexes(const build_query_index_options& options) const -> std::future<manager_error_context>;
 
     /**
@@ -155,6 +214,16 @@ class collection_query_index_manager
                        const watch_query_indexes_options& options,
                        watch_query_indexes_handler&& handler) const;
 
+    /**
+     * Polls the state of a set of indexes, until they all are online.
+     *
+     * @param index_names names of the indexes to watch
+     * @param options optional parameters
+     * @return future object that carries result of the operation
+     *
+     * @since 1.0.0
+     * @committed
+     */
     [[nodiscard]] auto watch_indexes(std::vector<std::string> index_names, const watch_query_indexes_options& options) const
       -> std::future<manager_error_context>;
 

--- a/couchbase/query_index_manager.hxx
+++ b/couchbase/query_index_manager.hxx
@@ -51,7 +51,6 @@ class query_index_manager
     /**
      * Get all indexes within a bucket.
      *
-     *
      * @param bucket_name specifies the bucket in which we look for the indexes
      * @param options optional parameters
      * @param handler the handler that implements @ref get_all_query_indexes_handler
@@ -65,7 +64,6 @@ class query_index_manager
 
     /**
      * Get all indexes within a bucket.
-     *
      *
      * @param bucket_name specifies the bucket in which we look for the indexes
      * @param options optional parameters
@@ -82,7 +80,7 @@ class query_index_manager
      *
      * @param bucket_name specifies the bucket in which to create the index
      * @param index_name name of the index
-     * @param fields the fields to create the index over
+     * @param keys the keys to create the index over
      * @param options optional parameters
      * @param handler the handler that implements @ref create_query_index_handler
      *
@@ -91,7 +89,7 @@ class query_index_manager
      */
     void create_index(std::string bucket_name,
                       std::string index_name,
-                      std::vector<std::string> fields,
+                      std::vector<std::string> keys,
                       const create_query_index_options& options,
                       create_query_index_handler&& handler) const;
 
@@ -100,7 +98,7 @@ class query_index_manager
      *
      * @param bucket_name specifies the bucket in which to create the index
      * @param index_name name of the index
-     * @param fields the fields to create the index over
+     * @param keys the keys to create the index over
      * @param options optional parameters
      * @return future object that carries result of the operation
      *
@@ -109,7 +107,7 @@ class query_index_manager
      */
     [[nodiscard]] auto create_index(std::string bucket_name,
                                     std::string index_name,
-                                    std::vector<std::string> fields,
+                                    std::vector<std::string> keys,
                                     const create_query_index_options& options) const -> std::future<manager_error_context>;
 
     /**
@@ -202,7 +200,7 @@ class query_index_manager
      * By default, this method will build the indexes on the bucket.
      *
      * @param bucket_name name of the bucket
-     * @param options the custom options
+     * @param options optional parameters
      * @param handler the handler that implements @ref build_deferred_query_indexes_handler
      *
      * @since 1.0.0
@@ -218,7 +216,7 @@ class query_index_manager
      * By default, this method will build the indexes on the bucket.
      *
      * @param bucket_name name of the bucket
-     * @param options the custom options
+     * @param options optional parameters
      * @return future object that carries result of the operation
      *
      * @since 1.0.0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ unit_test(options)
 unit_test(search)
 unit_test(query)
 unit_test(diagnostics)
+unit_test(management)
 target_link_libraries(test_unit_jsonsl jsonsl)
 
 integration_benchmark(get)

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -2184,7 +2184,6 @@ TEST_CASE("integration: query index management", "[integration]")
             REQUIRE(!wait_for_bucket_created(integration, bucket_name).ctx.ec);
             SECTION("core API")
             {
-                SKIP("XXX");
                 {
                     couchbase::core::operations::management::query_index_create_response resp;
                     bool operation_completed = test::utils::wait_until([&integration, &bucket_name, &resp]() {
@@ -2257,7 +2256,6 @@ TEST_CASE("integration: query index management", "[integration]")
     {
         SECTION("core API")
         {
-            SKIP("XXX");
             auto index_name = test::utils::uniq_id("index");
             {
                 couchbase::core::operations::management::query_index_create_response resp;
@@ -2265,7 +2263,7 @@ TEST_CASE("integration: query index management", "[integration]")
                     couchbase::core::operations::management::query_index_create_request req{};
                     req.bucket_name = integration.ctx.bucket;
                     req.index_name = index_name;
-                    req.fields = { "field", "field2 DESC", "`two words` DESC" };
+                    req.keys = { "field", "field2", "two words" };
                     resp = test::utils::execute(integration.cluster, req);
                     return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
                 });
@@ -2277,7 +2275,7 @@ TEST_CASE("integration: query index management", "[integration]")
                 couchbase::core::operations::management::query_index_create_request req{};
                 req.bucket_name = integration.ctx.bucket;
                 req.index_name = index_name;
-                req.fields = { "field" };
+                req.keys = { "field" };
                 auto resp = test::utils::execute(integration.cluster, req);
                 REQUIRE(resp.ctx.ec == couchbase::errc::common::index_exists);
             }
@@ -2286,7 +2284,7 @@ TEST_CASE("integration: query index management", "[integration]")
                 couchbase::core::operations::management::query_index_create_request req{};
                 req.bucket_name = integration.ctx.bucket;
                 req.index_name = index_name;
-                req.fields = { "field" };
+                req.keys = { "field" };
                 req.ignore_if_exists = true;
                 auto resp = test::utils::execute(integration.cluster, req);
                 REQUIRE_SUCCESS(resp.ctx.ec);
@@ -2304,8 +2302,8 @@ TEST_CASE("integration: query index management", "[integration]")
                 REQUIRE_FALSE(index->is_primary);
                 REQUIRE(index->index_key.size() == 3);
                 REQUIRE(index->index_key[0] == "`field`");
-                REQUIRE(index->index_key[1] == "`field2` DESC");
-                REQUIRE(index->index_key[2] == "`two words` DESC");
+                REQUIRE(index->index_key[1] == "`field2`");
+                REQUIRE(index->index_key[2] == "`two words`");
                 REQUIRE(index->bucket_name == integration.ctx.bucket);
                 REQUIRE(index->state == "online");
             }
@@ -2332,9 +2330,8 @@ TEST_CASE("integration: query index management", "[integration]")
             {
                 std::error_code ec;
                 bool operation_completed = test::utils::wait_until([&integration, &index_name, c, &ec]() {
-                    auto ctx = c.query_indexes()
-                                 .create_index(integration.ctx.bucket, index_name, { "field", "field2 DESC", "`two words` DESC" }, {})
-                                 .get();
+                    auto ctx =
+                      c.query_indexes().create_index(integration.ctx.bucket, index_name, { "field", "field2", "two words" }, {}).get();
                     ec = ctx.ec();
                     return ec != couchbase::errc::common::bucket_not_found;
                 });
@@ -2376,8 +2373,8 @@ TEST_CASE("integration: query index management", "[integration]")
                 REQUIRE_FALSE(index->is_primary);
                 REQUIRE(index->index_key.size() == 3);
                 REQUIRE(index->index_key[0] == "`field`");
-                REQUIRE(index->index_key[1] == "`field2` DESC");
-                REQUIRE(index->index_key[2] == "`two words` DESC");
+                REQUIRE(index->index_key[1] == "`field2`");
+                REQUIRE(index->index_key[2] == "`two words`");
                 REQUIRE(index->bucket_name == integration.ctx.bucket);
                 REQUIRE(index->state == "online");
             }
@@ -2463,7 +2460,7 @@ TEST_CASE("integration: query index management", "[integration]")
                     couchbase::core::operations::management::query_index_create_request req{};
                     req.bucket_name = integration.ctx.bucket;
                     req.index_name = index_name;
-                    req.fields = { "field" };
+                    req.keys = { "field" };
                     req.deferred = true;
                     resp = test::utils::execute(integration.cluster, req);
                     return resp.ctx.ec != couchbase::errc::common::bucket_not_found;
@@ -2768,7 +2765,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                     req.index_name = index_name;
                     req.scope_name = scope_name;
                     req.collection_name = collection_name;
-                    req.fields = { "field" };
+                    req.keys = { "field" };
                     resp = test::utils::execute(integration.cluster, req);
                     return resp.ctx.ec != couchbase::errc::common::bucket_not_found &&
                            resp.ctx.ec != couchbase::errc::common::scope_not_found;
@@ -2783,7 +2780,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 req.index_name = index_name;
                 req.scope_name = scope_name;
                 req.collection_name = collection_name;
-                req.fields = { "field" };
+                req.keys = { "field" };
                 auto resp = test::utils::execute(integration.cluster, req);
                 REQUIRE(resp.ctx.ec == couchbase::errc::common::index_exists);
             }
@@ -2794,7 +2791,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                 req.index_name = index_name;
                 req.scope_name = scope_name;
                 req.collection_name = collection_name;
-                req.fields = { "field" };
+                req.keys = { "field" };
                 req.ignore_if_exists = true;
                 auto resp = test::utils::execute(integration.cluster, req);
                 REQUIRE_SUCCESS(resp.ctx.ec);
@@ -2942,7 +2939,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
                     req.index_name = index_name;
                     req.scope_name = scope_name;
                     req.collection_name = collection_name;
-                    req.fields = { "field" };
+                    req.keys = { "field" };
                     req.deferred = true;
                     resp = test::utils::execute(integration.cluster, req);
                     return resp.ctx.ec != couchbase::errc::common::bucket_not_found &&

--- a/test/test_unit_management.cxx
+++ b/test/test_unit_management.cxx
@@ -1,0 +1,110 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include "core/cluster_options.hxx"
+#include "core/io/http_context.hxx"
+#include "core/io/http_message.hxx"
+#include "core/io/query_cache.hxx"
+#include "core/operations/management/query_index_create.hxx"
+#include "core/topology/configuration.hxx"
+
+#include <regex>
+#include <string>
+
+couchbase::core::http_context
+make_http_context()
+{
+    static couchbase::core::topology::configuration config{};
+    static couchbase::core::query_cache query_cache{};
+    static couchbase::core::cluster_options cluster_options{};
+    std::string hostname{};
+    std::uint16_t port{};
+    couchbase::core::http_context ctx{ config, cluster_options, query_cache, hostname, port };
+    return ctx;
+}
+
+TEST_CASE("unit: create query index key encoding", "[unit]")
+{
+    couchbase::core::io::http_request http_req;
+    couchbase::core::operations::management::query_index_create_request req{
+        "bucket_name", "scope_name", "collection_name", "test_index", {}, { "bucket_name", "scope_name" },
+    };
+    auto ctx = make_http_context();
+    std::regex r{ "CREATE INDEX (.+) ON .*\\((.*)\\) .* USING GSI.*" };
+
+    SECTION("single key")
+    {
+        req.keys = { "test_field" };
+        auto ec = req.encode_to(http_req, ctx);
+
+        REQUIRE_SUCCESS(ec);
+
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+
+        REQUIRE(body.is_object());
+        REQUIRE(body.get_object().at("statement").is_string());
+
+        auto statement = body.get_object().at("statement").get_string();
+        std::smatch match;
+
+        REQUIRE(std::regex_search(statement, match, r));
+        REQUIRE(match[1] == "`test_index`");
+        REQUIRE(match[2] == "`test_field`");
+    }
+
+    SECTION("multiple keys")
+    {
+        req.keys = { "field-1", "field-2", "field-3" };
+        auto ec = req.encode_to(http_req, ctx);
+
+        REQUIRE_SUCCESS(ec);
+
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+
+        REQUIRE(body.is_object());
+        REQUIRE(body.get_object().at("statement").is_string());
+
+        auto statement = body.get_object().at("statement").get_string();
+        std::smatch match;
+
+        REQUIRE(std::regex_search(statement, match, r));
+        REQUIRE(match[1] == "`test_index`");
+        REQUIRE(match[2] == "`field-1`, `field-2`, `field-3`");
+    }
+
+    SECTION("key already has backticks")
+    {
+        req.keys = { "field-1", "`field-2`", "`field-3`" };
+        auto ec = req.encode_to(http_req, ctx);
+
+        REQUIRE_SUCCESS(ec);
+
+        auto body = couchbase::core::utils::json::parse(http_req.body);
+
+        REQUIRE(body.is_object());
+        REQUIRE(body.get_object().at("statement").is_string());
+
+        auto statement = body.get_object().at("statement").get_string();
+        std::smatch match;
+
+        REQUIRE(std::regex_search(statement, match, r));
+        REQUIRE(match[1] == "`test_index`");
+        REQUIRE(match[2] == "`field-1`, `field-2`, `field-3`");
+    }
+}


### PR DESCRIPTION
## Motivation

Make the SDK consistent with the management RFC revision/clarification in couchbaselabs/sdk-rfcs#116

## Changes
* Rename `fields` parameter to `keys` in the Public API's `create_index()`
* Encode each index key provided to `create_index()` by surrounding them with backticks
* Add unit test for the encoding & update integration test to reflect these changes