### PR TITLE
Add feature check for scoped analyze_document in tests

### DIFF
--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -4869,8 +4869,8 @@ TEST_CASE("integration: scope search index management analyze document public AP
 {
     test::utils::integration_test_guard integration;
 
-    if (!integration.cluster_version().supports_scope_search()) {
-        SKIP("cluster does not support scope search");
+    if (!integration.cluster_version().supports_scope_search_analyze()) {
+        SKIP("cluster does not support scoped analyze_document");
     }
 
     if (integration.cluster_version().is_capella()) {

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -186,6 +186,12 @@ struct server_version {
         return (major == 7 && minor >= 6) || major > 7;
     }
 
+    [[nodiscard]] bool supports_scope_search_analyze() const
+    {
+        // Scoped endpoint for analyze_document added in 7.6.2 (MB-60643)
+        return (major == 7 && minor == 6 && micro >= 2) || (major == 7 && minor > 6) || major > 7;
+    }
+
     [[nodiscard]] bool is_enterprise() const
     {
         return edition == server_edition::enterprise;


### PR DESCRIPTION
A scoped endpoint for `analyze_document` was added in [MB-60643](https://issues.couchbase.com/browse/MB-60643). We should skip the tests for versions earlier than that.