### PR TITLE
Add to_raise getter to transaction_operation_failed

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -121,3 +121,8 @@
  * Support for couchbase::codec::raw_string_transcoder
  */
 #define COUCHBASE_CXX_CLIENT_HAS_RAW_STRING_TRANSCODER 1
+
+/**
+ * Transaction's transaction_operation_failed has a public getter for its final_error
+ */
+#define COUCHBASE_CXX_CLIENT_TRANSACTIONS_CAN_FETCH_TO_RAISE 1

--- a/core/transactions/internal/exceptions_internal.hxx
+++ b/core/transactions/internal/exceptions_internal.hxx
@@ -230,6 +230,11 @@ class transaction_operation_failed : public std::runtime_error
         return cause_;
     }
 
+    final_error to_raise() const
+    {
+        return to_raise_;
+    }
+
     void do_throw(const transaction_context& context) const
     {
         if (to_raise_ == FAILED_POST_COMMIT) {


### PR DESCRIPTION
Required for FIT performer exception validation