### PR TITLE
CXXCBC-500 Use couchbase::error for transactions

### DIFF
--- a/core/error_context/query_public_json.hxx
+++ b/core/error_context/query_public_json.hxx
@@ -1,0 +1,87 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/fmt/retry_reason.hxx>
+#include <couchbase/query_error_context.hxx>
+
+#include <fmt/format.h>
+#include <tao/json/forward.hpp>
+
+namespace tao::json
+{
+template<>
+struct traits<couchbase::query_error_context> {
+    template<template<typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits>& v, const couchbase::query_error_context& ctx)
+    {
+        if (ctx.last_dispatched_to()) {
+            v["last_dispatched_to"] = ctx.last_dispatched_to().value();
+        }
+        if (ctx.last_dispatched_from()) {
+            v["last_dispatched_from"] = ctx.last_dispatched_from().value();
+        }
+        if (ctx.retry_attempts()) {
+            v["retry_attempts"] = ctx.retry_attempts();
+        }
+        if (!ctx.retry_reasons().empty()) {
+            std::vector<tao::json::basic_value<Traits>> reasons{};
+            for (couchbase::retry_reason r : ctx.retry_reasons()) {
+                reasons.emplace_back(fmt::format("{}", r));
+            }
+            v["retry_reasons"] = reasons;
+        }
+        if (!ctx.operation_id().empty()) {
+            v["operation_id"] = ctx.operation_id();
+        }
+        if (ctx.first_error_code()) {
+            v["first_error_code"] = ctx.first_error_code();
+        }
+        if (!ctx.first_error_message().empty()) {
+            v["first_error_message"] = ctx.first_error_message();
+        }
+        if (!ctx.client_context_id().empty()) {
+            v["client_context_id"] = ctx.client_context_id();
+        }
+        if (!ctx.statement().empty()) {
+            v["statement"] = ctx.statement();
+        }
+        if (ctx.parameters()) {
+            v["parameters"] = ctx.parameters().value();
+        }
+        if (!ctx.method().empty()) {
+            v["method"] = ctx.method();
+        }
+        if (!ctx.path().empty()) {
+            v["path"] = ctx.path();
+        }
+        if (ctx.http_status()) {
+            v["http_status"] = ctx.http_status();
+        }
+        if (!ctx.http_body().empty()) {
+            v["http_body"] = ctx.http_body();
+        }
+        if (!ctx.hostname().empty()) {
+            v["hostname"] = ctx.hostname();
+        }
+        if (ctx.port()) {
+            v["port"] = ctx.port();
+        }
+    }
+};
+} // namespace tao::json

--- a/core/impl/bucket_manager.cxx
+++ b/core/impl/bucket_manager.cxx
@@ -26,8 +26,6 @@
 
 #include "core/impl/error.hxx"
 
-#include "core/impl/error.hxx"
-
 #include <couchbase/bucket_manager.hxx>
 
 #include <memory>

--- a/core/impl/bucket_manager.cxx
+++ b/core/impl/bucket_manager.cxx
@@ -26,6 +26,8 @@
 
 #include "core/impl/error.hxx"
 
+#include "core/impl/error.hxx"
+
 #include <couchbase/bucket_manager.hxx>
 
 #include <memory>

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -17,17 +17,17 @@
 
 #include <couchbase/error.hxx>
 #include <couchbase/error_context.hxx>
+#include <couchbase/transaction_error_context.hxx>
 
-#include <core/error_context/analytics_json.hxx>
-#include <core/error_context/http_json.hxx>
-#include <core/error_context/key_value_json.hxx>
-#include <core/error_context/query_json.hxx>
-#include <core/error_context/query_public_json.hxx>
-#include <core/error_context/search_json.hxx>
+#include "core/error_context/analytics_json.hxx"
+#include "core/error_context/http_json.hxx"
+#include "core/error_context/key_value_json.hxx"
+#include "core/error_context/query_json.hxx"
+#include "core/error_context/query_public_json.hxx"
+#include "core/error_context/search_json.hxx"
 #include "core/error_context/subdocument_json.hxx"
 #include "error.hxx"
 
-#include "couchbase/transaction_error_context.hxx"
 #include <memory>
 #include <optional>
 #include <system_error>
@@ -139,17 +139,17 @@ make_error(const couchbase::subdocument_error_context& core_ctx)
 error
 make_error(const couchbase::transaction_error_context& ctx)
 {
-    return {ctx.ec(), "", {}, { ctx.cause() }};
+    return { ctx.ec(), "", {}, { ctx.cause() } };
 }
 
 error
 make_error(const couchbase::transaction_op_error_context& ctx)
 {
     if (std::holds_alternative<key_value_error_context>(ctx.cause())) {
-        return {ctx.ec(), "", {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
+        return { ctx.ec(), "", {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
     }
     if (std::holds_alternative<query_error_context>(ctx.cause())) {
-        return {ctx.ec(), "", {}, make_error(std::get<query_error_context>(ctx.cause())) };
+        return { ctx.ec(), "", {}, make_error(std::get<query_error_context>(ctx.cause())) };
     }
     return ctx.ec();
 }

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -18,12 +18,12 @@
 #include <couchbase/error.hxx>
 #include <couchbase/error_context.hxx>
 
-#include "core/error_context/analytics_json.hxx"
-#include "core/error_context/http_json.hxx"
-#include "core/error_context/key_value_json.hxx"
-#include "core/error_context/query_json.hxx"
+#include <core/error_context/analytics_json.hxx>
+#include <core/error_context/http_json.hxx>
+#include <core/error_context/key_value_json.hxx>
+#include <core/error_context/query_json.hxx>
 #include <core/error_context/query_public_json.hxx>
-#include "core/error_context/search_json.hxx"
+#include <core/error_context/search_json.hxx>
 #include "core/error_context/subdocument_json.hxx"
 #include "error.hxx"
 
@@ -134,6 +134,24 @@ make_error(const couchbase::subdocument_error_context& core_ctx)
 {
     tao::json::value ctx(core_ctx);
     return { core_ctx.ec(), "", couchbase::error_context(ctx) };
+}
+
+error
+make_error(const couchbase::transaction_error_context& ctx)
+{
+    return {ctx.ec(), "", {}, { ctx.cause() }};
+}
+
+error
+make_error(const couchbase::transaction_op_error_context& ctx)
+{
+    if (std::holds_alternative<key_value_error_context>(ctx.cause())) {
+        return {ctx.ec(), "", {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
+    }
+    if (std::holds_alternative<query_error_context>(ctx.cause())) {
+        return {ctx.ec(), "", {}, make_error(std::get<query_error_context>(ctx.cause())) };
+    }
+    return ctx.ec();
 }
 } // namespace core::impl
 } // namespace couchbase

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -22,10 +22,12 @@
 #include "core/error_context/http_json.hxx"
 #include "core/error_context/key_value_json.hxx"
 #include "core/error_context/query_json.hxx"
+#include <core/error_context/query_public_json.hxx>
 #include "core/error_context/search_json.hxx"
 #include "core/error_context/subdocument_json.hxx"
 #include "error.hxx"
 
+#include "couchbase/transaction_error_context.hxx"
 #include <memory>
 #include <optional>
 #include <system_error>
@@ -93,6 +95,13 @@ error
 make_error(const core::error_context::query& core_ctx)
 {
     return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
+}
+
+error
+make_error(const query_error_context& core_ctx)
+{
+    tao::json::value ctx(core_ctx);
+    return { core_ctx.ec(), {}, couchbase::error_context(ctx) };
 }
 
 error

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -19,8 +19,8 @@
 
 #include <couchbase/error.hxx>
 #include <couchbase/key_value_error_context.hxx>
-#include <couchbase/subdocument_error_context.hxx>
 #include <couchbase/query_error_context.hxx>
+#include <couchbase/subdocument_error_context.hxx>
 #include <couchbase/transaction_error_context.hxx>
 #include <couchbase/transaction_op_error_context.hxx>
 

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -20,6 +20,9 @@
 #include <couchbase/error.hxx>
 #include <couchbase/key_value_error_context.hxx>
 #include <couchbase/subdocument_error_context.hxx>
+#include <couchbase/query_error_context.hxx>
+#include <couchbase/transaction_error_context.hxx>
+#include <couchbase/transaction_op_error_context.hxx>
 
 #include "core/error_context/analytics.hxx"
 #include "core/error_context/http.hxx"
@@ -45,4 +48,13 @@ make_error(const couchbase::key_value_error_context& core_ctx);
 
 error
 make_error(const couchbase::subdocument_error_context& core_ctx);
+
+error
+make_error(const couchbase::query_error_context& core_ctx);
+
+error
+make_error(const couchbase::transaction_error_context& core_ctx);
+
+error
+make_error(const couchbase::transaction_op_error_context& core_ctx);
 } // namespace couchbase::core::impl

--- a/core/impl/search_index_manager.cxx
+++ b/core/impl/search_index_manager.cxx
@@ -29,7 +29,6 @@
 #include "core/operations/management/search_index_upsert.hxx"
 #include "core/utils/json.hxx"
 
-#include <couchbase/error.hxx>
 #include <couchbase/scope_search_index_manager.hxx>
 #include <couchbase/search_index_manager.hxx>
 

--- a/core/impl/search_index_manager.cxx
+++ b/core/impl/search_index_manager.cxx
@@ -29,6 +29,7 @@
 #include "core/operations/management/search_index_upsert.hxx"
 #include "core/utils/json.hxx"
 
+#include <couchbase/error.hxx>
 #include <couchbase/scope_search_index_manager.hxx>
 #include <couchbase/search_index_manager.hxx>
 

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -74,6 +74,8 @@ struct transaction_op_error_category : std::error_category {
                 return "transaction already aborted (1320)";
             case errc::transaction_op::transaction_already_committed:
                 return "transaction already committed (1321)";
+            case errc::transaction_op::transaction_operation_failed:
+                return "transaction operation failed (1399)";
         }
         return "FIXME: unknown error code (recompile with newer library): couchbase.transaction_op." + std::to_string(ev);
     }

--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -183,7 +183,7 @@ class transactions : public couchbase::transactions::transactions
 
     couchbase::transactions::transaction_result run(const couchbase::transactions::transaction_options& config, logic&& code);
 
-    std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result> run(
+    std::pair<couchbase::error, couchbase::transactions::transaction_result> run(
       ::couchbase::transactions::txn_logic&& code,
       const couchbase::transactions::transaction_options& cfg = couchbase::transactions::transaction_options()) override;
 

--- a/core/transactions/attempt_context.cxx
+++ b/core/transactions/attempt_context.cxx
@@ -22,13 +22,13 @@
 
 namespace couchbase::transactions
 {
-std::pair<transaction_op_error_context, transaction_query_result>
+std::pair<error, transaction_query_result>
 attempt_context::query(const scope& scope, const std::string& statement, const transaction_query_options& opts)
 {
     return do_public_query(statement, opts, fmt::format("{}.{}", scope.bucket_name(), scope.name()));
 }
 
-std::pair<transaction_op_error_context, transaction_query_result>
+std::pair<error, transaction_query_result>
 attempt_context::query(const std::string& statement, const transaction_query_options& options)
 {
     return do_public_query(statement, options, {});

--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -394,8 +394,9 @@ attempt_context_impl::create_staged_replace(const transaction_get_result& docume
                 return op_completed_with_error(std::move(cb), err);
         }
     };
-    auto ec = wait_for_hook(
-      [this, key = document.id().key()](auto handler) mutable { return hooks_.before_staged_replace(this, key, std::move(handler)); });
+    auto ec = wait_for_hook([this, key = document.id().key()](auto handler) mutable {
+        return hooks_.before_staged_replace(this, key, std::move(handler));
+    });
     if (ec) {
         return error_handler(*ec, "before_staged_replace hook raised error", std::move(cb));
     }
@@ -1107,7 +1108,9 @@ attempt_context_impl::query(const std::string& statement,
                                    return do_query(statement, options, query_context, std::move(cb));
                                });
           },
-          [this, statement, options, query_context, cb]() mutable { return do_query(statement, options, query_context, std::move(cb)); });
+          [this, statement, options, query_context, cb]() mutable {
+              return do_query(statement, options, query_context, std::move(cb));
+          });
     });
 }
 
@@ -1437,7 +1440,9 @@ attempt_context_impl::atr_commit(bool ambiguity_resolution_mode)
             if (ec) {
                 throw client_error(*ec, "atr_commit check for expiry threw error");
             }
-            ec = wait_for_hook([this](auto handler) mutable { return hooks_.before_atr_commit(this, std::move(handler)); });
+            ec = wait_for_hook([this](auto handler) mutable {
+                return hooks_.before_atr_commit(this, std::move(handler));
+            });
             if (ec) {
                 // for now, throw.  Later, if this is async, we will use error handler no doubt.
                 throw client_error(*ec, "before_atr_commit hook raised error");
@@ -1446,10 +1451,13 @@ attempt_context_impl::atr_commit(bool ambiguity_resolution_mode)
             auto barrier = std::make_shared<std::promise<result>>();
             auto f = barrier->get_future();
             CB_ATTEMPT_CTX_LOG_TRACE(this, "updating atr {}, setting to {}", req.id, attempt_state_name(attempt_state::COMMITTED));
-            overall_.cluster_ref().execute(
-              req, [barrier](core::operations::mutate_in_response resp) { barrier->set_value(result::create_from_subdoc_response(resp)); });
+            overall_.cluster_ref().execute(req, [barrier](core::operations::mutate_in_response resp) {
+                barrier->set_value(result::create_from_subdoc_response(resp));
+            });
             auto res = wrap_operation_future(f, false);
-            ec = wait_for_hook([this](auto handler) mutable { return hooks_.after_atr_commit(this, std::move(handler)); });
+            ec = wait_for_hook([this](auto handler) mutable {
+                return hooks_.after_atr_commit(this, std::move(handler));
+            });
             if (ec) {
                 throw client_error(*ec, "after_atr_commit hook raised error");
             }
@@ -1479,7 +1487,9 @@ attempt_context_impl::atr_commit(bool ambiguity_resolution_mode)
 
                 case FAIL_PATH_ALREADY_EXISTS:
                     // Need retry_op as atr_commit_ambiguity_resolution can throw retry_operation
-                    return retry_op<void>([&]() { return atr_commit_ambiguity_resolution(); });
+                    return retry_op<void>([&]() {
+                        return atr_commit_ambiguity_resolution();
+                    });
                 case FAIL_HARD: {
                     auto out = transaction_operation_failed(ec, e.what()).no_rollback();
                     if (ambiguity_resolution_mode) {
@@ -1539,8 +1549,9 @@ attempt_context_impl::atr_commit_ambiguity_resolution()
         if (ec) {
             throw client_error(*ec, "atr_commit_ambiguity_resolution raised error");
         }
-        ec =
-          wait_for_hook([this](auto handler) mutable { return hooks_.before_atr_commit_ambiguity_resolution(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.before_atr_commit_ambiguity_resolution(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "before_atr_commit_ambiguity_resolution hook threw error");
         }
@@ -1549,8 +1560,9 @@ attempt_context_impl::atr_commit_ambiguity_resolution()
         req.specs = lookup_in_specs{ lookup_in_specs::get(prefix + ATR_FIELD_STATUS).xattr() }.specs();
         auto barrier = std::make_shared<std::promise<result>>();
         auto f = barrier->get_future();
-        overall_.cluster_ref().execute(
-          req, [barrier](core::operations::lookup_in_response resp) { barrier->set_value(result::create_from_subdoc_response(resp)); });
+        overall_.cluster_ref().execute(req, [barrier](core::operations::lookup_in_response resp) {
+            barrier->set_value(result::create_from_subdoc_response(resp));
+        });
         auto res = wrap_operation_future(f);
         auto atr_status_raw = res.values[0].content_as<std::string>();
         CB_ATTEMPT_CTX_LOG_DEBUG(this, "atr_commit_ambiguity_resolution read atr state {}", atr_status_raw);
@@ -1591,7 +1603,9 @@ attempt_context_impl::atr_complete()
 {
     try {
         result atr_res;
-        auto ec = wait_for_hook([this](auto handler) mutable { return hooks_.before_atr_complete(this, std::move(handler)); });
+        auto ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.before_atr_complete(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "before_atr_complete hook threw error");
         }
@@ -1610,10 +1624,13 @@ attempt_context_impl::atr_complete()
         wrap_durable_request(req, overall_.config());
         auto barrier = std::make_shared<std::promise<result>>();
         auto f = barrier->get_future();
-        overall_.cluster_ref().execute(
-          req, [barrier](core::operations::mutate_in_response resp) { barrier->set_value(result::create_from_subdoc_response(resp)); });
+        overall_.cluster_ref().execute(req, [barrier](core::operations::mutate_in_response resp) {
+            barrier->set_value(result::create_from_subdoc_response(resp));
+        });
         wrap_operation_future(f);
-        ec = wait_for_hook([this](auto handler) mutable { return hooks_.after_atr_complete(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.after_atr_complete(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "after_atr_complete hook threw error");
         }
@@ -1667,7 +1684,9 @@ attempt_context_impl::commit()
             throw transaction_operation_failed(FAIL_EXPIRY, "transaction expired").expired();
         }
         if (atr_id_ && !atr_id_->key().empty() && !is_done_) {
-            retry_op_exp<void>([&]() { atr_commit(false); });
+            retry_op_exp<void>([&]() {
+                atr_commit(false);
+            });
             staged_mutations_->commit(this);
             atr_complete();
             is_done_ = true;
@@ -1691,7 +1710,9 @@ attempt_context_impl::atr_abort()
         if (ec) {
             throw client_error(*ec, "atr_abort check for expiry threw error");
         }
-        ec = wait_for_hook([this](auto handler) mutable { return hooks_.before_atr_aborted(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.before_atr_aborted(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "before_atr_aborted hook threw error");
         }
@@ -1711,12 +1732,15 @@ attempt_context_impl::atr_abort()
         wrap_durable_request(req, overall_.config());
         auto barrier = std::make_shared<std::promise<result>>();
         auto f = barrier->get_future();
-        overall_.cluster_ref().execute(
-          req, [barrier](core::operations::mutate_in_response resp) { barrier->set_value(result::create_from_subdoc_response(resp)); });
+        overall_.cluster_ref().execute(req, [barrier](core::operations::mutate_in_response resp) {
+            barrier->set_value(result::create_from_subdoc_response(resp));
+        });
         wrap_operation_future(f);
         state(attempt_state::ABORTED);
 
-        ec = wait_for_hook([this](auto handler) mutable { return hooks_.after_atr_aborted(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.after_atr_aborted(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "after_atr_aborted hook threw error");
         }
@@ -1758,7 +1782,9 @@ attempt_context_impl::atr_rollback_complete()
             throw client_error(*ec, "atr_rollback_complete raised error");
         }
 
-        ec = wait_for_hook([this](auto handler) mutable { return hooks_.before_atr_rolled_back(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.before_atr_rolled_back(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "before_atr_rolled_back hook threw error");
         }
@@ -1772,11 +1798,14 @@ attempt_context_impl::atr_rollback_complete()
         wrap_durable_request(req, overall_.config());
         auto barrier = std::make_shared<std::promise<result>>();
         auto f = barrier->get_future();
-        overall_.cluster_ref().execute(
-          req, [barrier](core::operations::mutate_in_response resp) { barrier->set_value(result::create_from_subdoc_response(resp)); });
+        overall_.cluster_ref().execute(req, [barrier](core::operations::mutate_in_response resp) {
+            barrier->set_value(result::create_from_subdoc_response(resp));
+        });
         wrap_operation_future(f);
         state(attempt_state::ROLLED_BACK);
-        ec = wait_for_hook([this](auto handler) mutable { return hooks_.after_atr_rolled_back(this, std::move(handler)); });
+        ec = wait_for_hook([this](auto handler) mutable {
+            return hooks_.after_atr_rolled_back(this, std::move(handler));
+        });
         if (ec) {
             throw client_error(*ec, "after_atr_rolled_back hook threw error");
         }
@@ -1865,13 +1894,17 @@ attempt_context_impl::rollback()
     }
     try {
         // (1) atr_abort
-        retry_op_exp<void>([&]() { atr_abort(); });
+        retry_op_exp<void>([&]() {
+            atr_abort();
+        });
         // (2) rollback staged mutations
         staged_mutations_->rollback(this);
         CB_ATTEMPT_CTX_LOG_DEBUG(this, "rollback completed unstaging docs");
 
         // (3) atr_rollback
-        retry_op_exp<void>([&]() { atr_rollback_complete(); });
+        retry_op_exp<void>([&]() {
+            atr_rollback_complete();
+        });
     } catch (const client_error& e) {
         error_class ec = e.ec();
         CB_ATTEMPT_CTX_LOG_ERROR(this, "rollback transaction {}, attempt {} fail with error {}", transaction_id(), id(), e.what());
@@ -2449,8 +2482,9 @@ attempt_context_impl::create_staged_insert(const core::document_id& id,
                                                   "create_staged_insert expired and not in overtime");
     }
 
-    auto ec =
-      wait_for_hook([this, key = id.key()](auto handler) mutable { return hooks_.before_staged_insert(this, key, std::move(handler)); });
+    auto ec = wait_for_hook([this, key = id.key()](auto handler) mutable {
+        return hooks_.before_staged_insert(this, key, std::move(handler));
+    });
     if (ec) {
         return create_staged_insert_error_handler(
           id, content, cas, std::forward<Delay>(delay), op_id, std::forward<Handler>(cb), *ec, "before_staged_insert hook threw error");

--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -1142,7 +1142,7 @@ attempt_context_impl::do_public_query(const std::string& statement,
         return { core::impl::make_error(qe.ctx()), {} };
     } catch (...) {
         // should not be necessary, but just in case...
-        return { { couchbase::errc::transaction_op::unknown } , {} };
+        return { { couchbase::errc::transaction_op::unknown }, {} };
     }
 }
 

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -117,8 +117,9 @@ class attempt_context_impl
       const couchbase::transactions::transaction_get_result& doc,
       std::vector<std::byte> content) override
     {
-        return wrap_call_for_public_api(
-          [this, doc, &content]() -> transaction_get_result { return replace_raw(transaction_get_result(doc), content); });
+        return wrap_call_for_public_api([this, doc, &content]() -> transaction_get_result {
+            return replace_raw(transaction_get_result(doc), content);
+        });
     }
 
     void replace_raw(couchbase::transactions::transaction_get_result doc,
@@ -373,7 +374,9 @@ class attempt_context_impl
     void remove(const transaction_get_result& document) override;
     couchbase::error remove(const couchbase::transactions::transaction_get_result& doc) override
     {
-        return wrap_void_call_for_public_api([this, doc]() { remove(transaction_get_result(doc)); });
+        return wrap_void_call_for_public_api([this, doc]() {
+            remove(transaction_get_result(doc));
+        });
     }
     void remove(const transaction_get_result& document, VoidCallback&& cb) override;
     void remove(couchbase::transactions::transaction_get_result doc, couchbase::transactions::async_err_handler&& handler) override
@@ -627,7 +630,9 @@ class attempt_context_impl
             CB_LOG_DEBUG("ensure_open_bucket called with empty bucket_name");
             return handler(couchbase::errc::common::bucket_not_found);
         }
-        cluster_ref().open_bucket(bucket_name, [handler = std::move(handler)](std::error_code ec) { handler(ec); });
+        cluster_ref().open_bucket(bucket_name, [handler = std::move(handler)](std::error_code ec) {
+            handler(ec);
+        });
     }
 };
 

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -32,6 +32,7 @@
 #include "internal/exceptions_internal.hxx"
 #include "internal/transaction_context.hxx"
 #include "transaction_get_result.hxx"
+#include "core/impl/error.hxx"
 
 #include <chrono>
 #include <list>
@@ -87,7 +88,7 @@ class attempt_context_impl
     // transaction_context needs access to the two functions below
     friend class transaction_context;
 
-    std::pair<couchbase::transaction_op_error_context, couchbase::transactions::transaction_get_result>
+    std::pair<couchbase::error, couchbase::transactions::transaction_get_result>
     insert_raw(const couchbase::collection& coll, const std::string& id, std::vector<std::byte> content) override
     {
         return wrap_call_for_public_api([this, coll, &id, &content]() -> transaction_get_result {
@@ -111,7 +112,7 @@ class attempt_context_impl
 
     transaction_get_result replace_raw(const transaction_get_result& document, const std::vector<std::byte>& content) override;
 
-    std::pair<couchbase::transaction_op_error_context, couchbase::transactions::transaction_get_result> replace_raw(
+    std::pair<couchbase::error, couchbase::transactions::transaction_get_result> replace_raw(
       const couchbase::transactions::transaction_get_result& doc,
       std::vector<std::byte> content) override
     {
@@ -338,7 +339,7 @@ class attempt_context_impl
     ~attempt_context_impl() override;
 
     transaction_get_result get(const core::document_id& id) override;
-    std::pair<couchbase::transaction_op_error_context, couchbase::transactions::transaction_get_result> get(
+    std::pair<couchbase::error, couchbase::transactions::transaction_get_result> get(
       const couchbase::collection& coll,
       const std::string& id) override
     {
@@ -350,7 +351,7 @@ class attempt_context_impl
             return {};
         });
         if (!ctx.ec() && res.cas().empty()) {
-            return { transaction_op_error_context{ errc::transaction_op::document_not_found_exception }, res };
+            return {  { errc::transaction_op::document_not_found_exception }, res };
         }
         return { ctx, res };
     }
@@ -359,7 +360,7 @@ class attempt_context_impl
         get_optional({ coll.bucket_name(), coll.scope_name(), coll.name(), std::move(id) },
                      [this, handler = std::move(handler)](std::exception_ptr err, std::optional<transaction_get_result> res) mutable {
                          if (!res) {
-                             return handler(transaction_op_error_context{ errc::transaction_op::document_not_found_exception }, {});
+                             return handler({ errc::transaction_op::document_not_found_exception }, {});
                          }
                          return wrap_callback_for_async_public_api(err, res, std::move(handler));
                      });
@@ -370,7 +371,7 @@ class attempt_context_impl
     void get_optional(const core::document_id& id, Callback&& cb) override;
 
     void remove(const transaction_get_result& document) override;
-    couchbase::transaction_op_error_context remove(const couchbase::transactions::transaction_get_result& doc) override
+    couchbase::error remove(const couchbase::transactions::transaction_get_result& doc) override
     {
         return wrap_void_call_for_public_api([this, doc]() { remove(transaction_get_result(doc)); });
     }
@@ -386,7 +387,7 @@ class attempt_context_impl
                                                    const couchbase::transactions::transaction_query_options& options,
                                                    std::optional<std::string> query_context) override;
 
-    std::pair<couchbase::transaction_op_error_context, couchbase::transactions::transaction_query_result> do_public_query(
+    std::pair<couchbase::error, couchbase::transactions::transaction_query_result> do_public_query(
       const std::string& statement,
       const couchbase::transactions::transaction_query_options& opts,
       std::optional<std::string> query_context) override;
@@ -409,16 +410,16 @@ class attempt_context_impl
                       try {
                           std::rethrow_exception(err);
                       } catch (const transaction_operation_failed& e) {
-                          return handler(e.get_error_ctx(), {});
+                          return handler(core::impl::make_error(e.get_error_ctx()), {});
                       } catch (const op_exception& ex) {
-                          return handler(ex.ctx(), {});
+                          return handler(core::impl::make_error(ex.ctx()), {});
                       } catch (...) {
                           // just in case...
-                          return handler(transaction_op_error_context(couchbase::errc::transaction_op::unknown), {});
+                          return handler({ couchbase::errc::transaction_op::unknown }, {});
                       }
                   }
                   auto [ctx, res] = core::impl::build_transaction_query_result(*resp);
-                  handler(ctx, res);
+                  handler(core::impl::make_error(ctx), res);
               });
     }
 
@@ -557,38 +558,38 @@ class attempt_context_impl
                                             error_class ec,
                                             const std::string& message);
 
-    std::pair<couchbase::transaction_op_error_context, couchbase::transactions::transaction_get_result> wrap_call_for_public_api(
+    std::pair<couchbase::error, couchbase::transactions::transaction_get_result> wrap_call_for_public_api(
       std::function<transaction_get_result()>&& handler)
     {
         try {
             return { {}, handler().to_public_result() };
         } catch (const transaction_operation_failed& e) {
-            return { e.get_error_ctx(), {} };
+            return { core::impl::make_error(e.get_error_ctx()), {} };
         } catch (const op_exception& ex) {
-            return { ex.ctx(), {} };
+            return { core::impl::make_error(ex.ctx()), {} };
         } catch (...) {
             // the handler should catch everything else, but just in case...
-            return { transaction_op_error_context(errc::transaction_op::unknown), {} };
+            return { { errc::transaction_op::unknown }, {} };
         }
     }
 
-    couchbase::transaction_op_error_context wrap_void_call_for_public_api(std::function<void()>&& handler)
+    couchbase::error wrap_void_call_for_public_api(std::function<void()>&& handler)
     {
         try {
             handler();
             return {};
         } catch (const transaction_operation_failed& e) {
-            return e.get_error_ctx();
+            return core::impl::make_error(e.get_error_ctx());
         } catch (...) {
             // the handler should catch everything else, but just in case...
-            return transaction_op_error_context(errc::transaction_op::unknown);
+            return {errc::transaction_op::unknown };
         }
     }
 
     void wrap_callback_for_async_public_api(
       std::exception_ptr err,
       std::optional<transaction_get_result> res,
-      std::function<void(couchbase::transaction_op_error_context, couchbase::transactions::transaction_get_result)>&& cb)
+      std::function<void(couchbase::error, couchbase::transactions::transaction_get_result)>&& cb)
     {
         if (res) {
             return cb({}, res->to_public_result());
@@ -597,23 +598,23 @@ class attempt_context_impl
             try {
                 std::rethrow_exception(err);
             } catch (const op_exception& e) {
-                return cb(e.ctx(), {});
+                return cb(core::impl::make_error(e.ctx()), {});
             } catch (const transaction_operation_failed& e) {
-                return cb(e.get_error_ctx(), {});
+                return cb(core::impl::make_error(e.get_error_ctx()), {});
             } catch (...) {
-                return cb(transaction_op_error_context(errc::transaction_op::unknown), {});
+                return cb({ errc::transaction_op::unknown }, {});
             }
         }
-        return cb(transaction_op_error_context(errc::transaction_op::unknown), {});
+        return cb({errc::transaction_op::unknown }, {});
     }
 
-    void wrap_err_callback_for_async_api(std::exception_ptr err, std::function<void(couchbase::transaction_op_error_context)>&& cb)
+    void wrap_err_callback_for_async_api(std::exception_ptr err, std::function<void(couchbase::error)>&& cb)
     {
         if (err) {
             try {
                 std::rethrow_exception(err);
             } catch (const transaction_operation_failed& e) {
-                return cb(e.get_error_ctx());
+                return cb(core::impl::make_error(e.get_error_ctx()));
             } catch (...) {
                 return cb({ errc::transaction_op::unknown });
             }

--- a/core/transactions/internal/exceptions_internal.hxx
+++ b/core/transactions/internal/exceptions_internal.hxx
@@ -116,11 +116,12 @@ class attempt_expired : public client_error
  * derived from this.  The transaction logic then consumes them to decide to
  * retry, or rollback the transaction.
  */
-class transaction_operation_failed : public std::runtime_error
+class transaction_operation_failed : public std::runtime_error, public couchbase::error
 {
   public:
     explicit transaction_operation_failed(error_class ec, const std::string& what)
       : std::runtime_error(what)
+      , couchbase::error( errc::transaction_op::transaction_operation_failed )
       , ec_(ec)
       , retry_(false)
       , rollback_(true)
@@ -130,6 +131,7 @@ class transaction_operation_failed : public std::runtime_error
     }
     explicit transaction_operation_failed(const client_error& client_err)
       : std::runtime_error(client_err.what())
+      , couchbase::error( errc::transaction_op::transaction_operation_failed )
       , ec_(client_err.ec())
       , retry_(false)
       , rollback_(true)

--- a/core/transactions/internal/exceptions_internal.hxx
+++ b/core/transactions/internal/exceptions_internal.hxx
@@ -116,12 +116,14 @@ class attempt_expired : public client_error
  * derived from this.  The transaction logic then consumes them to decide to
  * retry, or rollback the transaction.
  */
-class transaction_operation_failed : public std::runtime_error, public couchbase::error
+class transaction_operation_failed
+  : public std::runtime_error
+  , public couchbase::error
 {
   public:
     explicit transaction_operation_failed(error_class ec, const std::string& what)
       : std::runtime_error(what)
-      , couchbase::error( errc::transaction_op::transaction_operation_failed )
+      , couchbase::error(errc::transaction_op::transaction_operation_failed)
       , ec_(ec)
       , retry_(false)
       , rollback_(true)
@@ -131,7 +133,7 @@ class transaction_operation_failed : public std::runtime_error, public couchbase
     }
     explicit transaction_operation_failed(const client_error& client_err)
       : std::runtime_error(client_err.what())
-      , couchbase::error( errc::transaction_op::transaction_operation_failed )
+      , couchbase::error(errc::transaction_op::transaction_operation_failed)
       , ec_(client_err.ec())
       , retry_(false)
       , rollback_(true)

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -26,8 +26,8 @@
 #include "internal/transactions_cleanup.hxx"
 #include "internal/utils.hxx"
 
-#include "couchbase/error.hxx"
 #include "core/impl/error.hxx"
+#include "couchbase/error.hxx"
 
 #include <system_error>
 

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -88,7 +88,9 @@ std::future<std::pair<std::error_code, std::shared_ptr<transactions>>>
 transactions::create(core::cluster cluster, const couchbase::transactions::transactions_config::built& config)
 {
     auto barrier = std::make_shared<std::promise<std::pair<std::error_code, std::shared_ptr<transactions>>>>();
-    create(std::move(cluster), config, [barrier](auto ec, auto txns) mutable { barrier->set_value({ ec, txns }); });
+    create(std::move(cluster), config, [barrier](auto ec, auto txns) mutable {
+        barrier->set_value({ ec, txns });
+    });
     return barrier->get_future();
 }
 

--- a/couchbase/error.hxx
+++ b/couchbase/error.hxx
@@ -33,6 +33,8 @@ class error
     error(std::error_code ec, std::string message = {}, error_context ctx = {});
     error(std::error_code ec, std::string message, error_context ctx, error cause);
 
+    virtual ~error() = default;
+
     [[nodiscard]] auto ec() const -> std::error_code;
     [[nodiscard]] auto message() const -> const std::string&;
     [[nodiscard]] auto ctx() const -> const error_context&;

--- a/couchbase/error_codes.hxx
+++ b/couchbase/error_codes.hxx
@@ -1112,6 +1112,10 @@ enum class transaction_op {
     rollback_not_permitted = 1319,
     transaction_already_aborted = 1320,
     transaction_already_committed = 1321,
+    /**
+     * Special code for internal use
+     */
+    transaction_operation_failed = 1399,
 };
 
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN

--- a/couchbase/transaction_op_error_context.hxx
+++ b/couchbase/transaction_op_error_context.hxx
@@ -64,13 +64,13 @@ class transaction_op_error_context
      *
      * @return the error_context associated with the underlying cause of this error.
      */
-    [[nodiscard]] std::variant<key_value_error_context, query_error_context> cause() const
+    [[nodiscard]] std::variant<std::monostate, key_value_error_context, query_error_context> cause() const
     {
         return cause_;
     }
 
   private:
     std::error_code ec_{}; // a transaction_op error_code
-    std::variant<key_value_error_context, query_error_context> cause_{};
+    std::variant<std::monostate, key_value_error_context, query_error_context> cause_{};
 };
 } // namespace couchbase

--- a/couchbase/transactions.hxx
+++ b/couchbase/transactions.hxx
@@ -52,8 +52,7 @@ class transactions
      * @param cfg if passed in, these options override the defaults, or those set in the {@link cluster_options}.
      * @return an {@link transaction_error_context}, and a {@link transaction_result} representing the results of the transaction.
      */
-    virtual std::pair<error, transaction_result> run(txn_logic&& logic,
-                                                                         const transaction_options& cfg = transaction_options()) = 0;
+    virtual std::pair<error, transaction_result> run(txn_logic&& logic, const transaction_options& cfg = transaction_options()) = 0;
     /**
      * Run an asynchronous transaction.
      *

--- a/couchbase/transactions.hxx
+++ b/couchbase/transactions.hxx
@@ -28,7 +28,7 @@ namespace couchbase::transactions
 {
 using txn_logic = std::function<void(attempt_context&)>;
 using async_txn_logic = std::function<void(async_attempt_context&)>;
-using async_txn_complete_logic = std::function<void(couchbase::transaction_error_context, transaction_result)>;
+using async_txn_complete_logic = std::function<void(error, transaction_result)>;
 
 /**
  * The transactions object is used to initiate a transaction.
@@ -52,7 +52,7 @@ class transactions
      * @param cfg if passed in, these options override the defaults, or those set in the {@link cluster_options}.
      * @return an {@link transaction_error_context}, and a {@link transaction_result} representing the results of the transaction.
      */
-    virtual std::pair<transaction_error_context, transaction_result> run(txn_logic&& logic,
+    virtual std::pair<error, transaction_result> run(txn_logic&& logic,
                                                                          const transaction_options& cfg = transaction_options()) = 0;
     /**
      * Run an asynchronous transaction.

--- a/couchbase/transactions/async_attempt_context.hxx
+++ b/couchbase/transactions/async_attempt_context.hxx
@@ -26,9 +26,9 @@ class scope;
 
 namespace transactions
 {
-using async_result_handler = std::function<void(transaction_op_error_context, transaction_get_result)>;
-using async_query_handler = std::function<void(transaction_op_error_context, transaction_query_result)>;
-using async_err_handler = std::function<void(transaction_op_error_context)>;
+using async_result_handler = std::function<void(error, transaction_get_result)>;
+using async_query_handler = std::function<void(error, transaction_query_result)>;
+using async_err_handler = std::function<void(error)>;
 
 /**
  * The async_attempt_context is used for all asynchronous transaction operations

--- a/couchbase/transactions/attempt_context.hxx
+++ b/couchbase/transactions/attempt_context.hxx
@@ -47,8 +47,7 @@ class attempt_context
      * @param id The unique id of the document.
      * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
      */
-    virtual std::pair<error, transaction_get_result> get(const couchbase::collection& coll,
-                                                                                const std::string& id) = 0;
+    virtual std::pair<error, transaction_get_result> get(const couchbase::collection& coll, const std::string& id) = 0;
 
     /**
      * Insert a document into a collection.
@@ -63,9 +62,7 @@ class attempt_context
      * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
      */
     template<typename Content>
-    std::pair<error, transaction_get_result> insert(const couchbase::collection& coll,
-                                                                           const std::string& id,
-                                                                           const Content& content)
+    std::pair<error, transaction_get_result> insert(const couchbase::collection& coll, const std::string& id, const Content& content)
     {
         if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
             return insert_raw(coll, id, content);
@@ -112,8 +109,7 @@ class attempt_context
      * @param options Options for the query.
      * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
      */
-    std::pair<error, transaction_query_result> query(const std::string& statement,
-                                                                            const transaction_query_options& options = {});
+    std::pair<error, transaction_query_result> query(const std::string& statement, const transaction_query_options& options = {});
 
     /**
      * Perform a scoped query.
@@ -124,23 +120,22 @@ class attempt_context
      * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
      */
     std::pair<error, transaction_query_result> query(const scope& scope,
-                                                                            const std::string& statement,
-                                                                            const transaction_query_options& opts = {});
+                                                     const std::string& statement,
+                                                     const transaction_query_options& opts = {});
 
     virtual ~attempt_context() = default;
 
   protected:
     /** @private */
-    virtual std::pair<error, transaction_get_result> replace_raw(const transaction_get_result& doc,
-                                                                                        std::vector<std::byte> content) = 0;
+    virtual std::pair<error, transaction_get_result> replace_raw(const transaction_get_result& doc, std::vector<std::byte> content) = 0;
     /** @private */
     virtual std::pair<error, transaction_get_result> insert_raw(const couchbase::collection& coll,
-                                                                                       const std::string& id,
-                                                                                       std::vector<std::byte> content) = 0;
+                                                                const std::string& id,
+                                                                std::vector<std::byte> content) = 0;
     /** @private */
     virtual std::pair<error, transaction_query_result> do_public_query(const std::string& statement,
-                                                                                              const transaction_query_options& options,
-                                                                                              std::optional<std::string> query_context) = 0;
+                                                                       const transaction_query_options& options,
+                                                                       std::optional<std::string> query_context) = 0;
 };
 } // namespace transactions
 } // namespace couchbase

--- a/couchbase/transactions/attempt_context.hxx
+++ b/couchbase/transactions/attempt_context.hxx
@@ -45,9 +45,9 @@ class attempt_context
      *
      * @param coll The collection which contains the document.
      * @param id The unique id of the document.
-     * @return The result of the operation, which is an @ref transaction_op_error_context and a @ref transaction_get_result.
+     * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
      */
-    virtual std::pair<transaction_op_error_context, transaction_get_result> get(const couchbase::collection& coll,
+    virtual std::pair<error, transaction_get_result> get(const couchbase::collection& coll,
                                                                                 const std::string& id) = 0;
 
     /**
@@ -60,10 +60,10 @@ class attempt_context
      * @param coll Collection in which to insert document.
      * @param id The unique id of the document.
      * @param content The content of the document.
-     * @return The result of the operation, which is an @ref transaction_op_error_context and a @ref transaction_get_result.
+     * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
      */
     template<typename Content>
-    std::pair<transaction_op_error_context, transaction_get_result> insert(const couchbase::collection& coll,
+    std::pair<error, transaction_get_result> insert(const couchbase::collection& coll,
                                                                            const std::string& id,
                                                                            const Content& content)
     {
@@ -83,10 +83,10 @@ class attempt_context
      * @tparam Content Type of the contents of the document.
      * @param doc Document whose content will be replaced.  This is gotten from a call to @ref attempt_context::get
      * @param content New content of the document.
-     * @return The result of the operation, which is an @ref transaction_op_error_context and a @ref transaction_get_result.
+     * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
      */
     template<typename Content>
-    std::pair<transaction_op_error_context, transaction_get_result> replace(const transaction_get_result& doc, const Content& content)
+    std::pair<error, transaction_get_result> replace(const transaction_get_result& doc, const Content& content)
     {
         if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
             return replace_raw(doc, content);
@@ -103,16 +103,16 @@ class attempt_context
      * @param doc The document to remove.
      * @return The result of the operation.
      */
-    virtual transaction_op_error_context remove(const transaction_get_result& doc) = 0;
+    virtual error remove(const transaction_get_result& doc) = 0;
 
     /**
      * Perform an unscoped query.
      *
      * @param statement The query statement.
      * @param options Options for the query.
-     * @return The result of the operation, with is an @ref transaction_op_error_context and a @ref transaction_query_result.
+     * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
      */
-    std::pair<transaction_op_error_context, transaction_query_result> query(const std::string& statement,
+    std::pair<error, transaction_query_result> query(const std::string& statement,
                                                                             const transaction_query_options& options = {});
 
     /**
@@ -121,9 +121,9 @@ class attempt_context
      * @param scope Scope for the query.
      * @param statement The query statement.
      * @param opts Options for the query.
-     * @return The result of the operation, with is an @ref transaction_op_error_context and a @ref transaction_query_result.
+     * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
      */
-    std::pair<transaction_op_error_context, transaction_query_result> query(const scope& scope,
+    std::pair<error, transaction_query_result> query(const scope& scope,
                                                                             const std::string& statement,
                                                                             const transaction_query_options& opts = {});
 
@@ -131,14 +131,14 @@ class attempt_context
 
   protected:
     /** @private */
-    virtual std::pair<transaction_op_error_context, transaction_get_result> replace_raw(const transaction_get_result& doc,
+    virtual std::pair<error, transaction_get_result> replace_raw(const transaction_get_result& doc,
                                                                                         std::vector<std::byte> content) = 0;
     /** @private */
-    virtual std::pair<transaction_op_error_context, transaction_get_result> insert_raw(const couchbase::collection& coll,
+    virtual std::pair<error, transaction_get_result> insert_raw(const couchbase::collection& coll,
                                                                                        const std::string& id,
                                                                                        std::vector<std::byte> content) = 0;
     /** @private */
-    virtual std::pair<transaction_op_error_context, transaction_query_result> do_public_query(const std::string& statement,
+    virtual std::pair<error, transaction_query_result> do_public_query(const std::string& statement,
                                                                                               const transaction_query_options& options,
                                                                                               std::optional<std::string> query_context) = 0;
 };

--- a/examples/async_game_server.cxx
+++ b/examples/async_game_server.cxx
@@ -134,12 +134,11 @@ class GameServer
         return experience / 100;
     }
 
-    std::future<std::pair<couchbase::error, transaction_result>> player_hits_monster(
-      int damage,
-      const couchbase::collection& collection,
-      const std::string& player_id,
-      const std::string& monster_id,
-      std::atomic<bool>& exists)
+    std::future<std::pair<couchbase::error, transaction_result>> player_hits_monster(int damage,
+                                                                                     const couchbase::collection& collection,
+                                                                                     const std::string& player_id,
+                                                                                     const std::string& monster_id,
+                                                                                     std::atomic<bool>& exists)
     {
         auto barrier = std::make_shared<std::promise<std::pair<couchbase::error, transaction_result>>>();
         auto f = barrier->get_future();

--- a/examples/async_game_server.cxx
+++ b/examples/async_game_server.cxx
@@ -144,71 +144,72 @@ class GameServer
         auto f = barrier->get_future();
         transactions_->run(
           [this, damage, collection, player_id, monster_id, &exists](async_attempt_context& ctx) {
-              ctx.get(
-                collection,
-                monster_id,
-                [&ctx, this, collection, monster_id, player_id, &exists, damage = std::move(damage)](auto e, auto monster) {
-                    if (e.ec() == couchbase::errc::transaction_op::document_not_found_exception) {
-                        std::cout << "monster no longer exists" << std::endl;
-                        exists = false;
-                        return;
-                    }
-                    auto monster_body = monster.template content<Monster>();
-                    auto monster_hitpoints = monster_body.hitpoints;
-                    auto monster_new_hitpoints = monster_hitpoints - damage;
+              ctx.get(collection,
+                      monster_id,
+                      [&ctx, this, collection, monster_id, player_id, &exists, damage = std::move(damage)](auto e, auto monster) {
+                          if (e.ec() == couchbase::errc::transaction_op::document_not_found_exception) {
+                              std::cout << "monster no longer exists" << std::endl;
+                              exists = false;
+                              return;
+                          }
+                          auto monster_body = monster.template content<Monster>();
+                          auto monster_hitpoints = monster_body.hitpoints;
+                          auto monster_new_hitpoints = monster_hitpoints - damage;
 
-                    std::cout << "Monster " << monster_id << " had " << monster_hitpoints << " hitpoints, took " << damage
-                              << " damage, now has " << monster_new_hitpoints << " hitpoints" << std::endl;
-                    if (monster_new_hitpoints <= 0) {
-                        // Monster is killed. The remove is just for demoing, and a more realistic examples would set a "dead" flag or
-                        // similar.
-                        ctx.remove(monster, [](auto e) {
-                            if (e.ec()) {
-                                std::cout << "error removing monster: " << e.ec().message() << std::endl;
-                            }
-                        });
-                        // also, in parallel, get/update player
-                        ctx.get(collection, player_id, [&ctx, player_id, monster_id, monster_body, this](auto e, auto player) {
-                            if (e.ec()) {
-                                std::cout << "error getting player: " << e.ec().message() << std::endl;
-                                return;
-                            }
-                            const Player& player_body = player.template content<Player>();
+                          std::cout << "Monster " << monster_id << " had " << monster_hitpoints << " hitpoints, took " << damage
+                                    << " damage, now has " << monster_new_hitpoints << " hitpoints" << std::endl;
+                          if (monster_new_hitpoints <= 0) {
+                              // Monster is killed. The remove is just for demoing, and a more realistic examples would set a "dead" flag or
+                              // similar.
+                              ctx.remove(monster, [](auto e) {
+                                  if (e.ec()) {
+                                      std::cout << "error removing monster: " << e.ec().message() << std::endl;
+                                  }
+                              });
+                              // also, in parallel, get/update player
+                              ctx.get(collection, player_id, [&ctx, player_id, monster_id, monster_body, this](auto e, auto player) {
+                                  if (e.ec()) {
+                                      std::cout << "error getting player: " << e.ec().message() << std::endl;
+                                      return;
+                                  }
+                                  const Player& player_body = player.template content<Player>();
 
-                            // the player earns experience for killing the monster
-                            int experience_for_killing_monster = monster_body.experience_when_killed;
-                            int player_experience = player_body.experience;
-                            int player_new_experience = player_experience + experience_for_killing_monster;
-                            int player_new_level = calculate_level_for_experience(player_new_experience);
+                                  // the player earns experience for killing the monster
+                                  int experience_for_killing_monster = monster_body.experience_when_killed;
+                                  int player_experience = player_body.experience;
+                                  int player_new_experience = player_experience + experience_for_killing_monster;
+                                  int player_new_level = calculate_level_for_experience(player_new_experience);
 
-                            std::cout << "Monster " << monster_id << " was killed. Player " << player_id << " gains "
-                                      << experience_for_killing_monster << " experience, now has level " << player_new_level << std::endl;
+                                  std::cout << "Monster " << monster_id << " was killed. Player " << player_id << " gains "
+                                            << experience_for_killing_monster << " experience, now has level " << player_new_level
+                                            << std::endl;
 
-                            Player player_new_body = player_body;
-                            player_new_body.experience = player_new_experience;
-                            player_new_body.level = player_new_level;
-                            ctx.replace(player, player_new_body, [](auto e, auto) {
-                                if (e.ec()) {
-                                    std::cout << "Error updating player :" << e.ec().message() << std::endl;
-                                }
-                            });
-                        });
-                    } else {
-                        std::cout << "Monster " << monster_id << " is damaged but alive" << std::endl;
+                                  Player player_new_body = player_body;
+                                  player_new_body.experience = player_new_experience;
+                                  player_new_body.level = player_new_level;
+                                  ctx.replace(player, player_new_body, [](auto e, auto) {
+                                      if (e.ec()) {
+                                          std::cout << "Error updating player :" << e.ec().message() << std::endl;
+                                      }
+                                  });
+                              });
+                          } else {
+                              std::cout << "Monster " << monster_id << " is damaged but alive" << std::endl;
 
-                        Monster monster_new_body = monster_body;
-                        monster_new_body.hitpoints = monster_new_hitpoints;
-                        ctx.replace(monster, monster_new_body, [monster_new_body](auto e, auto res) {
-                            if (e.ec()) {
-                                std::cout << "Error updating monster :" << e.ec().message() << std::endl;
-                            } else {
-                                auto body = couchbase::codec::tao_json_serializer::serialize(monster_new_body);
-                                std::cout << "Monster body updated to :" << std::string(reinterpret_cast<char*>(&body.front()), body.size())
-                                          << std::endl;
-                            }
-                        });
-                    }
-                });
+                              Monster monster_new_body = monster_body;
+                              monster_new_body.hitpoints = monster_new_hitpoints;
+                              ctx.replace(monster, monster_new_body, [monster_new_body](auto e, auto res) {
+                                  if (e.ec()) {
+                                      std::cout << "Error updating monster :" << e.ec().message() << std::endl;
+                                  } else {
+                                      auto body = couchbase::codec::tao_json_serializer::serialize(monster_new_body);
+                                      std::cout
+                                        << "Monster body updated to :" << std::string(reinterpret_cast<char*>(&body.front()), body.size())
+                                        << std::endl;
+                                  }
+                              });
+                          }
+                      });
           },
           [barrier](auto err, auto res) {
               barrier->set_value({ err, res });
@@ -233,7 +234,9 @@ main()
 
     std::list<std::thread> io_threads;
     for (int i = 0; i < 2 * (NUM_THREADS + 1); i++) {
-        io_threads.emplace_back([&io]() { io.run(); });
+        io_threads.emplace_back([&io]() {
+            io.run();
+        });
     }
 
     std::uniform_int_distribution<int> hit_distribution(1, 6);

--- a/examples/async_game_server.cxx
+++ b/examples/async_game_server.cxx
@@ -134,14 +134,14 @@ class GameServer
         return experience / 100;
     }
 
-    std::future<std::pair<couchbase::transaction_error_context, transaction_result>> player_hits_monster(
+    std::future<std::pair<couchbase::error, transaction_result>> player_hits_monster(
       int damage,
       const couchbase::collection& collection,
       const std::string& player_id,
       const std::string& monster_id,
       std::atomic<bool>& exists)
     {
-        auto barrier = std::make_shared<std::promise<std::pair<couchbase::transaction_error_context, transaction_result>>>();
+        auto barrier = std::make_shared<std::promise<std::pair<couchbase::error, transaction_result>>>();
         auto f = barrier->get_future();
         transactions_->run(
           [this, damage, collection, player_id, monster_id, &exists](async_attempt_context& ctx) {

--- a/examples/bulk_transactional_api.cxx
+++ b/examples/bulk_transactional_api.cxx
@@ -464,7 +464,9 @@ main()
 
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(arguments.username, arguments.password);
     options.apply_profile("wan_development");

--- a/examples/bulk_transactional_api.cxx
+++ b/examples/bulk_transactional_api.cxx
@@ -191,7 +191,7 @@ run_workload_sequential(const std::shared_ptr<couchbase::transactions::transacti
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().message());
+            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -232,7 +232,7 @@ run_workload_sequential(const std::shared_ptr<couchbase::transactions::transacti
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().message());
+            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -321,7 +321,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
         std::map<std::string, std::size_t> errors;
 
         auto tx_promise =
-          std::make_shared<std::promise<std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result>>>();
+          std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
         auto tx_future = tx_promise->get_future();
 
         auto schedule_start = std::chrono::system_clock::now();
@@ -357,7 +357,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().message());
+            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -378,7 +378,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
         std::map<std::string, std::size_t> errors;
 
         auto tx_promise =
-          std::make_shared<std::promise<std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result>>>();
+          std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
         auto tx_future = tx_promise->get_future();
 
         auto schedule_start = std::chrono::system_clock::now();
@@ -414,7 +414,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().message());
+            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }

--- a/examples/bulk_transactional_api.cxx
+++ b/examples/bulk_transactional_api.cxx
@@ -191,7 +191,9 @@ run_workload_sequential(const std::shared_ptr<couchbase::transactions::transacti
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
+            fmt::print("\tTransaction completed with error {}, cause={}\n",
+                       err.ec().message(),
+                       err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -232,7 +234,9 @@ run_workload_sequential(const std::shared_ptr<couchbase::transactions::transacti
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
+            fmt::print("\tTransaction completed with error {}, cause={}\n",
+                       err.ec().message(),
+                       err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -320,8 +324,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
     {
         std::map<std::string, std::size_t> errors;
 
-        auto tx_promise =
-          std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
+        auto tx_promise = std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
         auto tx_future = tx_promise->get_future();
 
         auto schedule_start = std::chrono::system_clock::now();
@@ -357,7 +360,9 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
+            fmt::print("\tTransaction completed with error {}, cause={}\n",
+                       err.ec().message(),
+                       err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }
@@ -377,8 +382,7 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
     {
         std::map<std::string, std::size_t> errors;
 
-        auto tx_promise =
-          std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
+        auto tx_promise = std::make_shared<std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>>();
         auto tx_future = tx_promise->get_future();
 
         auto schedule_start = std::chrono::system_clock::now();
@@ -414,7 +418,9 @@ run_workload_bulk(const std::shared_ptr<couchbase::transactions::transactions>& 
                    std::chrono::duration_cast<std::chrono::seconds>(exec_end - exec_start).count(),
                    std::chrono::duration_cast<std::chrono::milliseconds>(exec_end - exec_start).count() / arguments.number_of_operations);
         if (err.ec()) {
-            fmt::print("\tTransaction completed with error {}, cause={}\n", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "");
+            fmt::print("\tTransaction completed with error {}, cause={}\n",
+                       err.ec().message(),
+                       err.cause().has_value() ? err.cause().value().ec().message() : "");
             if (err.ec() == couchbase::errc::transaction::expired) {
                 fmt::print("\tINFO: Try to increase CB_TRANSACTION_TIMEOUT, current value is {} seconds\n", arguments.transaction_timeout);
             }

--- a/examples/bulk_transactional_get_replace.cxx
+++ b/examples/bulk_transactional_get_replace.cxx
@@ -258,7 +258,9 @@ main()
 
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(arguments.username, arguments.password);
     options.apply_profile("wan_development");

--- a/examples/bulk_transactional_get_replace.cxx
+++ b/examples/bulk_transactional_get_replace.cxx
@@ -145,8 +145,7 @@ run_workload(const std::shared_ptr<couchbase::transactions::transactions>& trans
     {
         std::map<std::string, std::size_t> errors;
 
-        using transaction_promise =
-          std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>;
+        using transaction_promise = std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>;
         std::vector<transaction_promise> results;
         results.resize(arguments.number_of_transactions);
 
@@ -200,7 +199,8 @@ run_workload(const std::shared_ptr<couchbase::transactions::transactions>& trans
         for (auto& promise : results) {
             auto [err, result] = promise.get_future().get();
             if (err.ec()) {
-                transactions_errors[fmt::format("error={}, cause={}", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "")]++;
+                transactions_errors[fmt::format(
+                  "error={}, cause={}", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "")]++;
             }
         }
         auto exec_end = std::chrono::system_clock::now();

--- a/examples/bulk_transactional_get_replace.cxx
+++ b/examples/bulk_transactional_get_replace.cxx
@@ -146,7 +146,7 @@ run_workload(const std::shared_ptr<couchbase::transactions::transactions>& trans
         std::map<std::string, std::size_t> errors;
 
         using transaction_promise =
-          std::promise<std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result>>;
+          std::promise<std::pair<couchbase::error, couchbase::transactions::transaction_result>>;
         std::vector<transaction_promise> results;
         results.resize(arguments.number_of_transactions);
 
@@ -200,7 +200,7 @@ run_workload(const std::shared_ptr<couchbase::transactions::transactions>& trans
         for (auto& promise : results) {
             auto [err, result] = promise.get_future().get();
             if (err.ec()) {
-                transactions_errors[fmt::format("error={}, cause={}", err.ec().message(), err.cause().message())]++;
+                transactions_errors[fmt::format("error={}, cause={}", err.ec().message(), err.cause().has_value() ? err.cause().value().ec().message() : "")]++;
             }
         }
         auto exec_end = std::chrono::system_clock::now();

--- a/examples/game_server.cxx
+++ b/examples/game_server.cxx
@@ -190,7 +190,8 @@ class GameServer
             }
         });
         if (err.ec()) {
-            std::cout << "txn error during player_hits_monster: " << err.ec().message() << ", " << (err.cause().has_value() ? err.cause().value().ec().message() : "") << std::endl;
+            std::cout << "txn error during player_hits_monster: " << err.ec().message() << ", "
+                      << (err.cause().has_value() ? err.cause().value().ec().message() : "") << std::endl;
         }
     }
 };

--- a/examples/game_server.cxx
+++ b/examples/game_server.cxx
@@ -190,7 +190,7 @@ class GameServer
             }
         });
         if (err.ec()) {
-            std::cout << "txn error during player_hits_monster: " << err.ec().message() << ", " << err.cause().message() << std::endl;
+            std::cout << "txn error during player_hits_monster: " << err.ec().message() << ", " << (err.cause().has_value() ? err.cause().value().ec().message() : "") << std::endl;
         }
     }
 };

--- a/test/test_transaction_examples.cxx
+++ b/test/test_transaction_examples.cxx
@@ -94,7 +94,10 @@ main(int argc, const char* argv[])
           });
         // [3.5] check the overall status of the transaction
         if (tx_err.ec()) {
-            fmt::print(stderr, "error in transaction {}, cause: {}\n", tx_err.ec().message(), tx_err.cause().has_value() ? tx_err.cause().value().ec().message() : "");
+            fmt::print(stderr,
+                       "error in transaction {}, cause: {}\n",
+                       tx_err.ec().message(),
+                       tx_err.cause().has_value() ? tx_err.cause().value().ec().message() : "");
             retval = 1;
         } else {
             fmt::print("transaction {} completed successfully\n", tx_res.transaction_id);

--- a/test/test_transaction_examples.cxx
+++ b/test/test_transaction_examples.cxx
@@ -94,7 +94,7 @@ main(int argc, const char* argv[])
           });
         // [3.5] check the overall status of the transaction
         if (tx_err.ec()) {
-            fmt::print(stderr, "error in transaction {}, cause: {}\n", tx_err.ec().message(), tx_err.cause().message());
+            fmt::print(stderr, "error in transaction {}, cause: {}\n", tx_err.ec().message(), tx_err.cause().has_value() ? tx_err.cause().value().ec().message() : "");
             retval = 1;
         } else {
             fmt::print("transaction {} completed successfully\n", tx_res.transaction_id);

--- a/test/test_transaction_examples.cxx
+++ b/test/test_transaction_examples.cxx
@@ -49,7 +49,9 @@ main(int argc, const char* argv[])
     // run IO context on separate thread
     asio::io_context io;
     auto guard = asio::make_work_guard(io);
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
 
     auto options = couchbase::cluster_options(username, password);
     // customize through the 'options'.

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -74,7 +74,9 @@ TEST_CASE("transactions public async API: can get fail as expected", "[transacti
     auto f = barrier->get_future();
     c.transactions()->run(
       [id, coll](couchbase::transactions::async_attempt_context& ctx) {
-          ctx.get(coll, id, [id](auto e, auto) { CHECK(e.ec() == couchbase::errc::transaction_op::document_not_found_exception); });
+          ctx.get(coll, id, [id](auto e, auto) {
+              CHECK(e.ec() == couchbase::errc::transaction_op::document_not_found_exception);
+          });
       },
       [barrier](auto e, auto res) {
           CHECK_FALSE(e.ec());
@@ -101,7 +103,9 @@ TEST_CASE("transactions public async API: can async remove", "[transactions]")
       [coll, id](couchbase::transactions::async_attempt_context& ctx) {
           ctx.get(coll, id, [&ctx](auto e, auto res) {
               CHECK_FALSE(e.ec());
-              ctx.remove(res, [](auto remove_err) { CHECK_FALSE(remove_err.ec()); });
+              ctx.remove(res, [](auto remove_err) {
+                  CHECK_FALSE(remove_err.ec());
+              });
           });
       },
       [barrier](auto e, auto res) {
@@ -132,7 +136,9 @@ TEST_CASE("transactions public async API: async remove with bad cas fails as exp
               // all this to change the cas...
               couchbase::core::transactions::transaction_get_result temp_doc(res);
               temp_doc.cas(100);
-              ctx.remove(temp_doc.to_public_result(), [](auto remove_err) { CHECK(remove_err.ec()); });
+              ctx.remove(temp_doc.to_public_result(), [](auto remove_err) {
+                  CHECK(remove_err.ec());
+              });
           });
       },
       [barrier](auto e, auto res) {
@@ -157,7 +163,9 @@ TEST_CASE("transactions public async API: can async insert", "[transactions]")
     auto f = barrier->get_future();
     c.transactions()->run(
       [id, coll](couchbase::transactions::async_attempt_context& ctx) {
-          ctx.insert(coll, id, async_content, [coll, id](auto e, auto) { CHECK_FALSE(e.ec()); });
+          ctx.insert(coll, id, async_content, [coll, id](auto e, auto) {
+              CHECK_FALSE(e.ec());
+          });
       },
       [barrier](auto e, auto res) {
           CHECK_FALSE(res.transaction_id.empty());
@@ -247,7 +255,9 @@ TEST_CASE("transactions public async API: async replace fails as expected with b
               // all this to change the cas...
               couchbase::core::transactions::transaction_get_result temp_doc(res);
               temp_doc.cas(100);
-              ctx.replace(temp_doc.to_public_result(), new_content, [](auto replace_e, auto) { CHECK(replace_e.ec()); });
+              ctx.replace(temp_doc.to_public_result(), new_content, [](auto replace_e, auto) {
+                  CHECK(replace_e.ec());
+              });
           });
       },
       [barrier](auto e, auto tx_result) {
@@ -351,7 +361,9 @@ TEST_CASE("transactions public async API: can do mutating query", "[transactions
     c.transactions()->run(
       [id, test_ctx = integration.ctx](couchbase::transactions::async_attempt_context& ctx) {
           ctx.query(fmt::format(R"(INSERT INTO `{}` (KEY, VALUE) VALUES("{}", {}))", test_ctx.bucket, id, async_content_json),
-                    [](auto e, auto) { CHECK_FALSE(e.ec()); });
+                    [](auto e, auto) {
+                        CHECK_FALSE(e.ec());
+                    });
       },
       [barrier](auto e, auto res) {
           CHECK_FALSE(e.ec());
@@ -382,7 +394,8 @@ TEST_CASE("transactions public async API: some query errors rollback", "[transac
                     [id, &ctx, &test_ctx](auto e, auto) {
                         CHECK_FALSE(e.ec());
                         ctx.query(fmt::format(R"(INSERT INTO `{}` (KEY, VALUE) VALUES("{}", {}))", test_ctx.bucket, id, async_content_json),
-                                  [](auto, auto) {});
+                                  [](auto, auto) {
+                                  });
                     });
       },
       [barrier](auto e, auto res) {

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -314,7 +314,9 @@ TEST_CASE("transactions public async API: can set transaction options", "[transa
               // all this to change the cas...
               couchbase::core::transactions::transaction_get_result temp_doc(doc);
               temp_doc.cas(100);
-              ctx.remove(temp_doc.to_public_result(), [](const couchbase::error& remove_err) { CHECK(remove_err.ec()); });
+              ctx.remove(temp_doc.to_public_result(), [](const couchbase::error& remove_err) {
+                  CHECK(remove_err.ec());
+              });
           });
       },
       [&begin, &cfg, barrier](auto e, auto res) {

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -314,7 +314,7 @@ TEST_CASE("transactions public async API: can set transaction options", "[transa
               // all this to change the cas...
               couchbase::core::transactions::transaction_get_result temp_doc(doc);
               temp_doc.cas(100);
-              ctx.remove(temp_doc.to_public_result(), [](couchbase::transaction_op_error_context remove_err) { CHECK(remove_err.ec()); });
+              ctx.remove(temp_doc.to_public_result(), [](const couchbase::error& remove_err) { CHECK(remove_err.ec()); });
           });
       },
       [&begin, &cfg, barrier](auto e, auto res) {

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -332,7 +332,8 @@ TEST_CASE("transactions public blocking API: remove fails as expected with missi
     CHECK_FALSE(result.transaction_id.empty());
     CHECK_FALSE(result.unstaging_complete);
     CHECK(tx_err.ec() == couchbase::errc::transaction::failed);
-    CHECK(tx_err.cause() == couchbase::errc::transaction_op::unknown);
+    CHECK(tx_err.cause().has_value());
+    CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::unknown);
 }
 
 TEST_CASE("transactions public blocking API: uncaught exception in lambda will rollback without retry", "[transactions]")
@@ -353,7 +354,8 @@ TEST_CASE("transactions public blocking API: uncaught exception in lambda will r
     CHECK_FALSE(result.transaction_id.empty());
     CHECK_FALSE(result.unstaging_complete);
     CHECK(tx_err.ec() == couchbase::errc::transaction::failed);
-    CHECK(tx_err.cause() == couchbase::errc::transaction_op::unknown);
+    CHECK(tx_err.cause().has_value());
+    CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::unknown);
 }
 
 TEST_CASE("transactions public blocking API: can pass per-transaction configs", "[transactions]")
@@ -499,7 +501,6 @@ TEST_CASE("transactions public blocking API: some query errors are seen immediat
       [](couchbase::transactions::attempt_context& ctx) {
           auto [e, res] = ctx.query("I am not a valid n1ql query");
           CHECK(e.ec());
-          CHECK(std::holds_alternative<couchbase::query_error_context>(e.cause()));
       },
       couchbase::transactions::transaction_options().timeout(std::chrono::seconds(10)));
     CHECK_FALSE(tx_err.ec());

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -53,7 +53,9 @@ with_new_cluster(test::utils::integration_test_guard& integration, std::function
     // make new virginal public cluster
 
     asio::io_context io;
-    std::thread io_thread([&io]() { io.run(); });
+    std::thread io_thread([&io]() {
+        io.run();
+    });
     auto options = couchbase::cluster_options(integration.ctx.username, integration.ctx.password);
     auto [cluster, ec] = couchbase::cluster::connect(io, integration.ctx.connection_string, options).get();
     CHECK_FALSE(ec);


### PR DESCRIPTION
Changes:
- Changed transactions APIs to use couchbase::error
- Made couchbase::error polymorphic & extended by transaction_operation_failed 