### PR TITLE
CXXCBC-523: Clean up dump_configuration config output

### DIFF
--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -467,17 +467,16 @@ class mcbp_session_impl
                         case protocol::client_opcode::get_cluster_config: {
                             protocol::cmd_info info{ session_->connection_endpoints_.remote_address,
                                                      session_->connection_endpoints_.remote.port() };
-                            if (session_->origin_.options().dump_configuration) {
-                                std::string_view config_text{ reinterpret_cast<const char*>(msg.body.data()), msg.body.size() };
+                            protocol::client_response<protocol::get_cluster_config_response_body> resp(std::move(msg), info);
+                            if (session_->origin_.options().dump_configuration && resp.body().config_text().has_value()) {
                                 CB_LOG_TRACE(
                                   "{} configuration from get_cluster_config request (bootstrap, size={}, endpoint=\"{}:{}\"), {}",
                                   session_->log_prefix_,
-                                  config_text.size(),
+                                  resp.body().config_text().value().size(),
                                   info.endpoint_address,
                                   info.endpoint_port,
-                                  config_text);
+                                  resp.body().config_text().value());
                             }
-                            protocol::client_response<protocol::get_cluster_config_response_body> resp(std::move(msg), info);
                             if (resp.status() == key_value_status_code::success) {
                                 // MB-60405 fixes this for 7.6.2, but for earlier versions we need to protect against using a
                                 // config that has an empty vbucket map.  Ideally we don't timeout if we retry here, but a timeout
@@ -526,17 +525,16 @@ class mcbp_session_impl
                     switch (static_cast<protocol::server_opcode>(msg.header.opcode)) {
                         case protocol::server_opcode::cluster_map_change_notification: {
                             protocol::cmd_info info{ session_->bootstrap_hostname_, session_->bootstrap_port_number_ };
-                            if (session_->origin_.options().dump_configuration) {
-                                std::string_view config_text{ reinterpret_cast<const char*>(msg.body.data()), msg.body.size() };
+                            protocol::server_request<protocol::cluster_map_change_notification_request_body> req(std::move(msg), info);
+                            if (session_->origin_.options().dump_configuration && req.body().config_text().has_value()) {
                                 CB_LOG_TRACE(
                                   "{} configuration from cluster_map_change_notification request (size={}, endpoint=\"{}:{}\"), {}",
                                   session_->log_prefix_,
-                                  config_text.size(),
+                                  req.body().config_text().value().size(),
                                   info.endpoint_address,
                                   info.endpoint_port,
-                                  config_text);
+                                  req.body().config_text().value());
                             }
-                            protocol::server_request<protocol::cluster_map_change_notification_request_body> req(std::move(msg), info);
                             std::optional<topology::configuration> config = req.body().config();
                             if (session_ && config.has_value()) {
                                 if ((!config->bucket.has_value() && req.body().bucket().empty()) ||
@@ -608,16 +606,15 @@ class mcbp_session_impl
                     switch (auto opcode = static_cast<protocol::client_opcode>(msg.header.opcode)) {
                         case protocol::client_opcode::get_cluster_config: {
                             protocol::cmd_info info{ session_->bootstrap_hostname_, session_->bootstrap_port_number_ };
-                            if (session_->origin_.options().dump_configuration) {
-                                std::string_view config_text{ reinterpret_cast<const char*>(msg.body.data()), msg.body.size() };
+                            protocol::client_response<protocol::get_cluster_config_response_body> resp(std::move(msg), info);
+                            if (session_->origin_.options().dump_configuration && resp.body().config_text().has_value()) {
                                 CB_LOG_TRACE("{} configuration from get_cluster_config response (size={}, endpoint=\"{}:{}\"), {}",
                                              session_->log_prefix_,
-                                             config_text.size(),
+                                             resp.body().config_text().value().size(),
                                              info.endpoint_address,
                                              info.endpoint_port,
-                                             config_text);
+                                             resp.body().config_text().value());
                             }
-                            protocol::client_response<protocol::get_cluster_config_response_body> resp(std::move(msg), info);
                             if (resp.status() == key_value_status_code::success) {
                                 if (session_) {
                                     session_->update_configuration(resp.body().config());
@@ -687,17 +684,16 @@ class mcbp_session_impl
                     switch (static_cast<protocol::server_opcode>(msg.header.opcode)) {
                         case protocol::server_opcode::cluster_map_change_notification: {
                             protocol::cmd_info info{ session_->bootstrap_hostname_, session_->bootstrap_port_number_ };
-                            if (session_->origin_.options().dump_configuration) {
-                                std::string_view config_text{ reinterpret_cast<const char*>(msg.body.data()), msg.body.size() };
+                            protocol::server_request<protocol::cluster_map_change_notification_request_body> req(std::move(msg), info);
+                            if (session_->origin_.options().dump_configuration && req.body().config_text().has_value()) {
                                 CB_LOG_TRACE(
                                   "{} configuration from cluster_map_change_notification request (size={}, endpoint=\"{}:{}\"), {}",
                                   session_->log_prefix_,
-                                  config_text.size(),
+                                  req.body().config_text().value().size(),
                                   info.endpoint_address,
                                   info.endpoint_port,
-                                  config_text);
+                                  req.body().config_text().value());
                             }
-                            protocol::server_request<protocol::cluster_map_change_notification_request_body> req(std::move(msg), info);
                             std::optional<topology::configuration> config = req.body().config();
                             if (session_ && config.has_value()) {
                                 if ((!config->bucket.has_value() && req.body().bucket().empty()) ||

--- a/core/protocol/cmd_cluster_map_change_notification.cxx
+++ b/core/protocol/cmd_cluster_map_change_notification.cxx
@@ -47,6 +47,7 @@ cluster_map_change_notification_request_body::parse(const header_buffer& header,
     if (body.size() > static_cast<std::size_t>(offset)) {
         std::string_view config_text{ data_ptr + offset, body.size() - static_cast<std::size_t>(offset) };
         config_ = parse_config(config_text, info.endpoint_address, info.endpoint_port);
+        config_text_.emplace(config_text);
     }
     return true;
 }

--- a/core/protocol/cmd_cluster_map_change_notification.hxx
+++ b/core/protocol/cmd_cluster_map_change_notification.hxx
@@ -34,6 +34,7 @@ class cluster_map_change_notification_request_body
     std::uint32_t protocol_revision_{};
     std::string bucket_{};
     std::optional<topology::configuration> config_{};
+    std::optional<std::string_view> config_text_;
 
   public:
     [[nodiscard]] std::uint32_t protocol_revision() const
@@ -49,6 +50,11 @@ class cluster_map_change_notification_request_body
     [[nodiscard]] std::optional<topology::configuration> config()
     {
         return config_;
+    }
+
+    [[nodiscard]] const std::optional<std::string_view>& config_text() const
+    {
+        return config_text_;
     }
 
     bool parse(const header_buffer& header, const std::vector<std::byte>& body, const cmd_info& info);

--- a/core/protocol/cmd_get_cluster_config.cxx
+++ b/core/protocol/cmd_get_cluster_config.cxx
@@ -75,6 +75,7 @@ get_cluster_config_response_body::parse(key_value_status_code status,
         std::string_view config_text{ reinterpret_cast<const char*>(body.data()) + offset, body.size() - static_cast<std::size_t>(offset) };
         try {
             config_ = parse_config(config_text, info.endpoint_address, info.endpoint_port);
+            config_text_.emplace(config_text);
         } catch (const tao::pegtl::parse_error& e) {
             CB_LOG_DEBUG("unable to parse cluster configuration as JSON: {}, {}", e.message(), config_text);
         }

--- a/core/protocol/cmd_get_cluster_config.hxx
+++ b/core/protocol/cmd_get_cluster_config.hxx
@@ -38,11 +38,17 @@ class get_cluster_config_response_body
 
   private:
     topology::configuration config_{};
+    std::optional<std::string_view> config_text_;
 
   public:
     [[nodiscard]] topology::configuration&& config()
     {
         return std::move(config_);
+    }
+
+    [[nodiscard]] const std::optional<std::string_view>& config_text() const
+    {
+        return config_text_;
     }
 
     bool parse(key_value_status_code status,


### PR DESCRIPTION
Motivation
==========
Being able to dump the cluster configuration is a useful debugging tool. An unfortunate side effect is the config is not properly trimmed when prepped to output in the log.  Removing the unwanted bytes in the log helps improve dev experience.

Changes
=======
* Update cmd_cluster_map_change_notification and cmd_get_cluster_config to save parsed config body as std::string_view.
* Update mcbp session to use new config_text from corresponding request/response.