### PR TITLE
CXXCBC-503: Ignore configuration if it contains an empty vBucketMap

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -591,7 +591,19 @@ class bucket_impl
         bool sequence_changed = false;
         {
             std::scoped_lock lock(config_mutex_);
-            if (!config_) {
+            if (config.vbmap && config.vbmap->size() == 0) {
+                if (!config_) {
+                    CB_LOG_DEBUG("{} will not initialize configuration rev={} because config has an empty partition map",
+                                 log_prefix_,
+                                 config.rev_str());
+                } else {
+                    CB_LOG_DEBUG("{} will not update the configuration old={} -> new={}, because new config has an empty partition map",
+                                 log_prefix_,
+                                 config_->rev_str(),
+                                 config.rev_str());
+                }
+                return;
+            } else if (!config_) {
                 CB_LOG_DEBUG("{} initialize configuration rev={}", log_prefix_, config.rev_str());
             } else if (config.force) {
                 CB_LOG_DEBUG("{} forced to accept configuration rev={}", log_prefix_, config.rev_str());

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -1256,6 +1256,10 @@ class mcbp_session_impl
             return;
         }
         std::scoped_lock lock(config_mutex_);
+        if (config.vbmap && config.vbmap->size() == 0) {
+            CB_LOG_DEBUG("{} received a configuration with an empty vbucket map, ignoring", log_prefix_);
+            return;
+        }
         if (config_) {
             if (config_->vbmap && config.vbmap && config_->vbmap->size() != config.vbmap->size()) {
                 CB_LOG_DEBUG("{} received a configuration with a different number of vbuckets, ignoring", log_prefix_);


### PR DESCRIPTION
Motivation
==========
Server versions prior to 7.6.2 (MB-60405) can sometimes provide a configuration that has a vBucketMap, but it does not contain any vbuckets. This should not happend, but since it does the SDK should ignore these configurations.

Changes
=======
Ignore a configuration if it contains an empty vBucketMap.