### PR TITLE
CXXCBC-456: handle 0x0d (config_only) status from KV

### DIFF
--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -177,6 +177,7 @@ class bucket
         });
     }
 
+    void fetch_config();
     void update_config(topology::configuration config) override;
     void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler);
     void with_configuration(utils::movable_function<void(std::error_code, topology::configuration)>&& handler);

--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -202,6 +202,8 @@ map_status_code(protocol::client_opcode opcode, std::uint16_t status)
 
         case key_value_status_code::unknown:
             break;
+        case key_value_status_code::config_only:
+            break;
     }
     return errc::network::protocol_error;
 }

--- a/core/protocol/status.hxx
+++ b/core/protocol/status.hxx
@@ -103,6 +103,7 @@ is_valid_status(std::uint16_t code)
         case key_value_status_code::range_scan_more:
         case key_value_status_code::range_scan_complete:
         case key_value_status_code::range_scan_vb_uuid_not_equal:
+        case key_value_status_code::config_only:
             return true;
         case key_value_status_code::unknown:
             return false;

--- a/couchbase/fmt/key_value_status_code.hxx
+++ b/couchbase/fmt/key_value_status_code.hxx
@@ -257,7 +257,9 @@ struct fmt::formatter<couchbase::key_value_status_code> {
             case key_value_status_code::range_scan_vb_uuid_not_equal:
                 name = "range_scan_vb_uuid_not_equal (0xa8)";
                 break;
-
+            case key_value_status_code::config_only:
+                name = "config_only (0x0d)";
+                break;
             case key_value_status_code::unknown:
                 name = "unknown (0xffff)";
                 break;

--- a/couchbase/key_value_status_code.hxx
+++ b/couchbase/key_value_status_code.hxx
@@ -35,6 +35,7 @@ enum class key_value_status_code : std::uint16_t {
     opaque_no_match = 0x0b,
     locked = 0x09,
     not_locked = 0x0e,
+    config_only = 0x0d,
     auth_stale = 0x1f,
     auth_error = 0x20,
     auth_continue = 0x21,


### PR DESCRIPTION
On 0x0d (EConfigOnly) status code SDK will request new configuration, and send current operation to retry orchestrator.