### PR TITLE
CXXCBC-494: fix memory issue in range scan implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,10 @@ IndentWidth: 4
 ColumnLimit: 140
 AllowShortFunctionsOnASingleLine: None
 AllowShortBlocksOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 BreakBeforeBraces: Linux
 FixNamespaceComments: true
-

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,14 +18,14 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y wget gnupg2 git
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo bash -c "echo 'deb https://apt.llvm.org/focal/ llvm-toolchain-focal-17 main' >> /etc/apt/sources.list"
+          sudo bash -c "echo 'deb https://apt.llvm.org/focal/ llvm-toolchain-focal-18 main' >> /etc/apt/sources.list"
           sudo apt-get update -y
-          sudo apt-get install -y clang-format-17
+          sudo apt-get install -y clang-format-18
       - name: Run clang-format
         run: ./bin/check-clang-format
         env:
-          CB_GIT_CLANG_FORMAT: /usr/bin/git-clang-format-17
-          CB_CLANG_FORMAT: /usr/bin/clang-format-17
+          CB_GIT_CLANG_FORMAT: /usr/bin/git-clang-format-18
+          CB_CLANG_FORMAT: /usr/bin/clang-format-18
 
   clang_static_analyzer:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We must be careful when invoking items callback for the range scan results, as the whole iteration might be canceled after any of the invocation. The library should not be calling any callbacks on canceled request to avoid memory issues.

In particular the test "integration: range scan cancel during streaming using pending_operation cancel" uses stack-allocated vector for results, and cancels request during itertion. The range scan completed, but the library might still call the items callback, which will try to insert items into deallocated result vector.