### PR TITLE
Always attempt to extract common query code if resp error code has not been set

### DIFF
--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -400,14 +400,15 @@ query_request::make_response(error_context::query&& ctx, const encoded_response_
                             response.ctx.ec = errc::query::index_failure;
                         } else if (response.ctx.first_error_code >= 4000 && response.ctx.first_error_code < 5000) {
                             response.ctx.ec = errc::query::planning_failure;
-                        } else {
-                            auto common_ec =
-                              management::extract_common_query_error_code(response.ctx.first_error_code, response.ctx.first_error_message);
-                            if (common_ec) {
-                                response.ctx.ec = common_ec.value();
-                            }
                         }
                         break;
+                }
+                if (!response.ctx.ec) {
+                    auto common_ec =
+                      management::extract_common_query_error_code(response.ctx.first_error_code, response.ctx.first_error_message);
+                    if (common_ec) {
+                        response.ctx.ec = common_ec.value();
+                    }
                 }
             }
             if (!response.ctx.ec) {


### PR DESCRIPTION
The error code cases in `extract_common_query_error_code` overlap with the ones in `query_request::make_response` (specifically for the 5000 code). Always call `extract_common_query_error_code` if the response error code has not been set, instead of calling it in the `default` block which does not get reached if the error code is 5000.