### PR TITLE
CXXCBC-487: Check if alternate addressing is used when bootstrapping

### DIFF
--- a/core/origin.hxx
+++ b/core/origin.hxx
@@ -70,6 +70,7 @@ struct origin {
     [[nodiscard]] std::vector<std::string> get_nodes() const;
 
     void set_nodes(node_list nodes);
+    void set_nodes_from_config(const topology::configuration& config);
 
     [[nodiscard]] std::pair<std::string, std::string> next_address();
 


### PR DESCRIPTION
bucket

Motivation
-----------
Fix potential bootstrapping failures if the SDK is in an environment that needs to use alternate addressing.

Changes
---------
* Consolidate logic to check for alternate address hostnames
* Check for alternate address hostnames when bootstrapping bucket