### PR TITLE
CXXCBC-452: detect new search capabilities

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -479,7 +479,7 @@ class collection_impl : public std::enable_shared_from_this<collection_impl>
           bucket_name_,
           [core = core_, r = std::move(request), h = std::move(handler)](std::error_code ec,
                                                                          const core::topology::configuration& config) mutable {
-              if (!config.supports_subdoc_read_replica()) {
+              if (!config.capabilities.supports_subdoc_read_replica()) {
                   ec = errc::common::feature_not_available;
               }
 
@@ -601,7 +601,7 @@ class collection_impl : public std::enable_shared_from_this<collection_impl>
           bucket_name_,
           [core = core_, r = std::move(request), h = std::move(handler)](std::error_code ec,
                                                                          const core::topology::configuration& config) mutable {
-              if (!config.supports_subdoc_read_replica()) {
+              if (!config.capabilities.supports_subdoc_read_replica()) {
                   ec = errc::common::feature_not_available;
               }
               if (r->specs().size() > 16) {

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -58,6 +58,12 @@ class http_session_manager
         meter_ = std::move(meter);
     }
 
+    auto configuration_capabilities() const -> configuration_capabilities
+    {
+        std::scoped_lock config_lock(config_mutex_);
+        return config_.capabilities;
+    }
+
     void update_config(topology::configuration config) override
     {
         std::scoped_lock config_lock(config_mutex_, sessions_mutex_);
@@ -387,7 +393,7 @@ class http_session_manager
     cluster_options options_{};
 
     topology::configuration config_{};
-    std::mutex config_mutex_{};
+    mutable std::mutex config_mutex_{};
     std::map<service_type, std::list<std::shared_ptr<http_session>>> busy_sessions_{};
     std::map<service_type, std::list<std::shared_ptr<http_session>>> idle_sessions_{};
     std::size_t next_index_{ 0 };

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -455,6 +455,16 @@ class mcbp_session_impl
                         case protocol::client_opcode::get_cluster_config: {
                             protocol::cmd_info info{ session_->connection_endpoints_.remote_address,
                                                      session_->connection_endpoints_.remote.port() };
+                            if (session_->origin_.options().dump_configuration) {
+                                std::string_view config_text{ reinterpret_cast<const char*>(msg.body.data()), msg.body.size() };
+                                CB_LOG_TRACE(
+                                  "{} configuration from get_cluster_config request (bootstrap, size={}, endpoint=\"{}:{}\"), {}",
+                                  session_->log_prefix_,
+                                  config_text.size(),
+                                  info.endpoint_address,
+                                  info.endpoint_port,
+                                  config_text);
+                            }
                             protocol::client_response<protocol::get_cluster_config_response_body> resp(std::move(msg), info);
                             if (resp.status() == key_value_status_code::success) {
                                 session_->update_configuration(resp.body().config());

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -69,7 +69,7 @@ struct lookup_in_all_replicas_request {
           id.bucket(),
           [core, id = id, timeout = timeout, specs = specs, parent_span = parent_span, h = std::forward<Handler>(handler)](
             std::error_code ec, const topology::configuration& config) mutable {
-              if (!config.supports_subdoc_read_replica()) {
+              if (!config.capabilities.supports_subdoc_read_replica()) {
                   ec = errc::common::feature_not_available;
               }
 

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -66,7 +66,7 @@ struct lookup_in_any_replica_request {
           id.bucket(),
           [core, id = id, timeout = timeout, specs = specs, parent_span = parent_span, h = std::forward<Handler>(handler)](
             std::error_code ec, const topology::configuration& config) mutable {
-              if (!config.supports_subdoc_read_replica()) {
+              if (!config.capabilities.supports_subdoc_read_replica()) {
                   ec = errc::common::feature_not_available;
               }
               if (specs.size() > 16) {

--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -47,7 +47,7 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
             }
         } else {
             body["statement"] = "PREPARE " + statement;
-            if (context.config.supports_enhanced_prepared_statements()) {
+            if (context.config.capabilities.supports_enhanced_prepared_statements()) {
                 body["auto_execute"] = true;
             } else {
                 extract_encoded_plan_ = true;
@@ -87,7 +87,7 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
             break;
     }
     if (use_replica.has_value()) {
-        if (context.config.supports_read_from_replica()) {
+        if (context.config.capabilities.supports_read_from_replica()) {
             if (use_replica.value()) {
                 body["use_replica"] = "on";
             } else {

--- a/core/operations/document_search.cxx
+++ b/core/operations/document_search.cxx
@@ -41,15 +41,15 @@ search_request::encode_to(search_request::encoded_request_type& encoded, http_co
 
     if (vector_search.has_value()) {
         body["knn"] = utils::json::parse(vector_search.value());
-    }
-    if (vector_query_combination.has_value()) {
-        switch (*vector_query_combination) {
-            case couchbase::core::vector_query_combination::combination_or:
-                body["knn_operator"] = "or";
-                break;
-            case couchbase::core::vector_query_combination::combination_and:
-                body["knn_operator"] = "and";
-                break;
+        if (vector_query_combination.has_value()) {
+            switch (*vector_query_combination) {
+                case couchbase::core::vector_query_combination::combination_or:
+                    body["knn_operator"] = "or";
+                    break;
+                case couchbase::core::vector_query_combination::combination_and:
+                    body["knn_operator"] = "and";
+                    break;
+            }
         }
     }
 

--- a/core/topology/capabilities.hxx
+++ b/core/topology/capabilities.hxx
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <set>
+
 namespace couchbase::core
 {
 enum class bucket_capability {
@@ -32,8 +34,15 @@ enum class bucket_capability {
     durable_write,
     tombstoned_user_xattrs,
     range_scan,
-    replica_read,
     non_deduped_history,
+    subdoc_replace_body_with_xattr,
+    subdoc_document_macro_support,
+    subdoc_revive_document,
+    dcp_ignore_purged_tombstones,
+    preserve_expiry,
+    query_system_collection,
+    mobile_system_collection,
+    subdoc_replica_read,
 };
 
 enum class cluster_capability {
@@ -43,5 +52,65 @@ enum class cluster_capability {
     n1ql_inline_functions,
     n1ql_enhanced_prepared_statements,
     n1ql_read_from_replica,
+    search_vector_search,
+    search_scoped_search_index,
 };
+
+struct configuration_capabilities {
+    std::set<bucket_capability> bucket{};
+    std::set<cluster_capability> cluster{};
+
+    [[nodiscard]] bool has_cluster_capability(cluster_capability cap) const
+    {
+        return cluster.find(cap) != cluster.end();
+    }
+
+    [[nodiscard]] bool has_bucket_capability(bucket_capability cap) const
+    {
+        return bucket.find(cap) != bucket.end();
+    }
+
+    [[nodiscard]] bool supports_enhanced_prepared_statements() const
+    {
+        return has_cluster_capability(cluster_capability::n1ql_enhanced_prepared_statements);
+    }
+
+    [[nodiscard]] bool supports_read_from_replica() const
+    {
+        return has_cluster_capability(cluster_capability::n1ql_read_from_replica);
+    }
+
+    [[nodiscard]] bool supports_range_scan() const
+    {
+        return has_bucket_capability(bucket_capability::range_scan);
+    }
+
+    [[nodiscard]] bool ephemeral() const
+    {
+        // Use bucket capabilities to identify if couchapi is missing (then its ephemeral). If its null then
+        // we are running an old version of couchbase which doesn't have ephemeral buckets at all.
+        return has_bucket_capability(bucket_capability::couchapi);
+    }
+
+    [[nodiscard]] bool supports_subdoc_read_replica() const
+    {
+        return has_bucket_capability(bucket_capability::subdoc_replica_read);
+    }
+
+    [[nodiscard]] bool supports_non_deduped_history() const
+    {
+        return has_bucket_capability(bucket_capability::non_deduped_history);
+    }
+
+    [[nodiscard]] bool supports_scoped_search_indexes() const
+    {
+        return has_cluster_capability(cluster_capability::search_scoped_search_index);
+    }
+
+    [[nodiscard]] bool supports_vector_search() const
+    {
+        return has_cluster_capability(cluster_capability::search_vector_search);
+    }
+};
+
 } // namespace couchbase::core

--- a/core/topology/capabilities_fmt.hxx
+++ b/core/topology/capabilities_fmt.hxx
@@ -70,11 +70,32 @@ struct fmt::formatter<couchbase::core::bucket_capability> {
             case couchbase::core::bucket_capability::range_scan:
                 name = "range_scan";
                 break;
-            case couchbase::core::bucket_capability::replica_read:
-                name = "replica_read";
+            case couchbase::core::bucket_capability::subdoc_replica_read:
+                name = "subdoc_replica_read";
                 break;
             case couchbase::core::bucket_capability::non_deduped_history:
                 name = "non_deduped_history";
+                break;
+            case couchbase::core::bucket_capability::subdoc_replace_body_with_xattr:
+                name = "subdoc_replace_body_with_xattr";
+                break;
+            case couchbase::core::bucket_capability::subdoc_document_macro_support:
+                name = "subdoc_document_macro_support";
+                break;
+            case couchbase::core::bucket_capability::subdoc_revive_document:
+                name = "subdoc_revive_document";
+                break;
+            case couchbase::core::bucket_capability::dcp_ignore_purged_tombstones:
+                name = "dcp_ignore_purged_tombstones";
+                break;
+            case couchbase::core::bucket_capability::preserve_expiry:
+                name = "preserve_expiry";
+                break;
+            case couchbase::core::bucket_capability::query_system_collection:
+                name = "query_system_collection";
+                break;
+            case couchbase::core::bucket_capability::mobile_system_collection:
+                name = "mobile_system_collection";
                 break;
         }
         return format_to(ctx.out(), "{}", name);
@@ -111,6 +132,13 @@ struct fmt::formatter<couchbase::core::cluster_capability> {
                 break;
             case couchbase::core::cluster_capability::n1ql_read_from_replica:
                 name = "n1ql_read_from_replica";
+                break;
+            case couchbase::core::cluster_capability::search_vector_search:
+                name = "search_vector_search";
+                break;
+            case couchbase::core::cluster_capability::search_scoped_search_index:
+                name = "search_scoped_search_index";
+                break;
         }
         return format_to(ctx.out(), "{}", name);
     }

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -89,8 +89,7 @@ struct configuration {
     std::optional<std::string> bucket{};
     std::optional<vbucket_map> vbmap{};
     std::optional<std::uint64_t> collections_manifest_uid{};
-    std::set<bucket_capability> bucket_capabilities{};
-    std::set<cluster_capability> cluster_capabilities{};
+    configuration_capabilities capabilities{};
     node_locator_type node_locator{ node_locator_type::unknown };
     bool force{ false };
 
@@ -110,38 +109,6 @@ struct configuration {
     }
 
     [[nodiscard]] std::string rev_str() const;
-
-    [[nodiscard]] bool supports_enhanced_prepared_statements() const
-    {
-        return cluster_capabilities.find(cluster_capability::n1ql_enhanced_prepared_statements) != cluster_capabilities.end();
-    }
-
-    [[nodiscard]] bool supports_read_from_replica() const
-    {
-        return cluster_capabilities.find(cluster_capability::n1ql_read_from_replica) != cluster_capabilities.end();
-    }
-
-    [[nodiscard]] bool supports_range_scan() const
-    {
-        return bucket_capabilities.find(bucket_capability::range_scan) != bucket_capabilities.end();
-    }
-
-    [[nodiscard]] bool ephemeral() const
-    {
-        // Use bucket capabilities to identify if couchapi is missing (then its ephemeral). If its null then
-        // we are running an old version of couchbase which doesn't have ephemeral buckets at all.
-        return bucket_capabilities.count(couchbase::core::bucket_capability::couchapi) == 0;
-    }
-
-    [[nodiscard]] bool supports_subdoc_read_replica() const
-    {
-        return bucket_capabilities.find(bucket_capability::replica_read) != bucket_capabilities.end();
-    }
-
-    [[nodiscard]] bool supports_non_deduped_history() const
-    {
-        return bucket_capabilities.find(bucket_capability::non_deduped_history) != bucket_capabilities.end();
-    }
 
     [[nodiscard]] std::size_t index_for_this_node() const;
     [[nodiscard]] bool has_node(const std::string& network,

--- a/core/topology/configuration_fmt.hxx
+++ b/core/topology/configuration_fmt.hxx
@@ -160,7 +160,7 @@ struct fmt::formatter<couchbase::core::topology::configuration> {
                          config.vbmap.has_value() ? fmt::format(", partitions={}", config.vbmap->size()) : "",
                          config.nodes.size(),
                          couchbase::core::utils::join_strings_fmt(config.nodes, ", "),
-                         couchbase::core::utils::join_strings_fmt(config.bucket_capabilities, ", "),
-                         couchbase::core::utils::join_strings_fmt(config.cluster_capabilities, ", "));
+                         couchbase::core::utils::join_strings_fmt(config.capabilities.bucket, ", "),
+                         couchbase::core::utils::join_strings_fmt(config.capabilities.cluster, ", "));
     }
 };

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -213,33 +213,47 @@ struct traits<couchbase::core::topology::configuration> {
             for (const auto& entry : m->get_array()) {
                 const auto& name = entry.get_string();
                 if (name == "couchapi") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::couchapi);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::couchapi);
                 } else if (name == "collections") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::collections);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::collections);
                 } else if (name == "durableWrite") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::durable_write);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::durable_write);
                 } else if (name == "tombstonedUserXAttrs") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::tombstoned_user_xattrs);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::tombstoned_user_xattrs);
                 } else if (name == "dcp") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::dcp);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::dcp);
                 } else if (name == "cbhello") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::cbhello);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::cbhello);
                 } else if (name == "touch") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::touch);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::touch);
                 } else if (name == "cccp") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::cccp);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::cccp);
                 } else if (name == "xdcrCheckpointing") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::xdcr_checkpointing);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::xdcr_checkpointing);
                 } else if (name == "nodesExt") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::nodes_ext);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::nodes_ext);
                 } else if (name == "xattr") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::xattr);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::xattr);
                 } else if (name == "rangeScan") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::range_scan);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::range_scan);
                 } else if (name == "subdoc.ReplicaRead") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::replica_read);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::subdoc_replica_read);
                 } else if (name == "nonDedupedHistory") {
-                    result.bucket_capabilities.insert(couchbase::core::bucket_capability::non_deduped_history);
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::non_deduped_history);
+                } else if (name == "subdoc.ReplaceBodyWithXattr") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::subdoc_replace_body_with_xattr);
+                } else if (name == "subdoc.DocumentMacroSupport") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::subdoc_document_macro_support);
+                } else if (name == "subdoc.ReviveDocument") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::subdoc_revive_document);
+                } else if (name == "dcp.IgnorePurgedTombstones") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::dcp_ignore_purged_tombstones);
+                } else if (name == "preserve_expiry") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::preserve_expiry);
+                } else if (name == "querySystemCollection") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::query_system_collection);
+                } else if (name == "mobileSystemCollection") {
+                    result.capabilities.bucket.insert(couchbase::core::bucket_capability::mobile_system_collection);
                 }
             }
         }
@@ -247,17 +261,26 @@ struct traits<couchbase::core::topology::configuration> {
             if (const auto nc = m->find("n1ql"); nc != nullptr && nc->is_array()) {
                 for (const auto& entry : nc->get_array()) {
                     if (const auto& name = entry.get_string(); name == "costBasedOptimizer") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_cost_based_optimizer);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_cost_based_optimizer);
                     } else if (name == "indexAdvisor") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_index_advisor);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_index_advisor);
                     } else if (name == "javaScriptFunctions") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_javascript_functions);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_javascript_functions);
                     } else if (name == "inlineFunctions") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_inline_functions);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_inline_functions);
                     } else if (name == "enhancedPreparedStatements") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_enhanced_prepared_statements);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_enhanced_prepared_statements);
                     } else if (name == "readFromReplica") {
-                        result.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
+                    }
+                }
+            }
+            if (const auto sc = m->find("search"); sc != nullptr && sc->is_array()) {
+                for (const auto& entry : sc->get_array()) {
+                    if (const auto& name = entry.get_string(); name == "vectorSearch") {
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::search_vector_search);
+                    } else if (name == "scopedSearchIndex") {
+                        result.capabilities.cluster.insert(couchbase::core::cluster_capability::search_scoped_search_index);
                     }
                 }
             }

--- a/test/test_unit_query.cxx
+++ b/test/test_unit_query.cxx
@@ -35,7 +35,7 @@ make_http_context(couchbase::core::topology::configuration& config)
 TEST_CASE("unit: query with read from replica", "[unit]")
 {
     couchbase::core::topology::configuration config{};
-    config.cluster_capabilities.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
+    config.capabilities.cluster.insert(couchbase::core::cluster_capability::n1ql_read_from_replica);
     auto ctx = make_http_context(config);
 
     SECTION("use_replica true")


### PR DESCRIPTION
Fail fast if the cluster does not support new search features.

The patch also updates list of known capabilities and provides utilities to help with asserting their presence in more general way.