### PR TITLE
CXXCBC-443: Public API for Range Scan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,8 @@ set(couchbase_cxx_client_FILES
     core/impl/vector_search.cxx
     core/impl/view_error_category.cxx
     core/impl/wildcard_query.cxx
+    core/impl/scan_result.cxx
+    core/impl/internal_scan_result.hxx
     core/io/dns_client.cxx
     core/io/dns_config.cxx
     core/io/http_parser.cxx

--- a/core/impl/internal_scan_result.hxx
+++ b/core/impl/internal_scan_result.hxx
@@ -1,0 +1,37 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/error_codes.hxx>
+#include <couchbase/scan_result.hxx>
+
+#include "core/scan_result.hxx"
+
+namespace couchbase
+{
+class internal_scan_result
+{
+
+  public:
+    explicit internal_scan_result(core::scan_result core_result);
+    ~internal_scan_result();
+    void next(scan_item_handler&& handler);
+    void cancel();
+
+  private:
+    core::scan_result core_result_;
+};
+} // namespace couchbase

--- a/core/impl/scan_result.cxx
+++ b/core/impl/scan_result.cxx
@@ -1,0 +1,174 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/codec/encoded_value.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/scan_result.hxx>
+#include <couchbase/scan_result_item.hxx>
+
+#include "core/range_scan_options.hxx"
+#include "core/scan_result.hxx"
+
+#include "internal_scan_result.hxx"
+
+#include <future>
+#include <memory>
+#include <optional>
+#include <system_error>
+#include <utility>
+
+namespace couchbase
+{
+namespace
+{
+auto
+to_scan_result_item(core::range_scan_item core_item) -> scan_result_item
+{
+    if (!core_item.body) {
+        return scan_result_item{ core_item.key };
+    }
+    return scan_result_item{
+        core_item.key,
+        core_item.body.value().cas,
+        couchbase::codec::encoded_value{ core_item.body.value().value, core_item.body.value().flags },
+        core_item.body.value().expiry_time(),
+    };
+}
+} // namespace
+
+internal_scan_result::internal_scan_result(core::scan_result core_result)
+  : core_result_{ std::move(core_result) }
+{
+}
+
+void
+internal_scan_result::next(scan_item_handler&& handler)
+{
+    return core_result_.next([handler = std::move(handler)](core::range_scan_item item, std::error_code ec) mutable {
+        if (ec == couchbase::errc::key_value::range_scan_completed) {
+            return handler({}, {});
+        }
+        if (ec) {
+            return handler(ec, {});
+        }
+        handler({}, to_scan_result_item(std::move(item)));
+    });
+}
+
+void
+internal_scan_result::cancel()
+{
+    return core_result_.cancel();
+}
+
+internal_scan_result::~internal_scan_result()
+{
+    cancel();
+}
+
+scan_result::scan_result(std::shared_ptr<couchbase::internal_scan_result> internal)
+  : internal_{ std::move(internal) }
+{
+}
+
+void
+scan_result::next(couchbase::scan_item_handler&& handler) const
+{
+    return internal_->next(std::move(handler));
+}
+
+auto
+scan_result::next() const -> std::future<std::pair<std::error_code, std::optional<scan_result_item>>>
+{
+    auto barrier = std::make_shared<std::promise<std::pair<std::error_code, std::optional<scan_result_item>>>>();
+    internal_->next([barrier](auto ec, auto item) mutable { barrier->set_value({ ec, item }); });
+    return barrier->get_future();
+}
+
+void
+scan_result::cancel()
+{
+    if (internal_) {
+        return internal_->cancel();
+    }
+}
+
+auto
+scan_result::begin() -> scan_result::iterator
+{
+    return scan_result::iterator(internal_);
+}
+
+auto
+scan_result::end() -> scan_result::iterator
+{
+    return scan_result::iterator({ errc::key_value::range_scan_completed, {} });
+}
+
+scan_result::iterator::iterator(std::shared_ptr<internal_scan_result> internal)
+  : internal_{ std::move(internal) }
+{
+    fetch_item();
+}
+
+scan_result::iterator::iterator(std::pair<std::error_code, scan_result_item> item)
+  : item_{ std::move(item) }
+{
+}
+
+void
+scan_result::iterator::fetch_item()
+{
+    auto barrier = std::make_shared<std::promise<std::pair<std::error_code, scan_result_item>>>();
+    internal_->next([barrier](std::error_code ec, std::optional<scan_result_item> item) mutable {
+        if (ec) {
+            return barrier->set_value({ ec, {} });
+        }
+        if (!item.has_value()) {
+            return barrier->set_value({ errc::key_value::range_scan_completed, {} });
+        }
+        barrier->set_value({ {}, item.value() });
+    });
+    auto f = barrier->get_future();
+    item_ = f.get();
+}
+
+auto
+scan_result::iterator::operator*() -> std::pair<std::error_code, scan_result_item>
+{
+    return item_;
+}
+
+auto
+scan_result::iterator::operator++() -> scan_result::iterator&
+{
+    fetch_item();
+    return *this;
+}
+
+auto
+scan_result::iterator::operator==(const couchbase::scan_result::iterator& other) const -> bool
+{
+    return item_ == other.item_;
+}
+
+auto
+scan_result::iterator::operator!=(const couchbase::scan_result::iterator& other) const -> bool
+{
+    return item_ != other.item_;
+}
+} // namespace couchbase

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -131,3 +131,9 @@
  * Hooks in the transactions core are asynchronous (they have a callback parameter)
  */
 #define COUCHBASE_CXX_CLIENT_TRANSACTIONS_CORE_ASYNC_HOOKS
+
+/**
+ * Range scan is accessible from the public API
+ * couchbase::collection::scan()
+ */
+#define COUCHBASE_CXX_CLIENT_HAS_PUBLIC_RANGE_SCAN 1

--- a/core/range_scan_orchestrator.hxx
+++ b/core/range_scan_orchestrator.hxx
@@ -45,6 +45,8 @@ class scan_stream_manager
     virtual void stream_completed(std::int16_t node_id, std::uint16_t vbucket_id) = 0;
 };
 
+using scan_callback = utils::movable_function<void(std::error_code, scan_result result)>;
+
 class range_scan_orchestrator
 {
   public:
@@ -57,6 +59,7 @@ class range_scan_orchestrator
                             range_scan_orchestrator_options options);
 
     auto scan() -> tl::expected<scan_result, std::error_code>;
+    void scan(scan_callback&& cb);
 
   private:
     std::shared_ptr<range_scan_orchestrator_impl> impl_;

--- a/core/scan_result.cxx
+++ b/core/scan_result.cxx
@@ -62,24 +62,35 @@ scan_result::scan_result(std::shared_ptr<range_scan_item_iterator> iterator)
 auto
 scan_result::next() const -> tl::expected<range_scan_item, std::error_code>
 {
-    return impl_->next();
+    if (impl_) {
+        return impl_->next();
+    }
+    return tl::unexpected{ errc::common::request_canceled };
 }
 
 void
 scan_result::next(utils::movable_function<void(range_scan_item, std::error_code)> callback) const
 {
-    return impl_->next(std::move(callback));
+    if (impl_) {
+        return impl_->next(std::move(callback));
+    }
+    callback({}, errc::common::request_canceled);
 }
 
 void
 scan_result::cancel()
 {
-    return impl_->cancel();
+    if (impl_) {
+        return impl_->cancel();
+    }
 }
 
 auto
 scan_result::is_cancelled() -> bool
 {
-    return impl_->is_cancelled();
+    if (impl_) {
+        return impl_->is_cancelled();
+    }
+    return true;
 }
 } // namespace couchbase::core

--- a/core/scan_result.hxx
+++ b/core/scan_result.hxx
@@ -40,6 +40,7 @@ class range_scan_item_iterator
 class scan_result
 {
   public:
+    scan_result() = default;
     explicit scan_result(std::shared_ptr<range_scan_item_iterator> iterator);
     [[nodiscard]] auto next() const -> tl::expected<range_scan_item, std::error_code>;
     void next(utils::movable_function<void(range_scan_item, std::error_code)> callback) const;

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -37,6 +37,9 @@
 #include <couchbase/query_options.hxx>
 #include <couchbase/remove_options.hxx>
 #include <couchbase/replace_options.hxx>
+#include <couchbase/scan_options.hxx>
+#include <couchbase/scan_result.hxx>
+#include <couchbase/scan_type.hxx>
 #include <couchbase/touch_options.hxx>
 #include <couchbase/unlock_options.hxx>
 #include <couchbase/upsert_options.hxx>
@@ -924,6 +927,39 @@ class collection
      */
     [[nodiscard]] auto exists(std::string document_id, const exists_options& options = {}) const
       -> std::future<std::pair<key_value_error_context, exists_result>>;
+
+    /**
+     * Performs a key-value scan operation on the collection.
+     *
+     * @param scan_type the type of the scan. Can be @ref range_scan, @ref prefix_scan or @ref sampling_scan
+     * @param options the options to customize
+     * @param handler callable that implements @ref scan_handler
+     *
+     * @note Use this API for low concurrency batch queries where latency is not critical as the system may have to scan
+     * a lot of documents to find the matching documents. For low latency range queries, it is recommended that you use
+     * SQL++ with the necessary indexes.
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    void scan(const scan_type& scan_type, const scan_options& options, scan_handler&& handler) const;
+
+    /**
+     * Performs a key-value scan operation on the collection.
+     *
+     * @param scan_type the type of the scan. Can be @ref range_scan, @ref prefix_scan or @ref sampling_scan
+     * @param options the options to customize
+     * @return future object that carries result of the operation
+     *
+     * @note Use this API for low concurrency batch queries where latency is not critical as the system may have to scan
+     * a lot of documents to find the matching documents. For low latency range queries, it is recommended that you use
+     * SQL++ with the necessary indexes.
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    [[nodiscard]] auto scan(const scan_type& scan_type, const scan_options& options = {}) const
+      -> std::future<std::pair<std::error_code, scan_result>>;
 
     [[nodiscard]] auto query_indexes() const -> collection_query_index_manager;
 

--- a/couchbase/scan_options.hxx
+++ b/couchbase/scan_options.hxx
@@ -1,0 +1,163 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/mutation_state.hxx>
+#include <couchbase/mutation_token.hxx>
+#include <couchbase/scan_result.hxx>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace couchbase
+{
+
+/**
+ * Options for @ref collection#scan().
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct scan_options : public common_options<scan_options> {
+  public:
+    /**
+     * Specifies whether only document IDs should be included in the results. Defaults to false.
+     *
+     * @param ids_only if set to true the content will not be included in the results
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto ids_only(bool ids_only) -> scan_options&
+    {
+        ids_only_ = ids_only;
+        return self();
+    }
+
+    /**
+     * Sets the {@link mutation_token}s this scan should be consistent with.
+     *
+     * These mutation tokens are returned from mutations (i.e. as part of a {@link mutation_result}) and if you want your
+     * scan to include those you need to pass the mutation tokens into a {@link mutation_state}.
+     *
+     * @param state the mutation state containing the mutation tokens.
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto consistent_with(const mutation_state& state) -> scan_options&
+    {
+        mutation_state_ = state.tokens();
+        return self();
+    }
+
+    /**
+     * Allows to limit the maximum amount of bytes that are sent from the server in each partition batch. Defaults to 15,000.
+     *
+     * @param batch_byte_limit the byte limit
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto batch_byte_limit(std::uint32_t batch_byte_limit) -> scan_options&
+    {
+        batch_byte_limit_ = batch_byte_limit;
+        return self();
+    }
+
+    /**
+     * Allows to limit the maximum number of scan items that are sent from the server in each partition batch. Defaults to 50.
+     *
+     * @param batch_item_limit the item limit
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto batch_item_limit(std::uint32_t batch_item_limit) -> scan_options&
+    {
+        batch_item_limit_ = batch_item_limit;
+        return self();
+    }
+
+    /**
+     * Specifies the maximum number of partitions that can be scanned concurrently. Defaults to 1.
+     *
+     * @param concurrency the maximum number of concurrent partition scans
+     * @return the options builder for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto concurrency(std::uint16_t concurrency) -> scan_options&
+    {
+        concurrency_ = concurrency;
+        return self();
+    }
+
+    /**
+     * Immutable value object representing consistent options.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built : public common_options<scan_options>::built {
+        bool ids_only;
+        std::vector<mutation_token> mutation_state;
+        std::optional<std::uint32_t> batch_byte_limit;
+        std::optional<std::uint32_t> batch_item_limit;
+        std::optional<std::uint16_t> concurrency;
+    };
+
+    /**
+     * Validates options and returns them as an immutable value.
+     *
+     * @return consistent options as an immutable value.
+     *
+     * @exception std::system_error with code @ref errc::common::invalid_argument if the options are not valid.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { build_common_options(), ids_only_, mutation_state_, batch_byte_limit_, batch_item_limit_, concurrency_ };
+    }
+
+  private:
+    bool ids_only_{ false };
+    std::vector<mutation_token> mutation_state_{};
+    std::optional<std::uint32_t> batch_byte_limit_{};
+    std::optional<std::uint32_t> batch_item_limit_{};
+    std::optional<std::uint16_t> concurrency_{};
+};
+
+/**
+ * The signature for the handler of the @ref collection#scan() operation.
+ *
+ * @since 1.0.0
+ * @volatile
+ */
+using scan_handler = std::function<void(std::error_code, scan_result)>;
+} // namespace couchbase

--- a/couchbase/scan_result.hxx
+++ b/couchbase/scan_result.hxx
@@ -1,0 +1,144 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/scan_result_item.hxx>
+
+#include <future>
+#include <iterator>
+#include <memory>
+#include <system_error>
+#include <utility>
+
+namespace couchbase
+{
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
+class internal_scan_result;
+#endif
+
+/**
+ * The signature for the handler of the @ref scan_result#next() operation
+ *
+ * @since 1.0.0
+ * @volatile
+ */
+using scan_item_handler = std::function<void(std::error_code, std::optional<scan_result_item>)>;
+
+class scan_result
+{
+  public:
+    /**
+     * Constructs an empty scan result.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    scan_result() = default;
+
+    /**
+     * Constructs a scan result from an internal scan result.
+     *
+     * @param internal the internal scan result
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    explicit scan_result(std::shared_ptr<internal_scan_result> internal);
+
+    /**
+     * Fetches the next scan result item.
+     *
+     * @param handler callable that implements @ref scan_handler
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    void next(scan_item_handler&& handler) const;
+
+    /**
+     * Fetches the next scan result item.
+     *
+     * @return future object that carries the result of the operation
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    auto next() const -> std::future<std::pair<std::error_code, std::optional<scan_result_item>>>;
+
+    /**
+     * Cancels the scan.
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    void cancel();
+
+    /**
+     * An iterator that can be used to iterate through all the {@link scan_result_item}s.
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    class iterator
+    {
+      public:
+        auto operator==(const iterator& other) const -> bool;
+        auto operator!=(const iterator& other) const -> bool;
+        auto operator*() -> std::pair<std::error_code, scan_result_item>;
+        auto operator++() -> iterator&;
+
+        explicit iterator(std::shared_ptr<internal_scan_result> internal);
+        explicit iterator(std::pair<std::error_code, scan_result_item> item);
+
+        using difference_type = std::ptrdiff_t;
+        using value_type = scan_result_item;
+        using pointer = const scan_result_item*;
+        using reference = const scan_result_item&;
+        using iterator_category = std::input_iterator_tag;
+
+      private:
+        void fetch_item();
+
+        std::shared_ptr<internal_scan_result> internal_{};
+        std::pair<std::error_code, scan_result_item> item_{};
+    };
+
+    /**
+     * Returns an iterator to the beginning.
+     *
+     * @return iterator to the beginning
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    auto begin() -> iterator;
+
+    /**
+     * Returns an iterator to the end.
+     *
+     * @return iterator to the end
+     *
+     * @since 1.0.0
+     * @volatile
+     */
+    auto end() -> iterator;
+
+  private:
+    std::shared_ptr<internal_scan_result> internal_{};
+};
+} // namespace couchbase

--- a/couchbase/scan_result_item.hxx
+++ b/couchbase/scan_result_item.hxx
@@ -1,0 +1,170 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/cas.hxx>
+#include <couchbase/codec/default_json_transcoder.hxx>
+#include <couchbase/codec/encoded_value.hxx>
+#include <couchbase/codec/transcoder_traits.hxx>
+#include <couchbase/result.hxx>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+/**
+ * Represents a single item from the result of @ref collection#scan()
+ *
+ * @since 1.0.0
+ * @uncommitted
+ */
+namespace couchbase
+{
+class scan_result_item : public result
+{
+  public:
+    /**
+     * Constructs an empty @ref scan_result_item.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    scan_result_item() = default;
+
+    /**
+     * Constructs an instance representing a single item from the result of a scan operation.
+     *
+     * @param id the document ID
+     * @param cas
+     * @param value raw document contents along with flags describing its structure
+     * @param expiry_time optional point in time when the document will expire
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    scan_result_item(std::string id,
+                     couchbase::cas cas,
+                     codec::encoded_value value,
+                     std::optional<std::chrono::system_clock::time_point> expiry_time)
+      : result{ cas }
+      , id_{ std::move(id) }
+      , id_only_{ false }
+      , value_{ std::move(value) }
+      , expiry_time_{ expiry_time }
+    {
+    }
+
+    /**
+     * Constructs an instance representing a single item from the result of an id-only scan operation.
+     *
+     * @param id the document ID
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    explicit scan_result_item(std::string id)
+      : id_{ std::move(id) }
+      , id_only_{ true }
+    {
+    }
+
+    bool operator==(const scan_result_item& other) const
+    {
+        return id_ == other.id_ && cas() == other.cas();
+    }
+
+    /**
+     * Returns the ID of the document
+     *
+     * @return document id
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id() const -> const std::string&
+    {
+        return id_;
+    }
+
+    /**
+     * Returns whether this scan result item only contains the document ID. If true, accessing the content or CAS will
+     * return the default values.
+     *
+     * @return whether this item comes from an id-only scan.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto id_only() const -> bool
+    {
+        return id_only_;
+    }
+
+    /**
+     * Decodes the content of the document using given codec.
+     *
+     * @note This method always returns an empty `std::optional` unless
+     * the {@link collection#scan()} request was made using {@link scan_options#ids_only()}
+     * set to false.
+     *
+     * @tparam Document custom type that `Transcoder` returns
+     * @tparam Transcoder type that has static function `decode` that takes codec::encoded_value and returns `Document`
+     * @return decoded document content
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    template<typename Document,
+             typename Transcoder = codec::default_json_transcoder,
+             std::enable_if_t<!codec::is_transcoder_v<Document>, bool> = true,
+             std::enable_if_t<codec::is_transcoder_v<Transcoder>, bool> = true>
+    [[nodiscard]] auto content_as() const -> Document
+    {
+        if (id_only_) {
+            return {};
+        }
+        return Transcoder::template decode<Document>(value_);
+    }
+
+    /**
+     * If the document has an expiry, returns the point in time when the loaded
+     * document expires.
+     *
+     * @note This method always returns an empty `std::optional` unless
+     * the {@link collection#scan()} request was made using {@link scan_options#ids_only()}
+     * set to false.
+     *
+     * @return expiry time if present
+     *
+     * @since 1.0.0
+     * @uncommitted
+     */
+    [[nodiscard]] auto expiry_time() const -> const std::optional<std::chrono::system_clock::time_point>&
+    {
+        return expiry_time_;
+    }
+
+  private:
+    std::string id_{};
+    bool id_only_{};
+    codec::encoded_value value_{};
+    std::optional<std::chrono::system_clock::time_point> expiry_time_{};
+};
+} // namespace couchbase

--- a/couchbase/scan_type.hxx
+++ b/couchbase/scan_type.hxx
@@ -1,0 +1,323 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace couchbase
+{
+/**
+ * A scan term used to specify the bounds of a range scan operation.
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct scan_term {
+  public:
+    /**
+     * Constructs an instance representing the scan term for the given term.
+     *
+     * @param term the string representation of the term.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    explicit scan_term(std::string term)
+      : term_{ std::move(term) }
+    {
+    }
+
+    /**
+     * Specifies whether this term is excluded from the scan results. The bounds are included by default.
+     *
+     * @param exclusive whether the term should be excluded.
+     * @return the scan term object for chaining purposes.
+     */
+    auto exclusive(bool exclusive) -> scan_term&
+    {
+        exclusive_ = exclusive;
+        return *this;
+    }
+
+    /**
+     * Immutable value representing the scan term.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built {
+        std::string term;
+        bool exclusive;
+    };
+
+    /**
+     * Returns the scan term as an immutable value.
+     *
+     * @return scan term as an immutable value.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built
+    {
+        return { term_, exclusive_ };
+    }
+
+  private:
+    std::string term_{};
+    bool exclusive_{ false };
+};
+
+/**
+ * The base class for the different scan types.
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct scan_type {
+    virtual ~scan_type() = default;
+
+    /**
+     * Immutable value representing the scan type.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    struct built {
+        enum type { prefix_scan, range_scan, sampling_scan };
+        type type;
+
+        std::string prefix{};
+
+        std::optional<scan_term::built> from{};
+        std::optional<scan_term::built> to{};
+
+        std::size_t limit{};
+        std::optional<std::uint64_t> seed{};
+    };
+
+    /**
+     * Returns the scan type as an immutable value.
+     *
+     * @return scan type as an immutable value.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] virtual auto build() const -> built = 0;
+};
+
+/**
+ * A prefix scan performs a scan that includes all documents whose keys start with the given prefix.
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct prefix_scan : scan_type {
+  public:
+    /**
+     * Creates an instance of a prefix scan type.
+     *
+     * @param prefix The prefix all document keys should start with.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    explicit prefix_scan(std::string prefix)
+      : prefix_{ std::move(prefix) }
+    {
+    }
+
+    /**
+     * Returns the prefix scan type as an immutable value.
+     *
+     * @return scan type as an immutable value.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built override
+    {
+        return {
+            scan_type::built::prefix_scan,
+            prefix_,
+        };
+    }
+
+  private:
+    std::string prefix_{};
+};
+
+/**
+ * A range scan performs a scan on a range of keys.
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct range_scan : scan_type {
+  public:
+    /**
+     * Creates an instance of a range scan type with no bounds.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    range_scan() = default;
+
+    /**
+     * Creates an instance of a range scan type
+     *
+     * @param from the scan term representing the lower bound of the range, optional.
+     * @param to the scan term representing the upper bound of the range, optional.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    range_scan(std::optional<scan_term> from, std::optional<scan_term> to)
+      : from_{ std::move(from) }
+      , to_{ std::move(to) }
+    {
+    }
+
+    /**
+     * Specifies the lower bound of the range
+     *
+     * @param from scan term representing the lower bound.
+     * @return the range scan object for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto from(scan_term from) -> range_scan&
+    {
+        from_ = std::move(from);
+        return *this;
+    }
+
+    /**
+     * Specifies the upper bound of the range.
+     *
+     * @param to scan term representing the upper bound.
+     * @return the range scan object for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto to(scan_term to) -> range_scan&
+    {
+        to_ = std::move(to);
+        return *this;
+    }
+
+    /**
+     * Returns the range scan type as an immutable value.
+     *
+     * @return scan type as an immutable value.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built override
+    {
+        return {
+            scan_type::built::type::range_scan,
+            {},
+            (from_) ? std::make_optional(from_->build()) : std::nullopt,
+            (to_) ? std::make_optional(to_->build()) : std::nullopt,
+        };
+    }
+
+  private:
+    std::optional<scan_term> from_{};
+    std::optional<scan_term> to_{};
+};
+
+/**
+ * A sampling scan performs a scan that randomly selects documents up to a configured limit.
+ *
+ * @since 1.0.0
+ * @committed
+ */
+struct sampling_scan : scan_type {
+  public:
+    /**
+     * Creates an instance of a sampling scan type.
+     *
+     * @param limit the maximum number of documents the sampling scan can return.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    explicit sampling_scan(std::size_t limit)
+      : limit_{ limit }
+    {
+    }
+
+    /**
+     * Creates an instance of a sampling scan type with a seed..
+     *
+     * @param limit the maximum number of documents the sampling scan can return.
+     * @param seed the seed used for the random number generator that selects the documents.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    sampling_scan(std::size_t limit, std::uint64_t seed)
+      : limit_{ limit }
+      , seed_{ seed }
+    {
+    }
+
+    /**
+     * Sets the seed for the sampling scan.
+     *
+     * @param seed the seed used for the random number generator that selects the documents.
+     * @return the sampling scan object for chaining purposes.
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    auto seed(std::uint64_t seed) -> sampling_scan&
+    {
+        seed_ = seed;
+        return *this;
+    }
+
+    /**
+     * Returns the sampling scan type as an immutable value.
+     *
+     * @return scan type as an immutable value.
+     *
+     * @since 1.0.0
+     * @internal
+     */
+    [[nodiscard]] auto build() const -> built override
+    {
+        return {
+            scan_type::built::type::sampling_scan, {}, {}, {}, limit_, seed_,
+        };
+    }
+
+  private:
+    std::size_t limit_{};
+    std::optional<std::uint64_t> seed_{};
+};
+} // namespace couchbase


### PR DESCRIPTION
## Motivation

Range scan has been implemented in the core. It also needs to be exposed via the Public API.

## Changes

* Added an async version of `core::range_scan_orchestrator.scan()`
* Add a `collection.scan()` method
* Added check for range scan bucket capability in `collection_impl.scan()` before executing the scan
* Add a `scan_type` abstract class with `range_scan`, `prefix_scan`, `sampling_scan` concrete subclasses, as well as `scan_options` which are used for the parameters of `collection.scan()`
* Add `scan_result` which is used for iterating through the results of the scan, either using `result.next()` or the input iterator `scan_options::iterator`. Each individual range scan result is of type `scan_result_item`.

## Results

All tests pass, including FIT.