### PR TITLE
lint: fix "Lock Consistency Violation" warnings

### DIFF
--- a/core/range_scan_orchestrator.cxx
+++ b/core/range_scan_orchestrator.cxx
@@ -568,7 +568,7 @@ class range_scan_orchestrator_impl
     std::atomic_uint16_t active_stream_count_{ 0 };
     std::uint16_t concurrency_{ 1 };
     std::size_t item_limit_{ std::numeric_limits<std::size_t>::max() };
-    bool cancelled_{ false };
+    std::atomic<bool> cancelled_{ false };
 };
 
 range_scan_orchestrator::range_scan_orchestrator(asio::io_context& io,

--- a/core/transactions/staged_mutation.cxx
+++ b/core/transactions/staged_mutation.cxx
@@ -43,7 +43,6 @@ unstaging_state::wait_until_unstage_possible()
             abort_ = true;
         }
     }
-    lock.unlock();
     return !abort_;
 }
 


### PR DESCRIPTION
```
core/range_scan_orchestrator.cxx:417: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::range_scan_orchestrator_impl::is_cancelled` reads without synchronization from `this->cancelled_`, which races with the write in method `couchbase::core::range_scan_orchestrator_impl::stream_failed`. 
  415.     bool is_cancelled() override
  416.     {
  417.         return cancelled_;
               ^
  418.     }
  419. 

core/range_scan_orchestrator.cxx:423: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::range_scan_orchestrator_impl::next` indirectly reads without synchronization from `this->cancelled_`, which races with the write in method `couchbase::core::range_scan_orchestrator_impl::stream_failed`. 
  421.     {
  422.         auto barrier = std::make_shared<std::promise<tl::expected<range_scan_item, std::error_code>>>();
  423.         next([barrier](range_scan_item item, std::error_code ec) mutable {
               ^
  424.             if (ec) {
  425.                 barrier->set_value(tl::unexpected{ ec });

core/range_scan_orchestrator.cxx:439: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::range_scan_orchestrator_impl::next` indirectly reads without synchronization from `this->cancelled_`, which races with the write in method `couchbase::core::range_scan_orchestrator_impl::stream_failed`. 
  437.             cancel();
  438.         } else {
  439.             next_item(std::move(callback));
                   ^
  440.         }
  441.     }

core/range_scan_orchestrator.cxx:446: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::range_scan_orchestrator_impl::next_item<2f1e96ca621ced24>` reads without synchronization from `this->cancelled_`, which races with the write in method `couchbase::core::range_scan_orchestrator_impl::stream_failed`. 
  444.     void next_item(Handler&& handler)
  445.     {
  446.         if (streams_.empty() || cancelled_) {
                                       ^
  447.             items_.cancel();
  448.             items_.close();

core/range_scan_orchestrator.cxx:480: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::range_scan_orchestrator_impl::start_streams` reads without synchronization from `this->cancelled_`, which races with the write in method `couchbase::core::range_scan_orchestrator_impl::stream_failed`. 
  478.     void start_streams(std::uint16_t stream_count)
  479.     {
  480.         if (cancelled_) {
                   ^
  481.             CB_LOG_TRACE("scan has been cancelled, do not start another stream");
  482.             return;

core/transactions/staged_mutation.cxx:47: warning: Lock Consistency Violation
  Read/Write race. Non-private method `couchbase::core::transactions::unstaging_state::wait_until_unstage_possible` reads without synchronization from `this->abort_`, which races with the write in method `couchbase::core::transactions::unstaging_state::wait_until_unstage_possible`.
  45.     }
  46.     lock.unlock();
  47.     return !abort_;
                  ^
  48. }
  49.

```