### PR TITLE
CXXCBC-480 LookupInAnyReplica TooManySpecs Failures

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -621,9 +621,6 @@ class collection_impl : public std::enable_shared_from_this<collection_impl>
                     if (!config.capabilities.supports_subdoc_read_replica()) {
                         ec = errc::common::feature_not_available;
                     }
-                    if (r->specs().size() > 16) {
-                        ec = errc::common::invalid_argument;
-                    }
                     if (ec) {
                         return h(core::make_subdocument_error_context(make_key_value_error_context(ec, r->id()), ec, {}, {}, false),
                                  lookup_in_replica_result{});

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -79,9 +79,6 @@ struct lookup_in_any_replica_request {
                                     if (!config.capabilities.supports_subdoc_read_replica()) {
                                         ec = errc::common::feature_not_available;
                                     }
-                                    if (specs.size() > 16) {
-                                        ec = errc::common::invalid_argument;
-                                    }
 
                                     if (ec) {
                                         std::optional<std::string> first_error_path{};

--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -1548,7 +1548,7 @@ TEST_CASE("integration: subdoc any replica reads", "[integration]")
         req.specs = specs.specs();
 
         auto resp = test::utils::execute(integration.cluster, req);
-        REQUIRE(resp.ctx.ec() == couchbase::errc::common::invalid_argument);
+        REQUIRE(resp.ctx.ec() == couchbase::errc::key_value::document_irretrievable);
         REQUIRE(resp.fields.empty());
     }
 
@@ -1588,7 +1588,7 @@ TEST_CASE("integration: subdoc any replica reads", "[integration]")
                 specs.push_back(couchbase::lookup_in_specs::get("dictkey"));
             }
             auto [ctx, result] = collection.lookup_in_any_replica(key, specs).get();
-            REQUIRE(ctx.ec() == couchbase::errc::common::invalid_argument);
+            REQUIRE(ctx.ec() == couchbase::errc::key_value::document_irretrievable);
             REQUIRE(result.cas().empty());
         }
 


### PR DESCRIPTION
Per the RFC, LookupInAnyReplica should only ever return DocumentIrretrievable & we shouldn't be enforcing the spec count on the client-side