### PR TITLE
CXXCBC-470: Distinguish between 'unset' and 'off' query_profile

### DIFF
--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -76,15 +76,18 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
         }
         body["args"] = std::move(parameters);
     }
-    switch (profile) {
-        case couchbase::query_profile::phases:
-            body["profile"] = "phases";
-            break;
-        case couchbase::query_profile::timings:
-            body["profile"] = "timings";
-            break;
-        case couchbase::query_profile::off:
-            break;
+    if (profile.has_value()) {
+        switch (profile.value()) {
+            case couchbase::query_profile::phases:
+                body["profile"] = "phases";
+                break;
+            case couchbase::query_profile::timings:
+                body["profile"] = "timings";
+                break;
+            case couchbase::query_profile::off:
+                body["profile"] = "off";
+                break;
+        }
     }
     if (use_replica.has_value()) {
         if (context.config.capabilities.supports_read_from_replica()) {

--- a/core/operations/document_query.hxx
+++ b/core/operations/document_query.hxx
@@ -103,7 +103,7 @@ struct query_request {
     std::optional<std::string> client_context_id{};
     std::optional<std::chrono::milliseconds> timeout{};
 
-    query_profile profile{ query_profile::off };
+    std::optional<query_profile> profile{};
 
     std::map<std::string, couchbase::core::json_string, std::less<>> raw{};
     std::vector<couchbase::core::json_string> positional_parameters{};

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -60,7 +60,7 @@ struct query_options : public common_options<query_options> {
         std::optional<std::string> client_context_id;
         std::optional<query_scan_consistency> scan_consistency;
         std::vector<mutation_token> mutation_state;
-        const query_profile profile;
+        std::optional<query_profile> profile;
         std::vector<codec::binary> positional_parameters;
         std::map<std::string, codec::binary, std::less<>> named_parameters;
         std::map<std::string, codec::binary, std::less<>> raw;
@@ -555,7 +555,7 @@ struct query_options : public common_options<query_options> {
     std::optional<std::chrono::milliseconds> scan_wait_{};
     std::optional<query_scan_consistency> scan_consistency_{};
     std::vector<mutation_token> mutation_state_{};
-    query_profile profile_{ query_profile::off };
+    std::optional<query_profile> profile_{};
     std::vector<codec::binary> positional_parameters_{};
     std::map<std::string, codec::binary, std::less<>> raw_{};
     std::map<std::string, codec::binary, std::less<>> named_parameters_{};

--- a/tools/query.cxx
+++ b/tools/query.cxx
@@ -71,8 +71,7 @@ Examples:
         add_flag("--disable-metrics", disable_metrics_, "Do not request metrics.");
         add_flag("--user-replica", use_replica_, "Allow using replica nodes for KV operations.");
         add_option("--profile", profile_, "Request the service to profile the query and return report.")
-          ->transform(CLI::IsMember(allowed_profile_modes))
-          ->default_val(fmt::format("{}", defaults.profile));
+          ->transform(CLI::IsMember(allowed_profile_modes));
         add_option("--bucket-name", bucket_name_, "Name of the bucket.");
         add_option("--scope-name", scope_name_, "Name of the scope.")->default_val(couchbase::scope::default_name);
         add_option("--client-context-id", client_context_id_, "Override client context ID for the query(-ies).");
@@ -141,14 +140,16 @@ Examples:
             fail(fmt::format("unexpected value '{}' for --scan-consistency", scan_consistency_));
         }
 
-        if (profile_ == "off") {
-            query_options.profile(couchbase::query_profile::off);
-        } else if (profile_ == "phases") {
-            query_options.profile(couchbase::query_profile::phases);
-        } else if (profile_ == "timings") {
-            query_options.profile(couchbase::query_profile::timings);
-        } else if (!profile_.empty()) {
-            fail(fmt::format("unexpected value '{}' for --scan-consistency", profile_));
+        if (profile_.has_value()) {
+            if (profile_.value() == "off") {
+                query_options.profile(couchbase::query_profile::off);
+            } else if (profile_.value() == "phases") {
+                query_options.profile(couchbase::query_profile::phases);
+            } else if (profile_.value() == "timings") {
+                query_options.profile(couchbase::query_profile::timings);
+            } else if (!profile_.value().empty()) {
+                fail(fmt::format("unexpected value '{}' for --profile", profile_.value()));
+            }
         }
 
         std::optional<scope_with_bucket> scope_id{};
@@ -437,7 +438,7 @@ Examples:
     bool read_only_{ false };
     bool preserve_expiry_{ false };
     bool disable_metrics_{ false };
-    std::string profile_{};
+    std::optional<std::string> profile_{};
     std::optional<bool> use_replica_;
     std::optional<std::uint64_t> maximum_parallelism_;
     std::optional<std::uint64_t> scan_cap_;


### PR DESCRIPTION
## Motivation

We can't distinguish whether the user explicitly set `profile` in the query options to 'off' or if it was left as the default value.

## Change

Make `profile` optional in the core `query_request` which is only set if the user specifies the profile in the Public API's query options. Always send the profile parameter to the server if the user has set its value.

## Results

All test cases in FIT's `QueryParametersTest` pass