### PR TITLE
CXXCBC-481: Fix potential crash when parsing search result hits

### DIFF
--- a/core/operations/document_search.hxx
+++ b/core/operations/document_search.hxx
@@ -155,6 +155,11 @@ struct search_request {
     std::optional<std::function<utils::json::stream_control(std::string)>> row_callback{};
     std::optional<std::string> client_context_id{};
     std::optional<std::chrono::milliseconds> timeout{};
+    /**
+     * UNCOMMITTED: If set to true, will log the request to and/or the response from the search service.
+     */
+    std::optional<bool> log_request{ false };
+    std::optional<bool> log_response{ false };
 
     [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
 

--- a/test/utils/wait_until.cxx
+++ b/test/utils/wait_until.cxx
@@ -159,7 +159,7 @@ wait_for_search_pindexes_ready(const couchbase::core::cluster& cluster, const st
 bool
 wait_until_indexed(const couchbase::core::cluster& cluster, const std::string& index_name, std::uint64_t expected_count)
 {
-    return test ::utils::wait_until(
+    return test::utils::wait_until(
       [cluster = std::move(cluster), &index_name, &expected_count]() {
           couchbase::core::operations::management::search_index_get_documents_count_request req{};
           req.index_name = index_name;


### PR DESCRIPTION
Motivation
==========
If scoring is disable on server versions > 7.6 the SDK can crash when parsing the hits in the result.  The SDK should be a bit more lenient when processing hits. Also instead of crashing, the SDK should raise an exception if there is a problem when parsing results.

Changes
=======
* Update JSON parsing of search results
* Added flags to output search request and/or response
* Updated search test suite