### PR TITLE
CXXCBC-336: Do not fallback to 8.8.8.8, if we cannot obtain system DNS server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /cmake-build-report.tar.gz
 /.idea/vcs.xml
 /.idea/workspace.xml
+/.idea/editor.xml
 /.idea/sonarlint
 /.cache
 /.vs

--- a/core/io/dns_client.cxx
+++ b/core/io/dns_client.cxx
@@ -285,6 +285,10 @@ dns_client::query_srv(const std::string& name,
                       const dns_config& config,
                       utils::movable_function<void(dns_srv_response&&)>&& handler)
 {
+    if (config.nameserver().empty()) {
+        return handler({ {} });
+    }
+
     std::error_code ec;
     auto address = asio::ip::make_address(config.nameserver(), ec);
     if (ec) {

--- a/core/io/dns_config.hxx
+++ b/core/io/dns_config.hxx
@@ -40,7 +40,7 @@ class dns_config
     [[nodiscard]] std::chrono::milliseconds timeout() const;
 
   private:
-    std::string nameserver_{ default_nameserver };
+    std::string nameserver_{};
     std::uint16_t port_{ default_port };
     std::chrono::milliseconds timeout_{ timeout_defaults::dns_srv_timeout };
 };


### PR DESCRIPTION
Avoid assuming Google DNS and rather report DNS-SRV lookup failure. The details still logged and user still can specify their DNS server in options.