### PR TITLE
CXXCBC-448: Expose hooks for fork() scenarious

### DIFF
--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -234,6 +234,13 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
                              });
     }
 
+    void notify_fork(fork_event event)
+    {
+        if (transactions_) {
+            transactions_->notify_fork(event);
+        }
+    }
+
     void close(core::utils::movable_function<void()> handler)
     {
         if (transactions_) {
@@ -410,6 +417,15 @@ cluster::connect(asio::io_context& io,
             return handler(cluster, ec);
         });
     });
+}
+
+auto
+cluster::notify_fork(fork_event event) -> void
+{
+    if (!impl_) {
+        return;
+    }
+    return impl_->notify_fork(event);
 }
 
 auto

--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -18,9 +18,11 @@
 
 #include <couchbase/transactions.hxx>
 
-#include "couchbase/transactions/transaction_options.hxx"
-#include "couchbase/transactions/transaction_result.hxx"
-#include "couchbase/transactions/transactions_config.hxx"
+#include <couchbase/fork_event.hxx>
+#include <couchbase/transactions/transaction_options.hxx>
+#include <couchbase/transactions/transaction_result.hxx>
+#include <couchbase/transactions/transactions_config.hxx>
+
 #include "transactions/async_attempt_context.hxx"
 #include "transactions/attempt_context.hxx"
 #include "transactions/exceptions.hxx"
@@ -221,6 +223,8 @@ class transactions : public couchbase::transactions::transactions
     {
         ctx.rollback();
     }
+
+    void notify_fork(fork_event event);
 
     /**
      * @brief Shut down the transactions object

--- a/core/transactions/internal/transactions_cleanup.hxx
+++ b/core/transactions/internal/transactions_cleanup.hxx
@@ -127,6 +127,8 @@ class transactions_cleanup
     const atr_cleanup_stats force_cleanup_atr(const core::document_id& atr_id, std::vector<transactions_cleanup_attempt>& results);
     const client_record_details get_active_clients(const couchbase::transactions::transaction_keyspace& keyspace, const std::string& uuid);
     void remove_client_record_from_all_buckets(const std::string& uuid);
+    void start();
+    void stop();
     void close();
 
   private:

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -203,6 +203,16 @@ transactions::run(async_logic&& code, txn_complete_callback&& cb)
 }
 
 void
+transactions::notify_fork(fork_event event)
+{
+    if (event == fork_event::prepare) {
+        cleanup_->stop();
+    } else {
+        cleanup_->start();
+    }
+}
+
+void
 transactions::close()
 {
     CB_TXN_LOG_DEBUG("closing transactions");

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -23,6 +23,7 @@
 #include <couchbase/bucket_manager.hxx>
 #include <couchbase/cluster_options.hxx>
 #include <couchbase/diagnostics_options.hxx>
+#include <couchbase/fork_event.hxx>
 #include <couchbase/ping_options.hxx>
 #include <couchbase/query_index_manager.hxx>
 #include <couchbase/query_options.hxx>
@@ -94,6 +95,8 @@ class cluster
     cluster(cluster&& other) = default;
     auto operator=(const cluster& other) -> cluster& = default;
     auto operator=(cluster&& other) -> cluster& = default;
+
+    void notify_fork(fork_event event);
 
     void close() const;
 

--- a/couchbase/fork_event.hxx
+++ b/couchbase/fork_event.hxx
@@ -1,0 +1,39 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+namespace couchbase
+{
+enum class fork_event {
+    /**
+     * Notify the cluster that the process is about to fork.
+     */
+    prepare,
+
+    /**
+     * Notify the context that the process has forked and is the parent.
+     */
+    parent,
+
+    /**
+     * Notify the context that the process has forked and is the child.
+     */
+    child,
+};
+
+} // namespace couchbase

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -782,6 +782,9 @@ TEST_CASE("example: using fork() for scaling", "[integration]")
 {
     {
         test::utils::integration_test_guard integration;
+        if (integration.cluster_version().is_capella()) {
+            SKIP("Capella does not allow to use REST API to load sample buckets");
+        }
         if (!integration.cluster_version().supports_collections()) {
             SKIP("cluster does not support collections");
         }

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -780,6 +780,13 @@ row: {"airline":{"callsign":"MILE-AIR","country":"United States","iata":"Q5","ic
 
 TEST_CASE("example: using fork() for scaling", "[integration]")
 {
+    {
+        test::utils::integration_test_guard integration;
+        if (!integration.cluster_version().supports_collections()) {
+            SKIP("cluster does not support collections");
+        }
+    }
+
     setbuf(stdout, nullptr); // disable buffering for output
     test::utils::init_logger();
 


### PR DESCRIPTION
In order to gracefully survive fork() syscall, the library should be able to move itself into stable and predictable state. In particular ASIO should not have any pending work, and all IO thread should be stopped. After the fork() the parent process retains control over all file descriptors, but the child have to reconnect them (ASIO does it in its hooks), and also the SDK should restart all the IO workers.

At the moment, the only worker thread that the library controls is the one that in charge of the transactions cleanup, but later once the public API will hide ASIO context, it will become in charge of the restarting IO threads.

In case of the wrappers, that use core API directly, they must be able to stop all IO threads before fork(), wait for work completion, then perform the syscall and restart IO threads and contexts in both child and parent later. See example in test/test_integration_examples.cxx