### PR TITLE
CXXCBC-499 Use couchbase::error for Query, Search and Analytics operations

### DIFF
--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -85,7 +85,8 @@ struct traits<couchbase::core::error_context::analytics> {
         if (const auto& first_error_code = v.find("first_error_code"); first_error_code != nullptr && first_error_code->is_integer()) {
             ctx.first_error_code = first_error_code->get_unsigned();
         }
-        if (const auto& first_error_message = v.find("first_error_message"); first_error_message != nullptr && first_error_message->is_string()) {
+        if (const auto& first_error_message = v.find("first_error_message");
+            first_error_message != nullptr && first_error_message->is_string()) {
             ctx.first_error_message = first_error_message->get_string();
         }
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
@@ -93,10 +94,12 @@ struct traits<couchbase::core::error_context::analytics> {
                 ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
-        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from");
+            last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
             ctx.last_dispatched_from = last_dispatched_from->get_string();
         }
-        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to");
+            last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
             ctx.last_dispatched_to = last_dispatched_to->get_string();
         }
         return ctx;

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -17,13 +17,14 @@
 
 #pragma once
 
+#include <core/impl/retry_reason.hxx>
 #include <core/error_context/analytics.hxx>
+
 #include <couchbase/error_codes.hxx>
+#include <couchbase/fmt/retry_reason.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
-
-#include <couchbase/fmt/retry_reason.hxx>
 
 namespace tao::json
 {

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -1,0 +1,73 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <core/error_context/analytics.hxx>
+
+#include <tao/json/forward.hpp>
+#include <tao/json/value.hpp>
+
+#include <couchbase/fmt/retry_reason.hxx>
+
+namespace tao::json
+{
+template<>
+struct traits<couchbase::core::error_context::analytics> {
+    template<template<typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::analytics& ctx)
+    {
+        v["ec"] =
+          tao::json::value{
+              { "value", ctx.ec.value() },
+              { "message", ctx.ec.message() },
+          },
+        v["retry_attempts"] = ctx.retry_attempts;
+        v["client_context_id"] = ctx.client_context_id;
+        v["statement"] = ctx.statement;
+        v["method"] = ctx.method;
+        v["path"] = ctx.path;
+        v["http_status"] = ctx.http_status;
+        v["http_body"] = ctx.http_body;
+        v["hostname"] = ctx.hostname;
+        v["port"] = ctx.port;
+
+        if (const auto& val = ctx.parameters; val.has_value()) {
+            v["parameters"] = val.value();
+        }
+        if (ctx.first_error_code > 0) {
+            v["first_error_code"] = ctx.first_error_code;
+        }
+        if (!ctx.first_error_message.empty()) {
+            v["first_error_message"] = ctx.first_error_message;
+        }
+        if (const auto& reasons = ctx.retry_reasons; !reasons.empty()) {
+            tao::json::value reasons_json = tao::json::empty_array;
+            for (const auto& reason : reasons) {
+                reasons_json.emplace_back(fmt::format("{}", reason));
+            }
+            v["retry_reasons"] = reasons_json;
+        }
+        if (const auto& val = ctx.last_dispatched_from; val.has_value()) {
+            v["last_dispatched_from"] = val.value();
+        }
+        if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
+            v["last_dispatched_to"] = val.value();
+        }
+    }
+};
+} // namespace tao::json

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -32,11 +32,6 @@ struct traits<couchbase::core::error_context::analytics> {
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::analytics& ctx)
     {
-        v["ec"] =
-          tao::json::value{
-              { "value", ctx.ec.value() },
-              { "message", ctx.ec.message() },
-          },
         v["retry_attempts"] = ctx.retry_attempts;
         v["client_context_id"] = ctx.client_context_id;
         v["statement"] = ctx.statement;

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/error_context/analytics.hxx>
+#include <couchbase/error_codes.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
@@ -68,6 +69,42 @@ struct traits<couchbase::core::error_context::analytics> {
         if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
             v["last_dispatched_to"] = val.value();
         }
+    }
+
+    template<template<typename...> class Traits>
+    static couchbase::core::error_context::analytics as(const tao::json::basic_value<Traits>& v)
+    {
+        couchbase::core::error_context::analytics ctx;
+        ctx.retry_attempts = v.at("retry_attempts").get_unsigned();
+        ctx.client_context_id = v.at("client_context_id").get_string();
+        ctx.statement = v.at("statement").get_string();
+        ctx.method = v.at("method").get_string();
+        ctx.path = v.at("path").get_string();
+        ctx.http_status = static_cast<uint32_t>(v.at("http_status").get_unsigned());
+        ctx.http_body = v.at("http_body").get_string();
+        ctx.hostname = v.at("hostname").get_string();
+        ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
+        if (const auto& parameters = v.find("parameters"); parameters != nullptr && parameters->is_string()) {
+            ctx.parameters = parameters->get_string();
+        }
+        if (const auto& first_error_code = v.find("first_error_code"); first_error_code != nullptr && first_error_code->is_integer()) {
+            ctx.first_error_code = first_error_code->get_unsigned();
+        }
+        if (const auto& first_error_message = v.find("first_error_message"); first_error_message != nullptr && first_error_message->is_string()) {
+            ctx.first_error_message = first_error_message->get_string();
+        }
+        if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
+            for (const auto& retry_reason : retry_reasons->get_array()) {
+                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+            }
+        }
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+            ctx.last_dispatched_from = last_dispatched_from->get_string();
+        }
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+            ctx.last_dispatched_to = last_dispatched_to->get_string();
+        }
+        return ctx;
     }
 };
 } // namespace tao::json

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2024. Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <core/impl/retry_reason.hxx>
 #include <core/error_context/analytics.hxx>
+#include <core/impl/retry_reason.hxx>
 
 #include <couchbase/error_codes.hxx>
 #include <couchbase/fmt/retry_reason.hxx>
@@ -30,6 +30,8 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::analytics> {
+    TAO_JSON_DEFAULT_KEY("analytics");
+
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::analytics& ctx)
     {
@@ -92,7 +94,7 @@ struct traits<couchbase::core::error_context::analytics> {
         }
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
             for (const auto& retry_reason : retry_reasons->get_array()) {
-                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+                ctx.retry_reasons.insert(couchbase::core::impl::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
         if (const auto& last_dispatched_from = v.find("last_dispatched_from");

--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -30,8 +30,6 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::analytics> {
-    TAO_JSON_DEFAULT_KEY("analytics");
-
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::analytics& ctx)
     {

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2024. Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ struct traits<couchbase::core::error_context::http> {
         ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
             for (const auto& retry_reason : retry_reasons->get_array()) {
-                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+                ctx.retry_reasons.insert(couchbase::core::impl::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
         if (const auto& last_dispatched_from = v.find("last_dispatched_from");

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <core/error_context/http.hxx>
+
+#include <tao/json/forward.hpp>
+#include <tao/json/value.hpp>
+
+#include <couchbase/fmt/retry_reason.hxx>
+
+namespace tao::json
+{
+template<>
+struct traits<couchbase::core::error_context::http> {
+    template<template<typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::http& ctx)
+    {
+        v["ec"] =
+          tao::json::value{
+              { "value", ctx.ec.value() },
+              { "message", ctx.ec.message() },
+          },
+        v["retry_attempts"] = ctx.retry_attempts;
+        v["client_context_id"] = ctx.client_context_id;
+        v["method"] = ctx.method;
+        v["path"] = ctx.path;
+        v["http_status"] = ctx.http_status;
+        v["http_body"] = ctx.http_body;
+        v["hostname"] = ctx.hostname;
+        v["port"] = ctx.port;
+
+        if (const auto& reasons = ctx.retry_reasons; !reasons.empty()) {
+            tao::json::value reasons_json = tao::json::empty_array;
+            for (const auto& reason : reasons) {
+                reasons_json.emplace_back(fmt::format("{}", reason));
+            }
+            v["retry_reasons"] = reasons_json;
+        }
+        if (const auto& val = ctx.last_dispatched_from; val.has_value()) {
+            v["last_dispatched_from"] = val.value();
+        }
+        if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
+            v["last_dispatched_to"] = val.value();
+        }
+    }
+};
+} // namespace tao::json

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -18,11 +18,13 @@
 #pragma once
 
 #include <core/error_context/http.hxx>
+#include <core/impl/retry_reason.hxx>
+
+#include <couchbase/error_codes.hxx>
+#include <couchbase/fmt/retry_reason.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
-
-#include <couchbase/fmt/retry_reason.hxx>
 
 namespace tao::json
 {

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -30,8 +30,6 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::http> {
-    TAO_JSON_DEFAULT_KEY("http");
-
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::http& ctx)
     {

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -66,16 +66,17 @@ struct traits<couchbase::core::error_context::http> {
         ctx.http_body = v.at("http_body").get_string();
         ctx.hostname = v.at("hostname").get_string();
         ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
-
-                if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
-                    for (const auto& retry_reason : retry_reasons->get_array()) {
-                        ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
-                    }
-                }
-        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+        if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
+            for (const auto& retry_reason : retry_reasons->get_array()) {
+                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+            }
+        }
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from");
+            last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
             ctx.last_dispatched_from = last_dispatched_from->get_string();
         }
-        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to");
+            last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
             ctx.last_dispatched_to = last_dispatched_to->get_string();
         }
         return ctx;

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -30,6 +30,8 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::http> {
+    TAO_JSON_DEFAULT_KEY("http");
+
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::http& ctx)
     {

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -31,11 +31,6 @@ struct traits<couchbase::core::error_context::http> {
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::http& ctx)
     {
-        v["ec"] =
-          tao::json::value{
-              { "value", ctx.ec.value() },
-              { "message", ctx.ec.message() },
-          },
         v["retry_attempts"] = ctx.retry_attempts;
         v["client_context_id"] = ctx.client_context_id;
         v["method"] = ctx.method;
@@ -58,6 +53,32 @@ struct traits<couchbase::core::error_context::http> {
         if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
             v["last_dispatched_to"] = val.value();
         }
+    }
+    template<template<typename...> class Traits>
+    static couchbase::core::error_context::http as(const tao::json::basic_value<Traits>& v)
+    {
+        couchbase::core::error_context::http ctx;
+        ctx.retry_attempts = v.at("retry_attempts").get_unsigned();
+        ctx.client_context_id = v.at("client_context_id").get_string();
+        ctx.method = v.at("method").get_string();
+        ctx.path = v.at("path").get_string();
+        ctx.http_status = static_cast<uint32_t>(v.at("http_status").get_unsigned());
+        ctx.http_body = v.at("http_body").get_string();
+        ctx.hostname = v.at("hostname").get_string();
+        ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
+
+                if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
+                    for (const auto& retry_reason : retry_reasons->get_array()) {
+                        ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+                    }
+                }
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+            ctx.last_dispatched_from = last_dispatched_from->get_string();
+        }
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+            ctx.last_dispatched_to = last_dispatched_to->get_string();
+        }
+        return ctx;
     }
 };
 } // namespace tao::json

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2024. Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <core/impl/retry_reason.hxx>
 #include <core/error_context/query.hxx>
+#include <core/impl/retry_reason.hxx>
 
 #include <couchbase/error_codes.hxx>
 #include <couchbase/fmt/retry_reason.hxx>
@@ -92,7 +92,7 @@ struct traits<couchbase::core::error_context::query> {
         }
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
             for (const auto& retry_reason : retry_reasons->get_array()) {
-                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+                ctx.retry_reasons.insert(couchbase::core::impl::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
         if (const auto& last_dispatched_from = v.find("last_dispatched_from");

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -85,7 +85,8 @@ struct traits<couchbase::core::error_context::query> {
         if (const auto& first_error_code = v.find("first_error_code"); first_error_code != nullptr && first_error_code->is_integer()) {
             ctx.first_error_code = first_error_code->get_unsigned();
         }
-        if (const auto& first_error_message = v.find("first_error_message"); first_error_message != nullptr && first_error_message->is_string()) {
+        if (const auto& first_error_message = v.find("first_error_message");
+            first_error_message != nullptr && first_error_message->is_string()) {
             ctx.first_error_message = first_error_message->get_string();
         }
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
@@ -93,10 +94,12 @@ struct traits<couchbase::core::error_context::query> {
                 ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
-        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from");
+            last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
             ctx.last_dispatched_from = last_dispatched_from->get_string();
         }
-        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to");
+            last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
             ctx.last_dispatched_to = last_dispatched_to->get_string();
         }
         return ctx;

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -1,0 +1,73 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <core/error_context/query.hxx>
+
+#include <tao/json/forward.hpp>
+#include <tao/json/value.hpp>
+
+#include <couchbase/fmt/retry_reason.hxx>
+
+namespace tao::json
+{
+template<>
+struct traits<couchbase::core::error_context::query> {
+    template<template<typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::query& ctx)
+    {
+        v["ec"] =
+          tao::json::value{
+              { "value", ctx.ec.value() },
+              { "message", ctx.ec.message() },
+          },
+        v["retry_attempts"] = ctx.retry_attempts;
+        v["client_context_id"] = ctx.client_context_id;
+        v["statement"] = ctx.statement;
+        v["method"] = ctx.method;
+        v["path"] = ctx.path;
+        v["http_status"] = ctx.http_status;
+        v["http_body"] = ctx.http_body;
+        v["hostname"] = ctx.hostname;
+        v["port"] = ctx.port;
+
+        if (const auto& val = ctx.parameters; val.has_value()) {
+            v["parameters"] = val.value();
+        }
+        if (ctx.first_error_code > 0) {
+            v["first_error_code"] = ctx.first_error_code;
+        }
+        if (!ctx.first_error_message.empty()) {
+            v["first_error_message"] = ctx.first_error_message;
+        }
+        if (const auto& reasons = ctx.retry_reasons; !reasons.empty()) {
+            tao::json::value reasons_json = tao::json::empty_array;
+            for (const auto& reason : reasons) {
+                reasons_json.emplace_back(fmt::format("{}", reason));
+            }
+            v["retry_reasons"] = reasons_json;
+        }
+        if (const auto& val = ctx.last_dispatched_from; val.has_value()) {
+            v["last_dispatched_from"] = val.value();
+        }
+        if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
+            v["last_dispatched_to"] = val.value();
+        }
+    }
+};
+} // namespace tao::json

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/error_context/query.hxx>
+#include <couchbase/error_codes.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
@@ -31,11 +32,6 @@ struct traits<couchbase::core::error_context::query> {
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::query& ctx)
     {
-        v["ec"] =
-          tao::json::value{
-              { "value", ctx.ec.value() },
-              { "message", ctx.ec.message() },
-          },
         v["retry_attempts"] = ctx.retry_attempts;
         v["client_context_id"] = ctx.client_context_id;
         v["statement"] = ctx.statement;
@@ -68,6 +64,42 @@ struct traits<couchbase::core::error_context::query> {
         if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
             v["last_dispatched_to"] = val.value();
         }
+    }
+
+    template<template<typename...> class Traits>
+    static couchbase::core::error_context::query as(const tao::json::basic_value<Traits>& v)
+    {
+        couchbase::core::error_context::query ctx;
+        ctx.retry_attempts = v.at("retry_attempts").get_unsigned();
+        ctx.client_context_id = v.at("client_context_id").get_string();
+        ctx.statement = v.at("statement").get_string();
+        ctx.method = v.at("method").get_string();
+        ctx.path = v.at("path").get_string();
+        ctx.http_status = static_cast<uint32_t>(v.at("http_status").get_unsigned());
+        ctx.http_body = v.at("http_body").get_string();
+        ctx.hostname = v.at("hostname").get_string();
+        ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
+        if (const auto& parameters = v.find("parameters"); parameters != nullptr && parameters->is_string()) {
+            ctx.parameters = parameters->get_string();
+        }
+        if (const auto& first_error_code = v.find("first_error_code"); first_error_code != nullptr && first_error_code->is_integer()) {
+            ctx.first_error_code = first_error_code->get_unsigned();
+        }
+        if (const auto& first_error_message = v.find("first_error_message"); first_error_message != nullptr && first_error_message->is_string()) {
+            ctx.first_error_message = first_error_message->get_string();
+        }
+        if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
+            for (const auto& retry_reason : retry_reasons->get_array()) {
+                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+            }
+        }
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+            ctx.last_dispatched_from = last_dispatched_from->get_string();
+        }
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+            ctx.last_dispatched_to = last_dispatched_to->get_string();
+        }
+        return ctx;
     }
 };
 } // namespace tao::json

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -30,7 +30,6 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::query> {
-    TAO_JSON_DEFAULT_KEY("query");
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::query& ctx)
     {

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -17,13 +17,14 @@
 
 #pragma once
 
+#include <core/impl/retry_reason.hxx>
 #include <core/error_context/query.hxx>
+
 #include <couchbase/error_codes.hxx>
+#include <couchbase/fmt/retry_reason.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
-
-#include <couchbase/fmt/retry_reason.hxx>
 
 namespace tao::json
 {

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -30,6 +30,7 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::query> {
+    TAO_JSON_DEFAULT_KEY("query");
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::query& ctx)
     {

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -1,0 +1,68 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <core/error_context/search.hxx>
+
+#include <tao/json/forward.hpp>
+#include <tao/json/value.hpp>
+
+#include <couchbase/fmt/retry_reason.hxx>
+
+namespace tao::json
+{
+template<>
+struct traits<couchbase::core::error_context::search> {
+    template<template<typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::search& ctx)
+    {
+        v["ec"] =
+          tao::json::value{
+              { "value", ctx.ec.value() },
+              { "message", ctx.ec.message() },
+          },
+        v["retry_attempts"] = ctx.retry_attempts;
+        v["client_context_id"] = ctx.client_context_id;
+        v["index_name"] = ctx.index_name;
+        v["query"] = ctx.query;
+        v["method"] = ctx.method;
+        v["path"] = ctx.path;
+        v["http_status"] = ctx.http_status;
+        v["http_body"] = ctx.http_body;
+        v["hostname"] = ctx.hostname;
+        v["port"] = ctx.port;
+
+        if (const auto& val = ctx.parameters; val.has_value()) {
+            v["parameters"] = val.value();
+        }
+        if (const auto& reasons = ctx.retry_reasons; !reasons.empty()) {
+            tao::json::value reasons_json = tao::json::empty_array;
+            for (const auto& reason : reasons) {
+                reasons_json.emplace_back(fmt::format("{}", reason));
+            }
+            v["retry_reasons"] = reasons_json;
+        }
+        if (const auto& val = ctx.last_dispatched_from; val.has_value()) {
+            v["last_dispatched_from"] = val.value();
+        }
+        if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
+            v["last_dispatched_to"] = val.value();
+        }
+    }
+};
+} // namespace tao::json

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <core/error_context/search.hxx>
+#include <couchbase/error_codes.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
@@ -63,6 +64,36 @@ struct traits<couchbase::core::error_context::search> {
         if (const auto& val = ctx.last_dispatched_to; val.has_value()) {
             v["last_dispatched_to"] = val.value();
         }
+    }
+    template<template<typename...> class Traits>
+    static couchbase::core::error_context::search as(const tao::json::basic_value<Traits>& v)
+    {
+        couchbase::core::error_context::search ctx;
+        ctx.retry_attempts = v.at("retry_attempts").get_unsigned();
+        ctx.client_context_id = v.at("client_context_id").get_string();
+        ctx.index_name = v.at("index_name").get_string();
+        ctx.query = v.at("query").get_string();
+        ctx.method = v.at("method").get_string();
+        ctx.path = v.at("path").get_string();
+        ctx.http_status = v.at("http_status").get_unsigned();
+        ctx.http_body = v.at("http_body").get_string();
+        ctx.hostname = v.at("hostname").get_string();
+        ctx.port = v.at("port").get_unsigned();
+        if (const auto& parameters = v.find("parameters"); parameters != nullptr && parameters->is_string()) {
+            ctx.parameters = parameters->get_string();
+        }
+        if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
+            for (const auto& retry_reason : retry_reasons->get_array()) {
+                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+            }
+        }
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+            ctx.last_dispatched_from = last_dispatched_from->get_string();
+        }
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+            ctx.last_dispatched_to = last_dispatched_to->get_string();
+        }
+        return ctx;
     }
 };
 } // namespace tao::json

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2024. Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ struct traits<couchbase::core::error_context::search> {
         }
         if (const auto& retry_reasons = v.find("retry_reasons"); retry_reasons != nullptr && retry_reasons->is_array()) {
             for (const auto& retry_reason : retry_reasons->get_array()) {
-                ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
+                ctx.retry_reasons.insert(couchbase::core::impl::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
         if (const auto& last_dispatched_from = v.find("last_dispatched_from");

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -32,11 +32,6 @@ struct traits<couchbase::core::error_context::search> {
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::search& ctx)
     {
-        v["ec"] =
-          tao::json::value{
-              { "value", ctx.ec.value() },
-              { "message", ctx.ec.message() },
-          },
         v["retry_attempts"] = ctx.retry_attempts;
         v["client_context_id"] = ctx.client_context_id;
         v["index_name"] = ctx.index_name;

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -30,6 +30,7 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::search> {
+    TAO_JSON_DEFAULT_KEY("search");
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::search& ctx)
     {

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -70,10 +70,10 @@ struct traits<couchbase::core::error_context::search> {
         ctx.query = v.at("query").get_string();
         ctx.method = v.at("method").get_string();
         ctx.path = v.at("path").get_string();
-        ctx.http_status = v.at("http_status").get_unsigned();
+        ctx.http_status = static_cast<uint32_t>(v.at("http_status").get_unsigned());
         ctx.http_body = v.at("http_body").get_string();
         ctx.hostname = v.at("hostname").get_string();
-        ctx.port = v.at("port").get_unsigned();
+        ctx.port = static_cast<uint16_t>(v.at("port").get_unsigned());
         if (const auto& parameters = v.find("parameters"); parameters != nullptr && parameters->is_string()) {
             ctx.parameters = parameters->get_string();
         }
@@ -82,10 +82,12 @@ struct traits<couchbase::core::error_context::search> {
                 ctx.retry_reasons.insert(couchbase::retry_reason_to_enum(retry_reason.get_string()));
             }
         }
-        if (const auto& last_dispatched_from = v.find("last_dispatched_from"); last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
+        if (const auto& last_dispatched_from = v.find("last_dispatched_from");
+            last_dispatched_from != nullptr && last_dispatched_from->is_string()) {
             ctx.last_dispatched_from = last_dispatched_from->get_string();
         }
-        if (const auto& last_dispatched_to = v.find("last_dispatched_to"); last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
+        if (const auto& last_dispatched_to = v.find("last_dispatched_to");
+            last_dispatched_to != nullptr && last_dispatched_to->is_string()) {
             ctx.last_dispatched_to = last_dispatched_to->get_string();
         }
         return ctx;

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -18,12 +18,13 @@
 #pragma once
 
 #include <core/error_context/search.hxx>
+#include <core/impl/retry_reason.hxx>
+
 #include <couchbase/error_codes.hxx>
+#include <couchbase/fmt/retry_reason.hxx>
 
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
-
-#include <couchbase/fmt/retry_reason.hxx>
 
 namespace tao::json
 {

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -30,7 +30,6 @@ namespace tao::json
 {
 template<>
 struct traits<couchbase::core::error_context::search> {
-    TAO_JSON_DEFAULT_KEY("search");
     template<template<typename...> class Traits>
     static void assign(tao::json::basic_value<Traits>& v, const couchbase::core::error_context::search& ctx)
     {

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -183,16 +183,18 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
 
     void query(std::string statement, query_options::built options, query_handler&& handler) const
     {
-        return core_.execute(
-          core::impl::build_query_request(std::move(statement), {}, std::move(options)),
-          [handler = std::move(handler)](auto resp) { return handler(make_error(resp.ctx), core::impl::build_result(resp)); });
+        return core_.execute(core::impl::build_query_request(std::move(statement), {}, std::move(options)),
+                             [handler = std::move(handler)](auto resp) {
+                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                             });
     }
 
     void analytics_query(std::string statement, analytics_options::built options, analytics_handler&& handler) const
     {
-        return core_.execute(
-          core::impl::build_analytics_request(std::move(statement), std::move(options), {}, {}),
-          [handler = std::move(handler)](auto resp) { return handler(make_error(resp.ctx), core::impl::build_result(resp)); });
+        return core_.execute(core::impl::build_analytics_request(std::move(statement), std::move(options), {}, {}),
+                             [handler = std::move(handler)](auto resp) {
+                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                             });
     }
 
     void search_query(std::string index_name,
@@ -202,8 +204,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), query, options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(make_error(resp.ctx),
-                                                search_result{ internal_search_result{ resp } });
+                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -213,13 +214,16 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
                           {},
                           core::impl::to_core_service_types(options.service_types),
                           options.timeout,
-                          [handler = std::move(handler)](auto resp) mutable { return handler(core::impl::build_result(resp)); });
+                          [handler = std::move(handler)](auto resp) mutable {
+                              return handler(core::impl::build_result(resp));
+                          });
     };
 
     void diagnostics(const diagnostics_options::built& options, diagnostics_handler&& handler) const
     {
-        return core_.diagnostics(options.report_id,
-                                 [handler = std::move(handler)](auto resp) mutable { return handler(core::impl::build_result(resp)); });
+        return core_.diagnostics(options.report_id, [handler = std::move(handler)](auto resp) mutable {
+            return handler(core::impl::build_result(resp));
+        });
     }
 
     void search(std::string index_name,
@@ -229,8 +233,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), std::move(request), options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(make_error(resp.ctx),
-                                                search_result{ internal_search_result{ resp } });
+                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -301,7 +304,9 @@ cluster::query(std::string statement, const query_options& options) const -> std
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, query_result>>>();
     auto future = barrier->get_future();
-    query(std::move(statement), options, [barrier](auto ctx, auto result) { barrier->set_value({ std::move(ctx), std::move(result) }); });
+    query(std::move(statement), options, [barrier](auto ctx, auto result) {
+        barrier->set_value({ std::move(ctx), std::move(result) });
+    });
     return future;
 }
 
@@ -312,8 +317,7 @@ cluster::analytics_query(std::string statement, const analytics_options& options
 }
 
 auto
-cluster::analytics_query(std::string statement, const analytics_options& options) const
-  -> std::future<std::pair<error, analytics_result>>
+cluster::analytics_query(std::string statement, const analytics_options& options) const -> std::future<std::pair<error, analytics_result>>
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, analytics_result>>>();
     auto future = barrier->get_future();
@@ -333,7 +337,9 @@ auto
 cluster::ping(const couchbase::ping_options& options) const -> std::future<ping_result>
 {
     auto barrier = std::make_shared<std::promise<ping_result>>();
-    ping(options, [barrier](auto result) mutable { barrier->set_value(std::move(result)); });
+    ping(options, [barrier](auto result) mutable {
+        barrier->set_value(std::move(result));
+    });
     return barrier->get_future();
 }
 
@@ -347,7 +353,9 @@ auto
 cluster::diagnostics(const couchbase::diagnostics_options& options) const -> std::future<diagnostics_result>
 {
     auto barrier = std::make_shared<std::promise<diagnostics_result>>();
-    diagnostics(options, [barrier](auto result) mutable { barrier->set_value(std::move(result)); });
+    diagnostics(options, [barrier](auto result) mutable {
+        barrier->set_value(std::move(result));
+    });
     return barrier->get_future();
 }
 
@@ -373,7 +381,9 @@ cluster::connect(asio::io_context& io, const std::string& connection_string, con
   -> std::future<std::pair<cluster, std::error_code>>
 {
     auto barrier = std::make_shared<std::promise<std::pair<cluster, std::error_code>>>();
-    connect(io, connection_string, options, [barrier](auto c, auto ec) mutable { barrier->set_value({ std::move(c), ec }); });
+    connect(io, connection_string, options, [barrier](auto c, auto ec) mutable {
+        barrier->set_value({ std::move(c), ec });
+    });
     return barrier->get_future();
 }
 
@@ -392,7 +402,9 @@ cluster::connect(asio::io_context& io,
         auto cluster = couchbase::cluster(std::move(core));
         return cluster.impl_->initialize_transactions([cluster, handler = std::move(handler)](std::error_code ec) mutable {
             if (ec) {
-                return cluster.impl_->close([ec, handler = std::move(handler)]() mutable { return handler({}, ec); });
+                return cluster.impl_->close([ec, handler = std::move(handler)]() mutable {
+                    return handler({}, ec);
+                });
             }
             return handler(cluster, ec);
         });

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -22,6 +22,7 @@
 #include "core/transactions.hxx"
 #include "core/utils/connection_string.hxx"
 #include "diagnostics.hxx"
+#include "error.hxx"
 #include "internal_search_error_context.hxx"
 #include "internal_search_meta_data.hxx"
 #include "internal_search_result.hxx"
@@ -149,7 +150,6 @@ options_to_origin(const std::string& connection_string, const couchbase::cluster
     // connection string might override some user options
     return { auth, couchbase::core::utils::parse_connection_string(connection_string, user_options) };
 }
-
 } // namespace
 
 class cluster_impl : public std::enable_shared_from_this<cluster_impl>
@@ -185,14 +185,14 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(
           core::impl::build_query_request(std::move(statement), {}, std::move(options)),
-          [handler = std::move(handler)](auto resp) { return handler(core::impl::build_context(resp), core::impl::build_result(resp)); });
+          [handler = std::move(handler)](auto resp) { return handler(make_error(resp.ctx), core::impl::build_result(resp)); });
     }
 
     void analytics_query(std::string statement, analytics_options::built options, analytics_handler&& handler) const
     {
         return core_.execute(
           core::impl::build_analytics_request(std::move(statement), std::move(options), {}, {}),
-          [handler = std::move(handler)](auto resp) { return handler(core::impl::build_context(resp), core::impl::build_result(resp)); });
+          [handler = std::move(handler)](auto resp) { return handler(make_error(resp.ctx), core::impl::build_result(resp)); });
     }
 
     void search_query(std::string index_name,
@@ -202,7 +202,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), query, options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(search_error_context{ internal_search_error_context{ resp } },
+                                 return handler(make_error(resp.ctx),
                                                 search_result{ internal_search_result{ resp } });
                              });
     }
@@ -229,7 +229,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), std::move(request), options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(search_error_context{ internal_search_error_context{ resp } },
+                                 return handler(make_error(resp.ctx),
                                                 search_result{ internal_search_result{ resp } });
                              });
     }
@@ -297,9 +297,9 @@ cluster::query(std::string statement, const query_options& options, query_handle
 }
 
 auto
-cluster::query(std::string statement, const query_options& options) const -> std::future<std::pair<query_error_context, query_result>>
+cluster::query(std::string statement, const query_options& options) const -> std::future<std::pair<error, query_result>>
 {
-    auto barrier = std::make_shared<std::promise<std::pair<query_error_context, query_result>>>();
+    auto barrier = std::make_shared<std::promise<std::pair<error, query_result>>>();
     auto future = barrier->get_future();
     query(std::move(statement), options, [barrier](auto ctx, auto result) { barrier->set_value({ std::move(ctx), std::move(result) }); });
     return future;
@@ -313,34 +313,14 @@ cluster::analytics_query(std::string statement, const analytics_options& options
 
 auto
 cluster::analytics_query(std::string statement, const analytics_options& options) const
-  -> std::future<std::pair<analytics_error_context, analytics_result>>
+  -> std::future<std::pair<error, analytics_result>>
 {
-    auto barrier = std::make_shared<std::promise<std::pair<analytics_error_context, analytics_result>>>();
+    auto barrier = std::make_shared<std::promise<std::pair<error, analytics_result>>>();
     auto future = barrier->get_future();
     analytics_query(std::move(statement), options, [barrier](auto ctx, auto result) {
         barrier->set_value({ std::move(ctx), std::move(result) });
     });
     return future;
-}
-
-void
-cluster::search_query(std::string index_name,
-                      const class search_query& query,
-                      const search_options& options,
-                      search_handler&& handler) const
-{
-    return impl_->search_query(std::move(index_name), query, options.build(), std::move(handler));
-}
-
-auto
-cluster::search_query(std::string index_name, const class search_query& query, const search_options& options) const
-  -> std::future<std::pair<search_error_context, search_result>>
-{
-    auto barrier = std::make_shared<std::promise<std::pair<search_error_context, search_result>>>();
-    search_query(std::move(index_name), query, options, [barrier](auto ctx, auto result) mutable {
-        barrier->set_value(std::make_pair(std::move(ctx), std::move(result)));
-    });
-    return barrier->get_future();
 }
 
 void
@@ -379,11 +359,11 @@ cluster::search(std::string index_name, search_request request, const search_opt
 
 auto
 cluster::search(std::string index_name, search_request request, const search_options& options) const
-  -> std::future<std::pair<search_error_context, search_result>>
+  -> std::future<std::pair<error, search_result>>
 {
-    auto barrier = std::make_shared<std::promise<std::pair<search_error_context, search_result>>>();
-    search(std::move(index_name), std::move(request), options, [barrier](auto ctx, auto result) mutable {
-        barrier->set_value(std::make_pair(std::move(ctx), std::move(result)));
+    auto barrier = std::make_shared<std::promise<std::pair<error, search_result>>>();
+    search(std::move(index_name), std::move(request), options, [barrier](auto error, auto result) mutable {
+        barrier->set_value(std::make_pair(std::move(error), std::move(result)));
     });
     return barrier->get_future();
 }

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -304,8 +304,8 @@ cluster::query(std::string statement, const query_options& options) const -> std
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, query_result>>>();
     auto future = barrier->get_future();
-    query(std::move(statement), options, [barrier](auto ctx, auto result) {
-        barrier->set_value({ std::move(ctx), std::move(result) });
+    query(std::move(statement), options, [barrier](auto err, auto result) {
+        barrier->set_value({ std::move(err), std::move(result) });
     });
     return future;
 }
@@ -321,8 +321,8 @@ cluster::analytics_query(std::string statement, const analytics_options& options
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, analytics_result>>>();
     auto future = barrier->get_future();
-    analytics_query(std::move(statement), options, [barrier](auto ctx, auto result) {
-        barrier->set_value({ std::move(ctx), std::move(result) });
+    analytics_query(std::move(statement), options, [barrier](auto err, auto result) {
+        barrier->set_value({ std::move(err), std::move(result) });
     });
     return future;
 }
@@ -373,8 +373,8 @@ cluster::search_query(std::string index_name, const class search_query& query, c
   -> std::future<std::pair<error, search_result>>
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, search_result>>>();
-    search_query(std::move(index_name), query, options, [barrier](auto ctx, auto result) mutable {
-        barrier->set_value(std::make_pair(std::move(ctx), std::move(result)));
+    search_query(std::move(index_name), query, options, [barrier](auto err, auto result) mutable {
+        barrier->set_value(std::make_pair(std::move(err), std::move(result)));
     });
     return barrier->get_future();
 }

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -185,7 +185,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_query_request(std::move(statement), {}, std::move(options)),
                              [handler = std::move(handler)](auto resp) {
-                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                                 return handler(core::impl::make_error(resp.ctx), core::impl::build_result(resp));
                              });
     }
 
@@ -193,7 +193,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_analytics_request(std::move(statement), std::move(options), {}, {}),
                              [handler = std::move(handler)](auto resp) {
-                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                                 return handler(core::impl::make_error(resp.ctx), core::impl::build_result(resp));
                              });
     }
 
@@ -204,7 +204,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), query, options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
+                                 return handler(core::impl::make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -233,7 +233,7 @@ class cluster_impl : public std::enable_shared_from_this<cluster_impl>
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), std::move(request), options, {}, {}),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
+                                 return handler(core::impl::make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -78,6 +78,8 @@ error::operator bool() const
     return ec_.value() != 0;
 }
 
+namespace core::impl
+{
 error
 make_error(const core::error_context::query& core_ctx)
 {
@@ -101,4 +103,5 @@ make_error(const core::error_context::http& core_ctx)
 {
     return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
+} // namespace core::impl
 } // namespace couchbase

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -81,41 +81,25 @@ error::operator bool() const
 error
 make_error(const core::error_context::query& core_ctx)
 {
-    return {
-        core_ctx.ec,
-          core_ctx.ec.message(),
-          couchbase::error_context{ internal_error_context(core_ctx) }
-    };
+    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::search& core_ctx)
 {
-    return {
-        core_ctx.ec,
-        core_ctx.ec.message(),
-        couchbase::error_context{ internal_error_context(core_ctx) }
-    };
+    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::analytics& core_ctx)
 {
-    return {
-        core_ctx.ec,
-        core_ctx.ec.message(),
-        couchbase::error_context{ internal_error_context(core_ctx) }
-    };
+    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::http& core_ctx)
 {
-    return {
-        core_ctx.ec,
-        core_ctx.ec.message(),
-        couchbase::error_context{ internal_error_context(core_ctx) }
-    };
+    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -81,33 +81,24 @@ error::operator bool() const
 error
 make_error(const core::error_context::query& core_ctx)
 {
-    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
+    return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::search& core_ctx)
 {
-    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
+    return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::analytics& core_ctx)
 {
-    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
+    return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
 error
 make_error(const core::error_context::http& core_ctx)
 {
-    return { core_ctx.ec, core_ctx.ec.message(), couchbase::error_context{ internal_error_context(core_ctx) } };
-}
-
-error
-make_error(core::error_context::http core_ctx, std::optional<std::error_code> ec)
-{
-    if (ec.has_value()) {
-        core_ctx.ec = ec.value();
-    }
-    return make_error(core_ctx);
+    return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 } // namespace couchbase

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -15,12 +15,16 @@
  *   limitations under the License.
  */
 
-#include <couchbase/error_context.hxx>
 #include <couchbase/error.hxx>
+#include <couchbase/error_context.hxx>
+
+#include <core/error_context/analytics_json.hxx>
+#include <core/error_context/http_json.hxx>
+#include <core/error_context/query_json.hxx>
+#include <core/error_context/search_json.hxx>
 
 #include <memory>
 #include <optional>
-#include <string>
 #include <system_error>
 #include <utility>
 
@@ -72,5 +76,54 @@ error::cause() const -> std::optional<error>
 error::operator bool() const
 {
     return ec_.value() != 0;
+}
+
+error
+make_error(const core::error_context::query& core_ctx)
+{
+    return {
+        core_ctx.ec,
+          core_ctx.ec.message(),
+          couchbase::error_context{ internal_error_context(core_ctx) }
+    };
+}
+
+error
+make_error(const core::error_context::search& core_ctx)
+{
+    return {
+        core_ctx.ec,
+        core_ctx.ec.message(),
+        couchbase::error_context{ internal_error_context(core_ctx) }
+    };
+}
+
+error
+make_error(const core::error_context::analytics& core_ctx)
+{
+    return {
+        core_ctx.ec,
+        core_ctx.ec.message(),
+        couchbase::error_context{ internal_error_context(core_ctx) }
+    };
+}
+
+error
+make_error(const core::error_context::http& core_ctx)
+{
+    return {
+        core_ctx.ec,
+        core_ctx.ec.message(),
+        couchbase::error_context{ internal_error_context(core_ctx) }
+    };
+}
+
+error
+make_error(core::error_context::http core_ctx, std::optional<std::error_code> ec)
+{
+    if (ec.has_value()) {
+        core_ctx.ec = ec.value();
+    }
+    return make_error(core_ctx);
 }
 } // namespace couchbase

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <core/error_context/analytics.hxx>
+#include <core/error_context/http.hxx>
 #include <core/error_context/query.hxx>
 #include <core/error_context/search.hxx>
-#include <core/error_context/http.hxx>
 
 #include <couchbase/error.hxx>
 

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2024. Couchbase, Inc.
+ *   Copyright 2020-2021 Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,25 +17,26 @@
 
 #pragma once
 
-#include <string>
+#include <core/error_context/analytics.hxx>
+#include <core/error_context/query.hxx>
+#include <core/error_context/search.hxx>
 
-#include <tao/json/value.hpp>
+#include <couchbase/error.hxx>
 
 namespace couchbase
 {
-using internal_error_context = tao::json::value;
+error
+make_error(const core::error_context::query& core_ctx);
 
-class error_context
-{
-  public:
-    error_context() = default;
-    explicit error_context(internal_error_context internal);
+error
+make_error(const core::error_context::search& core_ctx);
 
-    [[nodiscard]] auto to_string() const -> std::string;
-    [[nodiscard]] auto to_json() const -> std::string;
+error
+make_error(const core::error_context::analytics& core_ctx);
 
-  private:
-    internal_error_context internal_;
-};
+error
+make_error(const core::error_context::http& core_ctx);
 
+error
+make_error(core::error_context::http core_ctx, std::optional<std::error_code>);
 } // namespace couchbase

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -1,6 +1,6 @@
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- *   Copyright 2020-2021 Couchbase, Inc.
+ *   Copyright 2024. Couchbase, Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 
 #include <couchbase/error.hxx>
 
-namespace couchbase
+namespace couchbase::core::impl
 {
 error
 make_error(const core::error_context::query& core_ctx);
@@ -37,4 +37,4 @@ make_error(const core::error_context::analytics& core_ctx);
 
 error
 make_error(const core::error_context::http& core_ctx);
-} // namespace couchbase
+} // namespace couchbase::core::impl

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -20,6 +20,7 @@
 #include <core/error_context/analytics.hxx>
 #include <core/error_context/query.hxx>
 #include <core/error_context/search.hxx>
+#include <core/error_context/http.hxx>
 
 #include <couchbase/error.hxx>
 

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -37,7 +37,4 @@ make_error(const core::error_context::analytics& core_ctx);
 
 error
 make_error(const core::error_context::http& core_ctx);
-
-error
-make_error(core::error_context::http core_ctx, std::optional<std::error_code>);
 } // namespace couchbase

--- a/core/impl/retry_reason.cxx
+++ b/core/impl/retry_reason.cxx
@@ -82,4 +82,51 @@ always_retry(retry_reason reason)
     return false;
 }
 
+auto retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason
+{
+    if (reason == "do_not_retry") {
+        return couchbase::retry_reason::do_not_retry;
+    } if (reason == "unknown") {
+        return couchbase::retry_reason::unknown;
+    } if (reason == "socket_not_available") {
+        return couchbase::retry_reason::socket_not_available;
+    } if (reason == "service_not_available") {
+        return couchbase::retry_reason::service_not_available;
+    } if (reason == "node_not_available") {
+        return couchbase::retry_reason::node_not_available;
+    } if (reason == "kv_not_my_vbucket") {
+        return couchbase::retry_reason::key_value_not_my_vbucket;
+    } if (reason == "kv_collection_outdated") {
+        return couchbase::retry_reason::key_value_collection_outdated;
+    } if (reason == "kv_error_map_retry_indicated") {
+        return couchbase::retry_reason::key_value_error_map_retry_indicated;
+    } if (reason == "kv_locked") {
+        return couchbase::retry_reason::key_value_locked;
+    } if (reason == "kv_temporary_failure") {
+        return couchbase::retry_reason::key_value_temporary_failure;
+    } if (reason == "kv_sync_write_in_progress") {
+        return couchbase::retry_reason::key_value_sync_write_in_progress;
+    } if (reason == "kv_sync_write_re_commit_in_progress") {
+        return couchbase::retry_reason::key_value_sync_write_re_commit_in_progress;
+    } if (reason == "service_response_code_indicated") {
+        return couchbase::retry_reason::service_response_code_indicated;
+    } if (reason == "socket_closed_while_in_flight") {
+        return couchbase::retry_reason::socket_closed_while_in_flight;
+    } if (reason == "circuit_breaker_open") {
+        return couchbase::retry_reason::circuit_breaker_open;
+    } if (reason == "query_prepared_statement_failure") {
+        return couchbase::retry_reason::query_prepared_statement_failure;
+    } if (reason == "query_index_not_found") {
+        return couchbase::retry_reason::query_index_not_found;
+    } if (reason == "analytics_temporary_failure") {
+        return couchbase::retry_reason::analytics_temporary_failure;
+    } if (reason == "search_too_many_requests") {
+        return couchbase::retry_reason::search_too_many_requests;
+    } if (reason == "views_temporary_failure") {
+        return couchbase::retry_reason::views_temporary_failure;
+    } if (reason == "views_no_active_partition") {
+        return couchbase::retry_reason::views_no_active_partition;
+    }
+    return couchbase::retry_reason::unknown;
+}
 } // namespace couchbase

--- a/core/impl/retry_reason.cxx
+++ b/core/impl/retry_reason.cxx
@@ -17,6 +17,8 @@
 
 #include <couchbase/retry_reason.hxx>
 
+#include <string>
+
 namespace couchbase
 {
 bool

--- a/core/impl/retry_reason.cxx
+++ b/core/impl/retry_reason.cxx
@@ -84,6 +84,8 @@ always_retry(retry_reason reason)
     return false;
 }
 
+namespace core::impl
+{
 auto
 retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason
 {
@@ -152,4 +154,5 @@ retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason
     }
     return couchbase::retry_reason::unknown;
 }
+} // namespace core::impl
 } // namespace couchbase

--- a/core/impl/retry_reason.cxx
+++ b/core/impl/retry_reason.cxx
@@ -82,49 +82,70 @@ always_retry(retry_reason reason)
     return false;
 }
 
-auto retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason
+auto
+retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason
 {
     if (reason == "do_not_retry") {
         return couchbase::retry_reason::do_not_retry;
-    } if (reason == "unknown") {
+    }
+    if (reason == "unknown") {
         return couchbase::retry_reason::unknown;
-    } if (reason == "socket_not_available") {
+    }
+    if (reason == "socket_not_available") {
         return couchbase::retry_reason::socket_not_available;
-    } if (reason == "service_not_available") {
+    }
+    if (reason == "service_not_available") {
         return couchbase::retry_reason::service_not_available;
-    } if (reason == "node_not_available") {
+    }
+    if (reason == "node_not_available") {
         return couchbase::retry_reason::node_not_available;
-    } if (reason == "kv_not_my_vbucket") {
+    }
+    if (reason == "kv_not_my_vbucket") {
         return couchbase::retry_reason::key_value_not_my_vbucket;
-    } if (reason == "kv_collection_outdated") {
+    }
+    if (reason == "kv_collection_outdated") {
         return couchbase::retry_reason::key_value_collection_outdated;
-    } if (reason == "kv_error_map_retry_indicated") {
+    }
+    if (reason == "kv_error_map_retry_indicated") {
         return couchbase::retry_reason::key_value_error_map_retry_indicated;
-    } if (reason == "kv_locked") {
+    }
+    if (reason == "kv_locked") {
         return couchbase::retry_reason::key_value_locked;
-    } if (reason == "kv_temporary_failure") {
+    }
+    if (reason == "kv_temporary_failure") {
         return couchbase::retry_reason::key_value_temporary_failure;
-    } if (reason == "kv_sync_write_in_progress") {
+    }
+    if (reason == "kv_sync_write_in_progress") {
         return couchbase::retry_reason::key_value_sync_write_in_progress;
-    } if (reason == "kv_sync_write_re_commit_in_progress") {
+    }
+    if (reason == "kv_sync_write_re_commit_in_progress") {
         return couchbase::retry_reason::key_value_sync_write_re_commit_in_progress;
-    } if (reason == "service_response_code_indicated") {
+    }
+    if (reason == "service_response_code_indicated") {
         return couchbase::retry_reason::service_response_code_indicated;
-    } if (reason == "socket_closed_while_in_flight") {
+    }
+    if (reason == "socket_closed_while_in_flight") {
         return couchbase::retry_reason::socket_closed_while_in_flight;
-    } if (reason == "circuit_breaker_open") {
+    }
+    if (reason == "circuit_breaker_open") {
         return couchbase::retry_reason::circuit_breaker_open;
-    } if (reason == "query_prepared_statement_failure") {
+    }
+    if (reason == "query_prepared_statement_failure") {
         return couchbase::retry_reason::query_prepared_statement_failure;
-    } if (reason == "query_index_not_found") {
+    }
+    if (reason == "query_index_not_found") {
         return couchbase::retry_reason::query_index_not_found;
-    } if (reason == "analytics_temporary_failure") {
+    }
+    if (reason == "analytics_temporary_failure") {
         return couchbase::retry_reason::analytics_temporary_failure;
-    } if (reason == "search_too_many_requests") {
+    }
+    if (reason == "search_too_many_requests") {
         return couchbase::retry_reason::search_too_many_requests;
-    } if (reason == "views_temporary_failure") {
+    }
+    if (reason == "views_temporary_failure") {
         return couchbase::retry_reason::views_temporary_failure;
-    } if (reason == "views_no_active_partition") {
+    }
+    if (reason == "views_no_active_partition") {
         return couchbase::retry_reason::views_no_active_partition;
     }
     return couchbase::retry_reason::unknown;

--- a/core/impl/retry_reason.hxx
+++ b/core/impl/retry_reason.hxx
@@ -21,8 +21,8 @@
 
 #include <string>
 
-namespace couchbase
+namespace couchbase::core::impl
 {
 auto
 retry_reason_to_enum(const std::string& reason) -> retry_reason;
-} // namespace couchbase
+} // namespace couchbase::core::impl

--- a/core/impl/retry_reason.hxx
+++ b/core/impl/retry_reason.hxx
@@ -1,0 +1,28 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/retry_reason.hxx>
+
+#include <string>
+
+namespace couchbase
+{
+auto
+retry_reason_to_enum(const std::string& reason) -> retry_reason;
+} // namespace couchbase

--- a/core/impl/scope.cxx
+++ b/core/impl/scope.cxx
@@ -67,7 +67,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_query_request(std::move(statement), query_context_, std::move(options)),
                              [handler = std::move(handler)](auto resp) {
-                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                                 return handler(core::impl::make_error(resp.ctx), core::impl::build_result(resp));
                              });
     }
 
@@ -75,7 +75,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_analytics_request(std::move(statement), std::move(options), bucket_name_, name_),
                              [handler = std::move(handler)](auto resp) mutable {
-                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                                 return handler(core::impl::make_error(resp.ctx), core::impl::build_result(resp));
                              });
     }
 
@@ -86,7 +86,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), query, options, bucket_name_, name_),
                              [handler = std::move(handler)](auto&& resp) mutable {
-                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
+                                 return handler(core::impl::make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -94,7 +94,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), std::move(request), options, bucket_name_, name_),
                              [handler = std::move(handler)](auto&& resp) mutable {
-                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
+                                 return handler(core::impl::make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 

--- a/core/impl/scope.cxx
+++ b/core/impl/scope.cxx
@@ -139,8 +139,8 @@ scope::query(std::string statement, const query_options& options) const -> std::
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, query_result>>>();
     auto future = barrier->get_future();
-    query(std::move(statement), options, [barrier](auto ctx, auto result) {
-        barrier->set_value({ std::move(ctx), std::move(result) });
+    query(std::move(statement), options, [barrier](auto err, auto result) {
+        barrier->set_value({ std::move(err), std::move(result) });
     });
     return future;
 }
@@ -156,8 +156,8 @@ scope::analytics_query(std::string statement, const analytics_options& options) 
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, analytics_result>>>();
     auto future = barrier->get_future();
-    analytics_query(std::move(statement), options, [barrier](auto ctx, auto result) {
-        barrier->set_value({ std::move(ctx), std::move(result) });
+    analytics_query(std::move(statement), options, [barrier](auto err, auto result) {
+        barrier->set_value({ std::move(err), std::move(result) });
     });
     return future;
 }
@@ -174,8 +174,8 @@ scope::search(std::string index_name, search_request request, const search_optio
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, search_result>>>();
     auto future = barrier->get_future();
-    search(std::move(index_name), std::move(request), options, [barrier](auto ctx, auto result) {
-        barrier->set_value({ std::move(ctx), std::move(result) });
+    search(std::move(index_name), std::move(request), options, [barrier](auto err, auto result) {
+        barrier->set_value({ std::move(err), std::move(result) });
     });
     return future;
 }

--- a/core/impl/scope.cxx
+++ b/core/impl/scope.cxx
@@ -65,9 +65,10 @@ class scope_impl
 
     void query(std::string statement, query_options::built options, query_handler&& handler) const
     {
-        return core_.execute(
-          core::impl::build_query_request(std::move(statement), query_context_, std::move(options)),
-          [handler = std::move(handler)](auto resp) { return handler(make_error(resp.ctx), core::impl::build_result(resp)); });
+        return core_.execute(core::impl::build_query_request(std::move(statement), query_context_, std::move(options)),
+                             [handler = std::move(handler)](auto resp) {
+                                 return handler(make_error(resp.ctx), core::impl::build_result(resp));
+                             });
     }
 
     void analytics_query(std::string statement, analytics_options::built options, analytics_handler&& handler) const
@@ -85,8 +86,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), query, options, bucket_name_, name_),
                              [handler = std::move(handler)](auto&& resp) mutable {
-                                 return handler(make_error(resp.ctx),
-                                                search_result{ internal_search_result{ resp } });
+                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -94,8 +94,7 @@ class scope_impl
     {
         return core_.execute(core::impl::build_search_request(std::move(index_name), std::move(request), options, bucket_name_, name_),
                              [handler = std::move(handler)](auto&& resp) mutable {
-                                 return handler(make_error(resp.ctx),
-                                                search_result{ internal_search_result{ resp } });
+                                 return handler(make_error(resp.ctx), search_result{ internal_search_result{ resp } });
                              });
     }
 
@@ -140,7 +139,9 @@ scope::query(std::string statement, const query_options& options) const -> std::
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, query_result>>>();
     auto future = barrier->get_future();
-    query(std::move(statement), options, [barrier](auto ctx, auto result) { barrier->set_value({ std::move(ctx), std::move(result) }); });
+    query(std::move(statement), options, [barrier](auto ctx, auto result) {
+        barrier->set_value({ std::move(ctx), std::move(result) });
+    });
     return future;
 }
 
@@ -151,8 +152,7 @@ scope::analytics_query(std::string statement, const analytics_options& options, 
 }
 
 auto
-scope::analytics_query(std::string statement, const analytics_options& options) const
-  -> std::future<std::pair<error, analytics_result>>
+scope::analytics_query(std::string statement, const analytics_options& options) const -> std::future<std::pair<error, analytics_result>>
 {
     auto barrier = std::make_shared<std::promise<std::pair<error, analytics_result>>>();
     auto future = barrier->get_future();

--- a/couchbase/analytics_options.hxx
+++ b/couchbase/analytics_options.hxx
@@ -356,5 +356,5 @@ struct analytics_options : public common_options<analytics_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using analytics_handler = std::function<void(couchbase::error, analytics_result)>;
+using analytics_handler = std::function<void(error, analytics_result)>;
 } // namespace couchbase

--- a/couchbase/analytics_options.hxx
+++ b/couchbase/analytics_options.hxx
@@ -22,6 +22,7 @@
 #include <couchbase/analytics_scan_consistency.hxx>
 #include <couchbase/codec/tao_json_serializer.hxx>
 #include <couchbase/common_options.hxx>
+#include <couchbase/error.hxx>
 #include <couchbase/mutation_state.hxx>
 
 #include <chrono>
@@ -355,5 +356,5 @@ struct analytics_options : public common_options<analytics_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using analytics_handler = std::function<void(couchbase::analytics_error_context, analytics_result)>;
+using analytics_handler = std::function<void(couchbase::error, analytics_result)>;
 } // namespace couchbase

--- a/couchbase/base_error_context.hxx
+++ b/couchbase/base_error_context.hxx
@@ -59,11 +59,11 @@ class base_error_context
      * @internal
      */
     base_error_context(std::string operation_id,
-                  std::error_code ec,
-                  std::optional<std::string> last_dispatched_to,
-                  std::optional<std::string> last_dispatched_from,
-                  std::size_t retry_attempts,
-                  std::set<retry_reason> retry_reasons)
+                       std::error_code ec,
+                       std::optional<std::string> last_dispatched_to,
+                       std::optional<std::string> last_dispatched_from,
+                       std::size_t retry_attempts,
+                       std::set<retry_reason> retry_reasons)
       : operation_id_{ std::move(operation_id) }
       , ec_{ ec }
       , last_dispatched_to_{ std::move(last_dispatched_to) }

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -160,6 +160,49 @@ class cluster
     [[nodiscard]] auto query(std::string statement, const query_options& options) const -> std::future<std::pair<error, query_result>>;
 
     /**
+     * Performs a query against the full text search services.
+     *
+     * Consider using the newer @ref cluster::search() interface instead, which can be used
+     * for both traditional FTS queries, and to perform a @ref vector_search
+     *
+     * @param index_name name of the search index
+     * @param query query object, see hierarchy of @ref search_query for more details.
+     * @param options options to customize the query request.
+     * @param handler the handler that implements @ref search_handler
+     *
+     * @exception errc::common::ambiguous_timeout
+     * @exception errc::common::unambiguous_timeout
+     *
+     * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    void search_query(std::string index_name, const search_query& query, const search_options& options, search_handler&& handler) const;
+
+    /**
+     * Performs a query against the full text search services.
+     *
+     * Consider using the newer @ref cluster::search() interface instead, which can be used
+     * for both traditional FTS queries, and to perform a vector search.
+     *
+     * @param index_name name of the search index
+     * @param query query object, see hierarchy of @ref search_query for more details.
+     * @param options options to customize the query request.
+     * @return future object that carries result of the operation
+     *
+     * @exception errc::common::ambiguous_timeout
+     * @exception errc::common::unambiguous_timeout
+     *
+     * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
+     *
+     * @since 1.0.0
+     * @committed
+     */
+    [[nodiscard]] auto search_query(std::string index_name, const class search_query& query, const search_options& options = {}) const
+      -> std::future<std::pair<error, search_result>>;
+
+    /**
      * Performs a request against the full text search services.
      *
      * This can be used to perform a traditional FTS query, and/or a vector search.

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -158,50 +158,7 @@ class cluster
      * @committed
      */
     [[nodiscard]] auto query(std::string statement, const query_options& options) const
-      -> std::future<std::pair<query_error_context, query_result>>;
-
-    /**
-     * Performs a query against the full text search services.
-     *
-     * Consider using the newer @ref cluster::search() interface instead, which can be used
-     * for both traditional FTS queries, and to perform a @ref vector_search
-     *
-     * @param index_name name of the search index
-     * @param query query object, see hierarchy of @ref search_query for more details.
-     * @param options options to customize the query request.
-     * @param handler the handler that implements @ref search_handler
-     *
-     * @exception errc::common::ambiguous_timeout
-     * @exception errc::common::unambiguous_timeout
-     *
-     * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
-     *
-     * @since 1.0.0
-     * @committed
-     */
-    void search_query(std::string index_name, const search_query& query, const search_options& options, search_handler&& handler) const;
-
-    /**
-     * Performs a query against the full text search services.
-     *
-     * Consider using the newer @ref cluster::search() interface instead, which can be used
-     * for both traditional FTS queries, and to perform a vector search.
-     *
-     * @param index_name name of the search index
-     * @param query query object, see hierarchy of @ref search_query for more details.
-     * @param options options to customize the query request.
-     * @return future object that carries result of the operation
-     *
-     * @exception errc::common::ambiguous_timeout
-     * @exception errc::common::unambiguous_timeout
-     *
-     * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
-     *
-     * @since 1.0.0
-     * @committed
-     */
-    [[nodiscard]] auto search_query(std::string index_name, const class search_query& query, const search_options& options = {}) const
-      -> std::future<std::pair<search_error_context, search_result>>;
+      -> std::future<std::pair<error, query_result>>;
 
     /**
      * Performs a request against the full text search services.
@@ -242,7 +199,7 @@ class cluster
      * @volatile
      */
     [[nodiscard]] auto search(std::string index_name, search_request request, const search_options& options = {}) const
-      -> std::future<std::pair<search_error_context, search_result>>;
+      -> std::future<std::pair<error, search_result>>;
 
     /**
      * Performs a query against the analytics services.
@@ -274,7 +231,7 @@ class cluster
      * @committed
      */
     [[nodiscard]] auto analytics_query(std::string statement, const analytics_options& options = {}) const
-      -> std::future<std::pair<analytics_error_context, analytics_result>>;
+      -> std::future<std::pair<error, analytics_result>>;
 
     /**
      * Performs application-level ping requests against services in the Couchbase cluster.

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -157,8 +157,7 @@ class cluster
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto query(std::string statement, const query_options& options) const
-      -> std::future<std::pair<error, query_result>>;
+    [[nodiscard]] auto query(std::string statement, const query_options& options) const -> std::future<std::pair<error, query_result>>;
 
     /**
      * Performs a request against the full text search services.

--- a/couchbase/error.hxx
+++ b/couchbase/error.hxx
@@ -29,6 +29,7 @@ namespace couchbase
 class error
 {
   public:
+    error() = default;
     error(std::error_code ec, std::string message, error_context ctx);
     error(std::error_code ec, std::string message, error_context ctx, error cause);
 
@@ -42,7 +43,7 @@ class error
   private:
     std::error_code ec_{};
     std::string message_{};
-    error_context ctx_;
+    error_context ctx_{};
     std::shared_ptr<error> cause_{};
 };
 

--- a/couchbase/error_context.hxx
+++ b/couchbase/error_context.hxx
@@ -34,8 +34,13 @@ class error_context
     [[nodiscard]] auto to_string() const -> std::string;
     [[nodiscard]] auto to_json() const -> std::string;
 
+    template<typename T>
+    T as() const
+    {
+        return internal_.as<T>();
+    }
+
   private:
     internal_error_context internal_;
 };
-
 } // namespace couchbase

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -19,12 +19,12 @@
 
 #include <couchbase/codec/tao_json_serializer.hxx>
 #include <couchbase/common_options.hxx>
+#include <couchbase/error.hxx>
 #include <couchbase/mutation_state.hxx>
 #include <couchbase/query_error_context.hxx>
 #include <couchbase/query_profile.hxx>
 #include <couchbase/query_result.hxx>
 #include <couchbase/query_scan_consistency.hxx>
-#include <couchbase/error.hxx>
 
 #include <chrono>
 #include <functional>

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -568,5 +568,5 @@ struct query_options : public common_options<query_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using query_handler = std::function<void(couchbase::error, query_result)>;
+using query_handler = std::function<void(error, query_result)>;
 } // namespace couchbase

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -24,6 +24,7 @@
 #include <couchbase/query_profile.hxx>
 #include <couchbase/query_result.hxx>
 #include <couchbase/query_scan_consistency.hxx>
+#include <couchbase/error.hxx>
 
 #include <chrono>
 #include <functional>
@@ -567,5 +568,5 @@ struct query_options : public common_options<query_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using query_handler = std::function<void(couchbase::query_error_context, query_result)>;
+using query_handler = std::function<void(couchbase::error, query_result)>;
 } // namespace couchbase

--- a/couchbase/retry_reason.hxx
+++ b/couchbase/retry_reason.hxx
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace couchbase
 {
 /**
@@ -98,6 +100,8 @@ enum class retry_reason {
 
     views_no_active_partition,
 };
+
+auto retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason;
 
 bool
 allows_non_idempotent_retry(retry_reason reason);

--- a/couchbase/retry_reason.hxx
+++ b/couchbase/retry_reason.hxx
@@ -101,7 +101,8 @@ enum class retry_reason {
     views_no_active_partition,
 };
 
-auto retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason;
+auto
+retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason;
 
 bool
 allows_non_idempotent_retry(retry_reason reason);

--- a/couchbase/retry_reason.hxx
+++ b/couchbase/retry_reason.hxx
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <string>
-
 namespace couchbase
 {
 /**

--- a/couchbase/retry_reason.hxx
+++ b/couchbase/retry_reason.hxx
@@ -101,9 +101,6 @@ enum class retry_reason {
     views_no_active_partition,
 };
 
-auto
-retry_reason_to_enum(const std::string& reason) -> couchbase::retry_reason;
-
 bool
 allows_non_idempotent_retry(retry_reason reason);
 

--- a/couchbase/scope.hxx
+++ b/couchbase/scope.hxx
@@ -110,8 +110,7 @@ class scope
      * @since 1.0.0
      * @committed
      */
-    [[nodiscard]] auto query(std::string statement, const query_options& options = {}) const
-      -> std::future<std::pair<error, query_result>>;
+    [[nodiscard]] auto query(std::string statement, const query_options& options = {}) const -> std::future<std::pair<error, query_result>>;
 
     /**
      * Performs a request against the full text search services.

--- a/couchbase/scope.hxx
+++ b/couchbase/scope.hxx
@@ -111,7 +111,7 @@ class scope
      * @committed
      */
     [[nodiscard]] auto query(std::string statement, const query_options& options = {}) const
-      -> std::future<std::pair<query_error_context, query_result>>;
+      -> std::future<std::pair<error, query_result>>;
 
     /**
      * Performs a request against the full text search services.
@@ -152,7 +152,7 @@ class scope
      * @volatile
      */
     [[nodiscard]] auto search(std::string index_name, search_request request, const search_options& options = {}) const
-      -> std::future<std::pair<search_error_context, search_result>>;
+      -> std::future<std::pair<error, search_result>>;
 
     /**
      * Performs a query against the analytics services.
@@ -184,7 +184,7 @@ class scope
      * @committed
      */
     [[nodiscard]] auto analytics_query(std::string statement, const analytics_options& options = {}) const
-      -> std::future<std::pair<analytics_error_context, analytics_result>>;
+      -> std::future<std::pair<error, analytics_result>>;
 
     /**
      * Provides access to search index management services at the scope level

--- a/couchbase/search_options.hxx
+++ b/couchbase/search_options.hxx
@@ -505,5 +505,5 @@ struct search_options : public common_options<search_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using search_handler = std::function<void(couchbase::error, search_result)>;
+using search_handler = std::function<void(error, search_result)>;
 } // namespace couchbase

--- a/couchbase/search_options.hxx
+++ b/couchbase/search_options.hxx
@@ -19,9 +19,9 @@
 
 #include <couchbase/codec/tao_json_serializer.hxx>
 #include <couchbase/common_options.hxx>
+#include <couchbase/error.hxx>
 #include <couchbase/highlight_style.hxx>
 #include <couchbase/mutation_state.hxx>
-#include <couchbase/error.hxx>
 #include <couchbase/search_facet.hxx>
 #include <couchbase/search_result.hxx>
 #include <couchbase/search_scan_consistency.hxx>

--- a/couchbase/search_options.hxx
+++ b/couchbase/search_options.hxx
@@ -21,7 +21,7 @@
 #include <couchbase/common_options.hxx>
 #include <couchbase/highlight_style.hxx>
 #include <couchbase/mutation_state.hxx>
-#include <couchbase/search_error_context.hxx>
+#include <couchbase/error.hxx>
 #include <couchbase/search_facet.hxx>
 #include <couchbase/search_result.hxx>
 #include <couchbase/search_scan_consistency.hxx>
@@ -505,5 +505,5 @@ struct search_options : public common_options<search_options> {
  * @since 1.0.0
  * @uncommitted
  */
-using search_handler = std::function<void(couchbase::search_error_context, search_result)>;
+using search_handler = std::function<void(couchbase::error, search_result)>;
 } // namespace couchbase

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -424,16 +424,16 @@ TEST_CASE("integration: public API analytics query")
     SECTION("raw")
     {
         couchbase::analytics_result resp{};
-        couchbase::error ctx{};
+        couchbase::error error{};
         CHECK(test::utils::wait_until([&]() {
-            std::tie(ctx, resp) =
+            std::tie(error, resp) =
               cluster
                 .analytics_query(fmt::format(R"(SELECT testkey FROM `Default`.`{}` WHERE testkey = $testkey)", dataset_name),
                                  couchbase::analytics_options{}.raw("$testkey", test_value))
                 .get();
-            return !ctx.ec() && resp.meta_data().metrics().result_count() == 1;
+            return !error && resp.meta_data().metrics().result_count() == 1;
         }));
-        REQUIRE_SUCCESS(ctx.ec());
+        REQUIRE_SUCCESS(error.ec());
         auto rows = resp.rows_as_json();
         REQUIRE(rows.size() == 1);
         REQUIRE(rows[0] == document);

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -17,6 +17,7 @@
 
 #include "test_helper_integration.hxx"
 
+#include "core/error_context/analytics_json.hxx"
 #include "core/operations/document_analytics.hxx"
 #include "core/operations/document_append.hxx"
 #include "core/operations/document_decrement.hxx"
@@ -30,7 +31,6 @@
 #include "core/operations/management/analytics.hxx"
 #include "core/operations/management/collection_create.hxx"
 #include "core/operations/management/collections.hxx"
-#include "core/error_context/analytics_json.hxx"
 
 TEST_CASE("integration: analytics query")
 {
@@ -373,9 +373,9 @@ TEST_CASE("integration: public API analytics query")
         couchbase::error error{};
         CHECK(test::utils::wait_until([&]() {
             std::tie(error, resp) = cluster
-                                    .analytics_query(fmt::format(R"(SELECT testkey FROM `Default`.`{}` WHERE testkey = ?)", dataset_name),
-                                                     couchbase::analytics_options{}.positional_parameters(test_value))
-                                    .get();
+                                      .analytics_query(fmt::format(R"(SELECT testkey FROM `Default`.`{}` WHERE testkey = ?)", dataset_name),
+                                                       couchbase::analytics_options{}.positional_parameters(test_value))
+                                      .get();
             return !error && resp.meta_data().metrics().result_count() == 1;
         }));
         REQUIRE_SUCCESS(error.ec());

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -62,7 +62,9 @@ main(int argc, const char* argv[])
     // run IO context on separate thread
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(username, password);
     // customize through the 'options'.
@@ -226,7 +228,9 @@ main(int argc, const char* argv[])
     // run IO context on separate thread
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(username, password);
     // customize through the 'options'.
@@ -241,7 +245,8 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query\n");
-        auto [error, result] = cluster.search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("nice bar"))).get();
+        auto [error, result] =
+          cluster.search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("nice bar"))).get();
 
         if (error.ec()) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -256,10 +261,10 @@ main(int argc, const char* argv[])
     {
         fmt::print("--- simple query with fields\n");
         auto [error, result] = cluster
-                               .search("travel-sample-index",
-                                             couchbase::search_request(couchbase::query_string_query("nice bar")),
-                                             couchbase::search_options{}.fields({ "description" }))
-                               .get();
+                                 .search("travel-sample-index",
+                                         couchbase::search_request(couchbase::query_string_query("nice bar")),
+                                         couchbase::search_options{}.fields({ "description" }))
+                                 .get();
 
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -274,10 +279,11 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with limit\n");
-        auto [error, result] =
-          cluster
-            .search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("nice bar")), couchbase::search_options{}.skip(3).limit(4))
-            .get();
+        auto [error, result] = cluster
+                                 .search("travel-sample-index",
+                                         couchbase::search_request(couchbase::query_string_query("nice bar")),
+                                         couchbase::search_options{}.skip(3).limit(4))
+                                 .get();
 
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -294,8 +300,8 @@ main(int argc, const char* argv[])
         auto [error, result] =
           cluster
             .search("travel-sample-index",
-                          couchbase::search_request(couchbase::query_string_query("nice bar")),
-                          couchbase::search_options{}.highlight(couchbase::highlight_style::html, { "description", "title" }))
+                    couchbase::search_request(couchbase::query_string_query("nice bar")),
+                    couchbase::search_options{}.highlight(couchbase::highlight_style::html, { "description", "title" }))
             .get();
 
         if (error) {
@@ -317,10 +323,10 @@ main(int argc, const char* argv[])
     {
         fmt::print("--- simple query with collections\n");
         auto [error, result] = cluster
-                               .search("travel-sample-index",
-                                             couchbase::search_request(couchbase::query_string_query("west")),
-                                             couchbase::search_options{}.collections({ "airline" }))
-                               .get();
+                                 .search("travel-sample-index",
+                                         couchbase::search_request(couchbase::query_string_query("west")),
+                                         couchbase::search_options{}.collections({ "airline" }))
+                                 .get();
 
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -365,10 +371,11 @@ main(int argc, const char* argv[])
             state.add(upsert_result);
         }
 
-        auto [error, result] =
-          cluster
-            .search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("bree")), couchbase::search_options{}.consistent_with(state))
-            .get();
+        auto [error, result] = cluster
+                                 .search("travel-sample-index",
+                                         couchbase::search_request(couchbase::query_string_query("bree")),
+                                         couchbase::search_options{}.consistent_with(state))
+                                 .get();
 
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -382,15 +389,15 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- complex query\n");
-        auto [error, result] = cluster
-                               .search("travel-sample-index",
-                                             couchbase::search_request(
-                                         couchbase::boolean_query()
-                                               .must(couchbase::match_query("honeymoon").field("reviews.content"),
-                                                     couchbase::numeric_range_query().field("reviews.ratings.Overall").min(4))
-                                               .must_not(couchbase::match_query("San Francisco").field("city"))),
-                                             couchbase::search_options{}.collections({ "hotel" }).highlight())
-                               .get();
+        auto [error, result] =
+          cluster
+            .search("travel-sample-index",
+                    couchbase::search_request(couchbase::boolean_query()
+                                                .must(couchbase::match_query("honeymoon").field("reviews.content"),
+                                                      couchbase::numeric_range_query().field("reviews.ratings.Overall").min(4))
+                                                .must_not(couchbase::match_query("San Francisco").field("city"))),
+                    couchbase::search_options{}.collections({ "hotel" }).highlight())
+            .get();
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
@@ -406,8 +413,8 @@ main(int argc, const char* argv[])
         auto [error, result] =
           cluster
             .search("travel-sample-index",
-                          couchbase::search_request(couchbase::query_string_query("honeymoon")),
-                          couchbase::search_options{}.collections({ "hotel" }).facet("by_country", couchbase::term_facet("country", 3)))
+                    couchbase::search_request(couchbase::query_string_query("honeymoon")),
+                    couchbase::search_options{}.collections({ "hotel" }).facet("by_country", couchbase::term_facet("country", 3)))
             .get();
         if (error) {
             fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
@@ -487,7 +494,9 @@ main(int argc, const char* argv[])
     // run IO context on separate thread
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(username, password);
     // customize through the 'options'.
@@ -713,9 +722,7 @@ main(int argc, const char* argv[])
             auto inventory_scope = bucket.scope("inventory");
             auto [error, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
             if (error) {
-                fmt::print("PARENT(pid={}): unable to perform query: {}\n",
-                           getpid(),
-                           error.ctx().to_string());
+                fmt::print("PARENT(pid={}): unable to perform query: {}\n", getpid(), error.ctx().to_string());
                 return 1;
             }
             for (const auto& row : query_result.rows_as_json()) {

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -104,9 +104,9 @@ main(int argc, const char* argv[])
 
     { // [4] N1QL query
         auto inventory_scope = bucket.scope("inventory");
-        auto [ctx, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
-        if (ctx.ec()) {
-            fmt::print("unable to perform query: {}, ({}, {})\n", ctx.ec().message(), ctx.first_error_code(), ctx.first_error_message());
+        auto [error, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
+        if (error) {
+            fmt::print("unable to perform query: {}\n", error.ctx().to_string());
             return 1;
         }
         for (const auto& row : query_result.rows_as_json()) {
@@ -241,10 +241,10 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query\n");
-        auto [ctx, result] = cluster.search_query("travel-sample-index", couchbase::query_string_query("nice bar")).get();
+        auto [error, result] = cluster.search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("nice bar"))).get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error.ec()) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -255,14 +255,14 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with fields\n");
-        auto [ctx, result] = cluster
-                               .search_query("travel-sample-index",
-                                             couchbase::query_string_query("nice bar"),
+        auto [error, result] = cluster
+                               .search("travel-sample-index",
+                                             couchbase::search_request(couchbase::query_string_query("nice bar")),
                                              couchbase::search_options{}.fields({ "description" }))
                                .get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -274,13 +274,13 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with limit\n");
-        auto [ctx, result] =
+        auto [error, result] =
           cluster
-            .search_query("travel-sample-index", couchbase::query_string_query("nice bar"), couchbase::search_options{}.skip(3).limit(4))
+            .search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("nice bar")), couchbase::search_options{}.skip(3).limit(4))
             .get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -291,15 +291,15 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with highlight\n");
-        auto [ctx, result] =
+        auto [error, result] =
           cluster
-            .search_query("travel-sample-index",
-                          couchbase::query_string_query("nice bar"),
+            .search("travel-sample-index",
+                          couchbase::search_request(couchbase::query_string_query("nice bar")),
                           couchbase::search_options{}.highlight(couchbase::highlight_style::html, { "description", "title" }))
             .get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -316,14 +316,14 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with collections\n");
-        auto [ctx, result] = cluster
-                               .search_query("travel-sample-index",
-                                             couchbase::query_string_query("west"),
+        auto [error, result] = cluster
+                               .search("travel-sample-index",
+                                             couchbase::search_request(couchbase::query_string_query("west")),
                                              couchbase::search_options{}.collections({ "airline" }))
                                .get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -365,13 +365,13 @@ main(int argc, const char* argv[])
             state.add(upsert_result);
         }
 
-        auto [ctx, result] =
+        auto [error, result] =
           cluster
-            .search_query("travel-sample-index", couchbase::query_string_query("bree"), couchbase::search_options{}.consistent_with(state))
+            .search("travel-sample-index", couchbase::search_request(couchbase::query_string_query("bree")), couchbase::search_options{}.consistent_with(state))
             .get();
 
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -382,16 +382,17 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- complex query\n");
-        auto [ctx, result] = cluster
-                               .search_query("travel-sample-index",
-                                             couchbase::boolean_query()
+        auto [error, result] = cluster
+                               .search("travel-sample-index",
+                                             couchbase::search_request(
+                                         couchbase::boolean_query()
                                                .must(couchbase::match_query("honeymoon").field("reviews.content"),
                                                      couchbase::numeric_range_query().field("reviews.ratings.Overall").min(4))
-                                               .must_not(couchbase::match_query("San Francisco").field("city")),
+                                               .must_not(couchbase::match_query("San Francisco").field("city"))),
                                              couchbase::search_options{}.collections({ "hotel" }).highlight())
                                .get();
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -402,14 +403,14 @@ main(int argc, const char* argv[])
 
     {
         fmt::print("--- simple query with facets\n");
-        auto [ctx, result] =
+        auto [error, result] =
           cluster
-            .search_query("travel-sample-index",
-                          couchbase::query_string_query("honeymoon"),
+            .search("travel-sample-index",
+                          couchbase::search_request(couchbase::query_string_query("honeymoon")),
                           couchbase::search_options{}.collections({ "hotel" }).facet("by_country", couchbase::term_facet("country", 3)))
             .get();
-        if (ctx.ec()) {
-            fmt::print("unable to perform search query: {}, ({}, {})\n", ctx.ec().message(), ctx.status(), ctx.error());
+        if (error) {
+            fmt::print("unable to perform search query: {}\n", error.ctx().to_string());
             return 1;
         }
         fmt::print("{} hits, total: {}\n", result.rows().size(), result.meta_data().metrics().total_rows());
@@ -710,13 +711,11 @@ main(int argc, const char* argv[])
         }
         {
             auto inventory_scope = bucket.scope("inventory");
-            auto [ctx, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
-            if (ctx.ec()) {
-                fmt::print("PARENT(pid={}): unable to perform query: {}, ({}, {})\n",
+            auto [error, query_result] = inventory_scope.query("SELECT * FROM airline WHERE id = 10").get();
+            if (error) {
+                fmt::print("PARENT(pid={}): unable to perform query: {}\n",
                            getpid(),
-                           ctx.ec().message(),
-                           ctx.first_error_code(),
-                           ctx.first_error_message());
+                           error.ctx().to_string());
                 return 1;
             }
             for (const auto& row : query_result.rows_as_json()) {

--- a/test/test_integration_search.cxx
+++ b/test/test_integration_search.cxx
@@ -653,7 +653,7 @@ TEST_CASE("integration: scope search returns feature not available", "[integrati
     couchbase::cluster c(integration.cluster);
 
     auto search_request = couchbase::search_request(couchbase::match_none_query{});
-    auto [ctx, result] = c.bucket(integration.ctx.bucket).default_scope().search("does-not-exist", search_request).get();
+    auto [error, result] = c.bucket(integration.ctx.bucket).default_scope().search("does-not-exist", search_request).get();
 
-    REQUIRE(ctx.ec() == couchbase::errc::common::feature_not_available);
+    REQUIRE(error.ec() == couchbase::errc::common::feature_not_available);
 }

--- a/tools/analytics.cxx
+++ b/tools/analytics.cxx
@@ -24,11 +24,10 @@
 #include <couchbase/fmt/analytics_status.hxx>
 
 #include <asio/io_context.hpp>
+#include <core/error_context/analytics_json.hxx>
 #include <fmt/chrono.h>
 #include <spdlog/fmt/bin_to_hex.h>
 #include <tao/json.hpp>
-#include <core/error_context/analytics_json.hxx>
-
 
 #include <regex>
 
@@ -141,7 +140,9 @@ class analytics_app : public CLI::App
 
         asio::io_context io;
         auto guard = asio::make_work_guard(io);
-        std::thread io_thread([&io]() { io.run(); });
+        std::thread io_thread([&io]() {
+            io.run();
+        });
         const auto connection_string = common_options_.connection.connection_string;
 
         auto [cluster, ec] = couchbase::cluster::connect(io, connection_string, cluster_options).get();
@@ -163,7 +164,8 @@ class analytics_app : public CLI::App
                 .get();
 
             if (json_lines_) {
-                print_result_json_line(scope_id, statement, error.ctx().as<couchbase::core::error_context::analytics>(), resp, analytics_options);
+                print_result_json_line(
+                  scope_id, statement, error.ctx().as<couchbase::core::error_context::analytics>(), resp, analytics_options);
             } else {
                 print_result(scope_id, statement, error.ctx().as<couchbase::core::error_context::analytics>(), resp, analytics_options);
             }

--- a/tools/analytics.cxx
+++ b/tools/analytics.cxx
@@ -27,6 +27,8 @@
 #include <fmt/chrono.h>
 #include <spdlog/fmt/bin_to_hex.h>
 #include <tao/json.hpp>
+#include <core/error_context/analytics_json.hxx>
+
 
 #include <regex>
 
@@ -156,14 +158,14 @@ class analytics_app : public CLI::App
         }
 
         for (const auto& statement : queries_) {
-            auto [ctx, resp] =
+            auto [error, resp] =
               (scope ? do_analytics(scope.value(), statement, analytics_options) : do_analytics(cluster, statement, analytics_options))
                 .get();
 
             if (json_lines_) {
-                print_result_json_line(scope_id, statement, ctx, resp, analytics_options);
+                print_result_json_line(scope_id, statement, error.ctx().as<couchbase::core::error_context::analytics>(), resp, analytics_options);
             } else {
-                print_result(scope_id, statement, ctx, resp, analytics_options);
+                print_result(scope_id, statement, error.ctx().as<couchbase::core::error_context::analytics>(), resp, analytics_options);
             }
         }
 
@@ -178,14 +180,14 @@ class analytics_app : public CLI::App
   private:
     template<typename QueryEndpoint>
     auto do_analytics(QueryEndpoint& endpoint, std::string statement, const couchbase::analytics_options& options) const
-      -> std::future<std::pair<couchbase::analytics_error_context, couchbase::analytics_result>>
+      -> std::future<std::pair<couchbase::error, couchbase::analytics_result>>
     {
         return endpoint.analytics_query(std::move(statement), options);
     }
 
     void print_result_json_line(const std::optional<scope_with_bucket>& scope_id,
                                 const std::string& statement,
-                                const couchbase::analytics_error_context& ctx,
+                                const couchbase::core::error_context::analytics& ctx,
                                 const couchbase::analytics_result& resp,
                                 const couchbase::analytics_options& analytics_options) const
     {
@@ -200,25 +202,25 @@ class analytics_app : public CLI::App
             meta["bucket_name"] = scope_id->bucket_name;
             meta["scope_name"] = scope_id->scope_name;
         }
-        if (ctx.parameters()) {
+        if (ctx.parameters) {
             try {
-                auto json = tao::json::from_string(ctx.parameters().value());
+                auto json = tao::json::from_string(ctx.parameters.value());
                 json.erase("statement");
                 meta["options"] = json;
             } catch (const tao::pegtl::parse_error&) {
-                meta["options"] = ctx.parameters().value();
+                meta["options"] = ctx.parameters.value();
             }
         }
 
-        if (ctx.ec()) {
+        if (ctx.ec) {
             tao::json::value error = {
-                { "code", ctx.ec().value() },
-                { "message", ctx.ec().message() },
+                { "code", ctx.ec.value() },
+                { "message", ctx.ec.message() },
             };
             try {
-                error["body"] = tao::json::from_string(ctx.http_body());
+                error["body"] = tao::json::from_string(ctx.http_body);
             } catch (const tao::pegtl::parse_error&) {
-                error["text"] = ctx.http_body();
+                error["text"] = ctx.http_body;
             }
             line["error"] = error;
         } else {
@@ -268,7 +270,7 @@ class analytics_app : public CLI::App
 
     void print_result(const std::optional<scope_with_bucket>& scope_id,
                       const std::string& statement,
-                      const couchbase::analytics_error_context& ctx,
+                      const couchbase::core::error_context::analytics& ctx,
                       const couchbase::analytics_result& resp,
                       const couchbase::analytics_options& analytics_options) const
     {
@@ -281,28 +283,28 @@ class analytics_app : public CLI::App
         fmt::format_to(
           std::back_inserter(header), "{}statement: \"{}\"", header.size() == 0 ? "" : ", ", tao::json::internal::escape(statement));
 
-        if (ctx.parameters()) {
+        if (ctx.parameters) {
             try {
-                auto json = tao::json::from_string(ctx.parameters().value());
+                auto json = tao::json::from_string(ctx.parameters.value());
                 json.erase("statement");
                 fmt::format_to(std::back_inserter(header), ", options: {}", tao::json::to_string(json));
             } catch (const tao::pegtl::parse_error&) {
-                fmt::format_to(std::back_inserter(header), ", options: {}", ctx.parameters().value());
+                fmt::format_to(std::back_inserter(header), ", options: {}", ctx.parameters.value());
             }
         }
         fmt::print(stdout, "--- {}\n", std::string_view{ header.data(), header.size() });
 
-        if (ctx.ec()) {
+        if (ctx.ec) {
             fmt::print("ERROR. code: {}, message: {}, server: {} \"{}\"\n",
-                       ctx.ec().value(),
-                       ctx.ec().message(),
-                       ctx.first_error_code(),
-                       tao::json::internal::escape(ctx.first_error_message()));
-            if (!ctx.http_body().empty()) {
+                       ctx.ec.value(),
+                       ctx.ec.message(),
+                       ctx.first_error_code,
+                       tao::json::internal::escape(ctx.first_error_message));
+            if (!ctx.http_body.empty()) {
                 try {
-                    fmt::print("{}\n", tao::json::to_string(tao::json::from_string(ctx.http_body())));
+                    fmt::print("{}\n", tao::json::to_string(tao::json::from_string(ctx.http_body)));
                 } catch (const tao::pegtl::parse_error&) {
-                    fmt::print("{}\n", ctx.http_body());
+                    fmt::print("{}\n", ctx.http_body);
                 }
             }
         } else {

--- a/tools/pillowfight.cxx
+++ b/tools/pillowfight.cxx
@@ -392,8 +392,9 @@ class pillowfight_app : public CLI::App
         while (running.test_and_set() && !stopping) {
             std::list<std::pair<std::chrono::system_clock::time_point,
                                 std::variant<std::future<std::pair<couchbase::key_value_error_context, couchbase::mutation_result>>,
-                                             std::future<std::pair<couchbase::key_value_error_context, couchbase::get_result>>,
-                                             std::future<std::pair<couchbase::query_error_context, couchbase::query_result>>>>>
+                                             std::future<std::pair<couchbase::key_value_error_context, couchbase::get_result>>
+                                            // ,std::future<std::pair<couchbase::error, couchbase::query_result>> //TODO readd
+                                             >>>
               futures;
             for (std::size_t i = 0; i < key_value_batch_size_; ++i) {
                 auto opcode = (dist(gen) <= chance_of_get_) ? operation::get : operation::upsert;
@@ -426,11 +427,12 @@ class pillowfight_app : public CLI::App
                 }
             }
 
-            for (std::size_t i = 0; i < query_batch_size_; ++i) {
-                if (chance_of_query_ > 0 && dist(gen) <= chance_of_query_) {
-                    futures.emplace_back(std::chrono::system_clock::now(), cluster.query(query_statement, couchbase::query_options{}));
-                }
-            }
+            //TODO: readd
+//            for (std::size_t i = 0; i < query_batch_size_; ++i) {
+//                if (chance_of_query_ > 0 && dist(gen) <= chance_of_query_) {
+//                    futures.emplace_back(std::chrono::system_clock::now(), cluster.query(query_statement, couchbase::query_options{}));
+//                }
+//            }
 
             for (auto&& [start, future] : futures) {
                 std::visit(

--- a/tools/pillowfight.cxx
+++ b/tools/pillowfight.cxx
@@ -144,8 +144,9 @@ dump_stats(asio::steady_timer& timer, std::chrono::system_clock::time_point star
         const std::uint64_t current_total = total;
         const std::uint64_t current_errors = [] {
             std::scoped_lock lock(errors_mutex);
-            return std::accumulate(
-              errors.begin(), errors.end(), std::uint64_t{ 0 }, [](auto acc, const auto& pair) { return acc + pair.second; });
+            return std::accumulate(errors.begin(), errors.end(), std::uint64_t{ 0 }, [](auto acc, const auto& pair) {
+                return acc + pair.second;
+            });
         }();
         stats_window.push_back({
           now,
@@ -263,7 +264,9 @@ class pillowfight_app : public CLI::App
         std::vector<std::thread> io_pool{};
         io_pool.reserve(number_of_io_threads_);
         for (std::size_t i = 0; i < number_of_io_threads_; ++i) {
-            io_pool.emplace_back([&io]() { io.run(); });
+            io_pool.emplace_back([&io]() {
+                io.run();
+            });
         }
 
         hdr_init(/* minimum - 1 us*/ 1'000,
@@ -317,7 +320,9 @@ class pillowfight_app : public CLI::App
         std::vector<std::thread> worker_pool{};
         worker_pool.reserve(number_of_worker_threads_);
         for (std::size_t i = 0; i < number_of_worker_threads_; ++i) {
-            worker_pool.emplace_back([this, cluster = cluster, &keys = known_keys[i]]() { worker(cluster, keys); });
+            worker_pool.emplace_back([this, cluster = cluster, &keys = known_keys[i]]() {
+                worker(cluster, keys);
+            });
         }
         for (auto& thread : worker_pool) {
             thread.join();
@@ -393,7 +398,7 @@ class pillowfight_app : public CLI::App
             std::list<std::pair<std::chrono::system_clock::time_point,
                                 std::variant<std::future<std::pair<couchbase::key_value_error_context, couchbase::mutation_result>>,
                                              std::future<std::pair<couchbase::key_value_error_context, couchbase::get_result>>
-                                            // ,std::future<std::pair<couchbase::error, couchbase::query_result>> //TODO readd
+                                             // ,std::future<std::pair<couchbase::error, couchbase::query_result>> //TODO readd
                                              >>>
               futures;
             for (std::size_t i = 0; i < key_value_batch_size_; ++i) {
@@ -427,12 +432,13 @@ class pillowfight_app : public CLI::App
                 }
             }
 
-            //TODO: readd
-//            for (std::size_t i = 0; i < query_batch_size_; ++i) {
-//                if (chance_of_query_ > 0 && dist(gen) <= chance_of_query_) {
-//                    futures.emplace_back(std::chrono::system_clock::now(), cluster.query(query_statement, couchbase::query_options{}));
-//                }
-//            }
+            // TODO: readd
+            //            for (std::size_t i = 0; i < query_batch_size_; ++i) {
+            //                if (chance_of_query_ > 0 && dist(gen) <= chance_of_query_) {
+            //                    futures.emplace_back(std::chrono::system_clock::now(), cluster.query(query_statement,
+            //                    couchbase::query_options{}));
+            //                }
+            //            }
 
             for (auto&& [start, future] : futures) {
                 std::visit(

--- a/tools/query.cxx
+++ b/tools/query.cxx
@@ -26,10 +26,10 @@
 #include <couchbase/fmt/query_status.hxx>
 
 #include <asio/io_context.hpp>
+#include <core/error_context/query_json.hxx>
 #include <fmt/chrono.h>
 #include <spdlog/fmt/bin_to_hex.h>
 #include <tao/json.hpp>
-#include <core/error_context/query_json.hxx>
 
 #include <regex>
 
@@ -197,7 +197,9 @@ Examples:
 
         asio::io_context io;
         auto guard = asio::make_work_guard(io);
-        std::thread io_thread([&io]() { io.run(); });
+        std::thread io_thread([&io]() {
+            io.run();
+        });
         const auto connection_string = common_options_.connection.connection_string;
 
         auto [cluster, ec] = couchbase::cluster::connect(io, connection_string, cluster_options).get();

--- a/tools/query.cxx
+++ b/tools/query.cxx
@@ -29,6 +29,7 @@
 #include <fmt/chrono.h>
 #include <spdlog/fmt/bin_to_hex.h>
 #include <tao/json.hpp>
+#include <core/error_context/query_json.hxx>
 
 #include <regex>
 
@@ -213,13 +214,13 @@ Examples:
         }
 
         for (const auto& statement : queries_) {
-            auto [ctx, resp] =
+            auto [error, resp] =
               (scope ? do_query(scope.value(), statement, query_options) : do_query(cluster, statement, query_options)).get();
 
             if (json_lines_) {
-                print_result_json_line(scope_id, statement, ctx, resp, query_options);
+                print_result_json_line(scope_id, statement, error.ctx().as<couchbase::core::error_context::query>(), resp, query_options);
             } else {
-                print_result(scope_id, statement, ctx, resp, query_options);
+                print_result(scope_id, statement, error.ctx().as<couchbase::core::error_context::query>(), resp, query_options);
             }
         }
 
@@ -234,14 +235,14 @@ Examples:
   private:
     template<typename QueryEndpoint>
     auto do_query(QueryEndpoint& endpoint, std::string statement, const couchbase::query_options& options) const
-      -> std::future<std::pair<couchbase::query_error_context, couchbase::query_result>>
+      -> std::future<std::pair<couchbase::error, couchbase::query_result>>
     {
         return endpoint.query(std::move(statement), options);
     }
 
     void print_result_json_line(const std::optional<scope_with_bucket>& scope_id,
                                 const std::string& statement,
-                                const couchbase::query_error_context& ctx,
+                                const couchbase::core::error_context::query& ctx,
                                 const couchbase::query_result& resp,
                                 const couchbase::query_options& query_options) const
     {
@@ -256,25 +257,25 @@ Examples:
             meta["bucket_name"] = scope_id->bucket_name;
             meta["scope_name"] = scope_id->scope_name;
         }
-        if (ctx.parameters()) {
+        if (ctx.parameters) {
             try {
-                auto json = tao::json::from_string(ctx.parameters().value());
+                auto json = tao::json::from_string(ctx.parameters.value());
                 json.erase("statement");
                 meta["options"] = json;
             } catch (const tao::pegtl::parse_error&) {
-                meta["options"] = ctx.parameters().value();
+                meta["options"] = ctx.parameters.value();
             }
         }
 
-        if (ctx.ec()) {
+        if (ctx.ec) {
             tao::json::value error = {
-                { "code", ctx.ec().value() },
-                { "message", ctx.ec().message() },
+                { "code", ctx.ec.value() },
+                { "message", ctx.ec.message() },
             };
             try {
-                error["body"] = tao::json::from_string(ctx.http_body());
+                error["body"] = tao::json::from_string(ctx.http_body);
             } catch (const tao::pegtl::parse_error&) {
-                error["text"] = ctx.http_body();
+                error["text"] = ctx.http_body;
             }
             line["error"] = error;
         } else {
@@ -341,7 +342,7 @@ Examples:
 
     void print_result(const std::optional<scope_with_bucket>& scope_id,
                       const std::string& statement,
-                      const couchbase::query_error_context& ctx,
+                      const couchbase::core::error_context::query& ctx,
                       const couchbase::query_result& resp,
                       const couchbase::query_options& query_options) const
     {
@@ -354,28 +355,28 @@ Examples:
         fmt::format_to(
           std::back_inserter(header), "{}statement: \"{}\"", header.size() == 0 ? "" : ", ", tao::json::internal::escape(statement));
 
-        if (ctx.parameters()) {
+        if (ctx.parameters) {
             try {
-                auto json = tao::json::from_string(ctx.parameters().value());
+                auto json = tao::json::from_string(ctx.parameters.value());
                 json.erase("statement");
                 fmt::format_to(std::back_inserter(header), ", options: {}", tao::json::to_string(json));
             } catch (const tao::pegtl::parse_error&) {
-                fmt::format_to(std::back_inserter(header), ", options: {}", ctx.parameters().value());
+                fmt::format_to(std::back_inserter(header), ", options: {}", ctx.parameters.value());
             }
         }
         fmt::print(stdout, "--- {}\n", std::string_view{ header.data(), header.size() });
 
-        if (ctx.ec()) {
+        if (ctx.ec) {
             fmt::print("ERROR. code: {}, message: {}, server: {} \"{}\"\n",
-                       ctx.ec().value(),
-                       ctx.ec().message(),
-                       ctx.first_error_code(),
-                       tao::json::internal::escape(ctx.first_error_message()));
-            if (!ctx.http_body().empty()) {
+                       ctx.ec.value(),
+                       ctx.ec.message(),
+                       ctx.first_error_code,
+                       tao::json::internal::escape(ctx.first_error_message));
+            if (!ctx.http_body.empty()) {
                 try {
-                    fmt::print("{}\n", tao::json::to_string(tao::json::from_string(ctx.http_body())));
+                    fmt::print("{}\n", tao::json::to_string(tao::json::from_string(ctx.http_body)));
                 } catch (const tao::pegtl::parse_error&) {
-                    fmt::print("{}\n", ctx.http_body());
+                    fmt::print("{}\n", ctx.http_body);
                 }
             }
         } else {


### PR DESCRIPTION
Changes:

- Convert query, search & analytics to use couchbase::error
- Add assign & as() methods for JSON conversion for analytics, search, query (and http) error contexts
- Add make_error util methods
- Add as() method to error context 