### PR TITLE
CXXCBC-482: Range scan orchestrator should use best effort retry strategy by default

### DIFF
--- a/core/range_scan_orchestrator_options.hxx
+++ b/core/range_scan_orchestrator_options.hxx
@@ -18,6 +18,7 @@
 #include "range_scan_options.hxx"
 #include "timeout_defaults.hxx"
 
+#include <couchbase/best_effort_retry_strategy.hxx>
 #include <couchbase/mutation_token.hxx>
 #include <couchbase/retry_strategy.hxx>
 
@@ -51,7 +52,7 @@ struct range_scan_orchestrator_options {
     std::uint32_t batch_byte_limit{ range_scan_continue_options::default_batch_byte_limit };
     std::uint16_t concurrency{ default_concurrency };
 
-    std::shared_ptr<couchbase::retry_strategy> retry_strategy{ nullptr };
+    std::shared_ptr<couchbase::retry_strategy> retry_strategy{ make_best_effort_retry_strategy() };
     std::chrono::milliseconds timeout{ timeout_defaults::key_value_scan_timeout };
     std::shared_ptr<couchbase::tracing::request_span> parent_span{};
 };


### PR DESCRIPTION
The retry strategy is unset instead of being set to best-effort by default.

This has been found via the custom transcoder FIT tests which create a collection and immediately perform a range scan on them, where the SDK fast-fails instead of retrying the get_collection_id operation (which uses the retry strategy specified in the orchestrator).