### PR TITLE
CXXCBC-458: Transactions hooks should be asynchronous

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -126,3 +126,8 @@
  * Transaction's transaction_operation_failed has a public getter for its final_error
  */
 #define COUCHBASE_CXX_CLIENT_TRANSACTIONS_CAN_FETCH_TO_RAISE 1
+
+/**
+ * Hooks in the transactions core are asynchronous (they have a callback parameter)
+ */
+#define COUCHBASE_CXX_CLIENT_TRANSACTIONS_CORE_ASYNC_HOOKS

--- a/core/transactions/attempt_context_testing_hooks.cxx
+++ b/core/transactions/attempt_context_testing_hooks.cxx
@@ -15,79 +15,80 @@
  */
 
 #include "attempt_context_testing_hooks.hxx"
+#include "core/utils/movable_function.hxx"
 
 namespace couchbase::core::transactions
 {
 namespace
 {
-inline std::optional<error_class>
-noop_1(attempt_context*)
+inline void
+noop1(attempt_context*, utils::movable_function<void(std::optional<error_class>)>&& handler)
 {
-    return {};
+    return handler({});
 }
 
-inline std::optional<error_class>
-noop_2(attempt_context*, const std::string&)
+inline void
+noop2(attempt_context*, const std::string&, utils::movable_function<void(std::optional<error_class>)>&& handler)
 {
-    return {};
+    return handler({});
 }
 
 inline std::optional<const std::string>
-noop_3(attempt_context*)
+noop3(attempt_context*)
 {
     return {};
 }
 
 inline bool
-noop_4(attempt_context*, const std::string&, std::optional<const std::string>)
+noop4(attempt_context*, const std::string&, std::optional<const std::string>)
 {
     return false;
 }
 } // namespace
 
 attempt_context_testing_hooks::attempt_context_testing_hooks()
-  : before_atr_commit{ noop_1 }
-  , before_atr_commit_ambiguity_resolution{ noop_1 }
-  , after_atr_commit{ noop_1 }
-  , before_doc_committed{ noop_2 }
-  , before_removing_doc_during_staged_insert{ noop_2 }
-  , before_rollback_delete_inserted{ noop_2 }
-  , after_doc_committed_before_saving_cas{ noop_2 }
-  , after_doc_committed{ noop_2 }
-  , before_staged_insert{ noop_2 }
-  , before_staged_remove{ noop_2 }
-  , before_staged_replace{ noop_2 }
-  , before_doc_removed{ noop_2 }
-  , before_doc_rolled_back{ noop_2 }
-  , after_doc_removed_pre_retry{ noop_2 }
-  , after_doc_removed_post_retry{ noop_2 }
-  , after_get_complete{ noop_2 }
-  , after_staged_replace_complete_before_cas_saved{ noop_2 }
-  , after_staged_replace_complete{ noop_2 }
-  , after_staged_remove_complete{ noop_2 }
-  , after_staged_insert_complete{ noop_2 }
-  , after_rollback_replace_or_remove{ noop_2 }
-  , after_rollback_delete_inserted{ noop_2 }
-  , before_check_atr_entry_for_blocking_doc{ noop_2 }
-  , before_doc_get{ noop_2 }
-  , before_get_doc_in_exists_during_staged_insert{ noop_2 }
-  , before_query{ noop_2 }
-  , after_query{ noop_2 }
-  , before_remove_staged_insert{ noop_2 }
-  , after_remove_staged_insert{ noop_2 }
-  , after_docs_committed{ noop_1 }
-  , after_docs_removed{ noop_1 }
-  , after_atr_pending{ noop_1 }
-  , before_atr_pending{ noop_1 }
-  , before_atr_complete{ noop_1 }
-  , before_atr_rolled_back{ noop_1 }
-  , after_atr_complete{ noop_1 }
-  , before_get_atr_for_abort{ noop_1 }
-  , before_atr_aborted{ noop_1 }
-  , after_atr_aborted{ noop_1 }
-  , after_atr_rolled_back{ noop_1 }
-  , random_atr_id_for_vbucket{ noop_3 }
-  , has_expired_client_side{ noop_4 }
+  : before_atr_commit{ noop1 }
+  , before_atr_commit_ambiguity_resolution{ noop1 }
+  , after_atr_commit{ noop1 }
+  , before_doc_committed{ noop2 }
+  , before_removing_doc_during_staged_insert{ noop2 }
+  , before_rollback_delete_inserted{ noop2 }
+  , after_doc_committed_before_saving_cas{ noop2 }
+  , after_doc_committed{ noop2 }
+  , before_staged_insert{ noop2 }
+  , before_staged_remove{ noop2 }
+  , before_staged_replace{ noop2 }
+  , before_doc_removed{ noop2 }
+  , before_doc_rolled_back{ noop2 }
+  , after_doc_removed_pre_retry{ noop2 }
+  , after_doc_removed_post_retry{ noop2 }
+  , after_get_complete{ noop2 }
+  , after_staged_replace_complete_before_cas_saved{ noop2 }
+  , after_staged_replace_complete{ noop2 }
+  , after_staged_remove_complete{ noop2 }
+  , after_staged_insert_complete{ noop2 }
+  , after_rollback_replace_or_remove{ noop2 }
+  , after_rollback_delete_inserted{ noop2 }
+  , before_check_atr_entry_for_blocking_doc{ noop2 }
+  , before_doc_get{ noop2 }
+  , before_get_doc_in_exists_during_staged_insert{ noop2 }
+  , before_query{ noop2 }
+  , after_query{ noop2 }
+  , before_remove_staged_insert{ noop2 }
+  , after_remove_staged_insert{ noop2 }
+  , after_docs_committed{ noop1 }
+  , after_docs_removed{ noop1 }
+  , after_atr_pending{ noop1 }
+  , before_atr_pending{ noop1 }
+  , before_atr_complete{ noop1 }
+  , before_atr_rolled_back{ noop1 }
+  , after_atr_complete{ noop1 }
+  , before_get_atr_for_abort{ noop1 }
+  , before_atr_aborted{ noop1 }
+  , after_atr_aborted{ noop1 }
+  , after_atr_rolled_back{ noop1 }
+  , random_atr_id_for_vbucket{ noop3 }
+  , has_expired_client_side{ noop4 }
 {
 }
 } // namespace couchbase::core::transactions

--- a/core/transactions/attempt_context_testing_hooks.hxx
+++ b/core/transactions/attempt_context_testing_hooks.hxx
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "core/transactions/error_class.hxx"
+#include "core/utils/movable_function.hxx"
 
 #include <functional>
 #include <optional>
@@ -25,8 +26,9 @@ namespace couchbase::core::transactions
 {
 class attempt_context;
 
-using error_func1 = std::function<std::optional<error_class>(attempt_context*)>;
-using error_func2 = std::function<std::optional<error_class>(attempt_context*, const std::string&)>;
+using error_func1 = std::function<void(attempt_context*, core::utils::movable_function<void(std::optional<error_class>)>&&)>;
+using error_func2 =
+  std::function<void(attempt_context*, const std::string&, core::utils::movable_function<void(std::optional<error_class>)>&&)>;
 
 static const std::string STAGE_ROLLBACK = "rollback";
 static const std::string STAGE_GET = "get";

--- a/core/transactions/cleanup_testing_hooks.cxx
+++ b/core/transactions/cleanup_testing_hooks.cxx
@@ -20,16 +20,16 @@ namespace couchbase::core::transactions
 {
 namespace
 {
-inline std::optional<couchbase::core::transactions::error_class>
-noop1(const std::string&)
+inline void
+noop1(const std::string&, utils::movable_function<void(std::optional<error_class>)>&& handler)
 {
-    return {};
+    return handler({});
 }
 
-inline std::optional<couchbase::core::transactions::error_class>
-noop2()
+inline void
+noop2(utils::movable_function<void(std::optional<error_class>)>&& handler)
 {
-    return {};
+    return handler({});
 }
 } // namespace
 

--- a/core/transactions/cleanup_testing_hooks.hxx
+++ b/core/transactions/cleanup_testing_hooks.hxx
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "core/transactions/error_class.hxx"
+#include "core/utils/movable_function.hxx"
 
 #include <functional>
 #include <optional>
@@ -23,8 +24,8 @@
 
 namespace couchbase::core::transactions
 {
-using error_func3 = std::function<std::optional<error_class>(const std::string&)>;
-using error_func4 = std::function<std::optional<error_class>(void)>;
+using error_func3 = std::function<void(const std::string&, core::utils::movable_function<void(std::optional<error_class>)>&&)>;
+using error_func4 = std::function<void(core::utils::movable_function<void(std::optional<error_class>)>&&)>;
 
 /**
  * Hooks purely for testing purposes.  If you're an end-user looking at these for any reason, then please contact us first

--- a/core/transactions/internal/utils.hxx
+++ b/core/transactions/internal/utils.hxx
@@ -26,6 +26,7 @@
 #include <functional>
 #include <future>
 #include <limits>
+#include <optional>
 #include <random>
 #include <string>
 #include <thread>
@@ -78,6 +79,9 @@ validate_operation_result(result& res, bool ignore_subdoc_errors = true);
 
 result
 wrap_operation_future(std::future<result>& fut, bool ignore_subdoc_errors = true);
+
+std::optional<error_class>
+wait_for_hook(std::function<void(utils::movable_function<void(std::optional<error_class>)>)> hook);
 
 inline void
 wrap_collection_call(result& res, std::function<void(result&)> call);
@@ -326,7 +330,7 @@ struct async_exp_delay {
 
     void operator()(utils::movable_function<void(std::exception_ptr)> callback) const
     {
-        if (retries >= max_retries) {
+        if (retries++ >= max_retries) {
             callback(std::make_exception_ptr(retry_operation_retries_exhausted("retries exhausted")));
             return;
         }

--- a/core/transactions/staged_mutation.hxx
+++ b/core/transactions/staged_mutation.hxx
@@ -129,51 +129,62 @@ class staged_mutation_queue
     std::mutex mutex_;
     std::vector<staged_mutation> queue_;
 
-    static void validate_rollback_remove_or_replace_result(attempt_context_impl* ctx, result& res, const staged_mutation& item);
-    static void validate_rollback_insert_result(attempt_context_impl* ctx, result& res, const staged_mutation& item);
-    static void validate_commit_doc_result(attempt_context_impl* ctx, result& res, staged_mutation& item);
-    static void validate_remove_doc_result(attempt_context_impl* ctx, result& res, const staged_mutation& item);
+    using client_error_handler = utils::movable_function<void(const std::optional<client_error>&)>;
+
+    static void validate_rollback_remove_or_replace_result(attempt_context_impl* ctx,
+                                                           result& res,
+                                                           const staged_mutation& item,
+                                                           client_error_handler&& handler);
+    static void validate_rollback_insert_result(attempt_context_impl* ctx,
+                                                result& res,
+                                                const staged_mutation& item,
+                                                client_error_handler&& handler);
+    static void validate_commit_doc_result(attempt_context_impl* ctx, result& res, staged_mutation& item, client_error_handler&& handler);
+    static void validate_remove_doc_result(attempt_context_impl* ctx,
+                                           result& res,
+                                           const staged_mutation& item,
+                                           client_error_handler&& handler);
 
     void handle_commit_doc_error(const client_error& e,
                                  attempt_context_impl* ctx,
                                  staged_mutation& item,
-                                 async_constant_delay delay,
+                                 async_constant_delay& delay,
                                  bool ambiguity_resolution_mode,
                                  bool cas_zero_mode,
                                  utils::movable_function<void(std::exception_ptr)> callback);
     void handle_remove_doc_error(const client_error& e,
                                  attempt_context_impl* ctx,
                                  const staged_mutation& item,
-                                 async_constant_delay delay,
+                                 async_constant_delay& delay,
                                  utils::movable_function<void(std::exception_ptr)> callback);
     void handle_rollback_insert_error(const client_error& e,
                                       attempt_context_impl* ctx,
                                       const staged_mutation& item,
-                                      async_exp_delay delay,
+                                      async_exp_delay& delay,
                                       utils::movable_function<void(std::exception_ptr)> callback);
     void handle_rollback_remove_or_replace_error(const client_error& e,
                                                  attempt_context_impl* ctx,
                                                  const staged_mutation& item,
-                                                 async_exp_delay delay,
+                                                 async_exp_delay& delay,
                                                  utils::movable_function<void(std::exception_ptr)> callback);
 
     void commit_doc(attempt_context_impl* ctx,
                     staged_mutation& item,
-                    async_constant_delay delay,
+                    async_constant_delay& delay,
                     utils::movable_function<void(std::exception_ptr)> callback,
                     bool ambiguity_resolution_mode = false,
                     bool cas_zero_mode = false);
     void remove_doc(attempt_context_impl* ctx,
                     const staged_mutation& item,
-                    async_constant_delay delay,
+                    async_constant_delay& delay,
                     utils::movable_function<void(std::exception_ptr)> callback);
     void rollback_insert(attempt_context_impl* ctx,
                          const staged_mutation& item,
-                         async_exp_delay delay,
+                         async_exp_delay& delay,
                          utils::movable_function<void(std::exception_ptr)> callback);
     void rollback_remove_or_replace(attempt_context_impl* ctx,
                                     const staged_mutation& item,
-                                    async_exp_delay delay,
+                                    async_exp_delay& delay,
                                     utils::movable_function<void(std::exception_ptr)> callback);
 
   public:

--- a/core/transactions/utils.cxx
+++ b/core/transactions/utils.cxx
@@ -92,6 +92,15 @@ wrap_operation_future(std::future<result>& fut, bool ignore_subdoc_errors)
     return res;
 }
 
+std::optional<error_class>
+wait_for_hook(std::function<void(utils::movable_function<void(std::optional<error_class>)>)> hook)
+{
+    auto hook_barrier = std::make_shared<std::promise<std::optional<error_class>>>();
+    auto hook_future = hook_barrier->get_future();
+    hook([hook_barrier](std::optional<error_class> ec) mutable { return hook_barrier->set_value(ec); });
+    return hook_future.get();
+}
+
 template<>
 bool
 is_error(const core::operations::mutate_in_response& resp)


### PR DESCRIPTION
## Motivation

Transactions hooks are sometimes required to perform KV operations. They should be async to avoid blocking in IO threads that are calling the hooks.

## Changes

Add a callback to all hooks so they can be executed asynchronously and called from callbacks of KV operations without blocking the IO thread.