### PR TITLE
Apply modernize-use-trailing-return-type everywhere

### DIFF
--- a/core/error_context/analytics_json.hxx
+++ b/core/error_context/analytics_json.hxx
@@ -69,7 +69,8 @@ struct traits<couchbase::core::error_context::analytics> {
   }
 
   template<template<typename...> class Traits>
-  static couchbase::core::error_context::analytics as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::error_context::analytics
   {
     couchbase::core::error_context::analytics ctx;
     ctx.retry_attempts = v.at("retry_attempts").get_unsigned();

--- a/core/error_context/http_json.hxx
+++ b/core/error_context/http_json.hxx
@@ -58,7 +58,7 @@ struct traits<couchbase::core::error_context::http> {
     }
   }
   template<template<typename...> class Traits>
-  static couchbase::core::error_context::http as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v) -> couchbase::core::error_context::http
   {
     couchbase::core::error_context::http ctx;
     ctx.retry_attempts = v.at("retry_attempts").get_unsigned();

--- a/core/error_context/key_value.cxx
+++ b/core/error_context/key_value.cxx
@@ -20,20 +20,20 @@
 namespace couchbase::core
 {
 
-key_value_error_context
-make_key_value_error_context(std::error_code ec, const document_id& id)
+auto
+make_key_value_error_context(std::error_code ec, const document_id& id) -> key_value_error_context
 {
   return {
     {}, ec, {}, {}, 0, {}, id.key(), id.bucket(), id.scope(), id.collection(), 0, {}, {}, {}, {},
   };
 }
 
-subdocument_error_context
+auto
 make_subdocument_error_context(const key_value_error_context& ctx,
                                std::error_code ec,
                                std::optional<std::string> first_error_path,
                                std::optional<std::uint64_t> first_error_index,
-                               bool deleted)
+                               bool deleted) -> subdocument_error_context
 {
   return {
     ctx.operation_id(),

--- a/core/error_context/key_value.hxx
+++ b/core/error_context/key_value.hxx
@@ -30,15 +30,15 @@
 namespace couchbase::core
 {
 
-key_value_error_context
-make_key_value_error_context(std::error_code ec, const document_id& id);
+auto
+make_key_value_error_context(std::error_code ec, const document_id& id) -> key_value_error_context;
 
 template<typename Command, typename Response>
-key_value_error_context
+auto
 make_key_value_error_context(std::error_code ec,
                              std::uint16_t status_code,
                              const Command& command,
-                             const Response& response)
+                             const Response& response) -> key_value_error_context
 {
 
   const auto& key = command->request.id.key();
@@ -75,11 +75,11 @@ make_key_value_error_context(std::error_code ec,
            response.error_info() };
 }
 
-subdocument_error_context
+auto
 make_subdocument_error_context(const key_value_error_context& ctx,
                                std::error_code ec,
                                std::optional<std::string> first_error_path,
                                std::optional<std::uint64_t> first_error_index,
-                               bool deleted);
+                               bool deleted) -> subdocument_error_context;
 
 } // namespace couchbase::core

--- a/core/error_context/query_json.hxx
+++ b/core/error_context/query_json.hxx
@@ -69,7 +69,7 @@ struct traits<couchbase::core::error_context::query> {
   }
 
   template<template<typename...> class Traits>
-  static couchbase::core::error_context::query as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v) -> couchbase::core::error_context::query
   {
     couchbase::core::error_context::query ctx;
     ctx.retry_attempts = v.at("retry_attempts").get_unsigned();

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -63,7 +63,7 @@ struct traits<couchbase::core::error_context::search> {
     }
   }
   template<template<typename...> class Traits>
-  static couchbase::core::error_context::search as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v) -> couchbase::core::error_context::search
   {
     couchbase::core::error_context::search ctx;
     ctx.retry_attempts = v.at("retry_attempts").get_unsigned();

--- a/core/impl/analytics.cxx
+++ b/core/impl/analytics.cxx
@@ -30,8 +30,8 @@ namespace couchbase::core::impl
 namespace
 {
 
-static analytics_status
-map_status(core::operations::analytics_response::analytics_status status)
+static auto
+map_status(core::operations::analytics_response::analytics_status status) -> analytics_status
 {
   switch (status) {
     case core::operations::analytics_response::running:
@@ -58,8 +58,9 @@ map_status(core::operations::analytics_response::analytics_status status)
   return analytics_status::unknown;
 }
 
-static std::optional<couchbase::core::analytics_scan_consistency>
+static auto
 map_scan_consistency(std::optional<couchbase::analytics_scan_consistency> consistency)
+  -> std::optional<couchbase::core::analytics_scan_consistency>
 {
   if (consistency.has_value()) {
     switch (consistency.value()) {
@@ -72,8 +73,8 @@ map_scan_consistency(std::optional<couchbase::analytics_scan_consistency> consis
   return {};
 }
 
-static std::vector<codec::binary>
-map_rows(const core::operations::analytics_response& resp)
+static auto
+map_rows(const core::operations::analytics_response& resp) -> std::vector<codec::binary>
 {
   std::vector<codec::binary> rows;
   rows.reserve(resp.rows.size());
@@ -83,8 +84,8 @@ map_rows(const core::operations::analytics_response& resp)
   return rows;
 }
 
-static std::vector<analytics_warning>
-map_warnings(core::operations::analytics_response& resp)
+static auto
+map_warnings(core::operations::analytics_response& resp) -> std::vector<analytics_warning>
 {
   if (resp.meta.warnings.empty()) {
     return {};
@@ -97,8 +98,8 @@ map_warnings(core::operations::analytics_response& resp)
   return warnings;
 }
 
-static analytics_metrics
-map_metrics(const core::operations::analytics_response& resp)
+static auto
+map_metrics(const core::operations::analytics_response& resp) -> analytics_metrics
 {
   return analytics_metrics{
     resp.meta.metrics.elapsed_time,      resp.meta.metrics.execution_time,
@@ -108,8 +109,8 @@ map_metrics(const core::operations::analytics_response& resp)
   };
 }
 
-static std::optional<std::vector<std::byte>>
-map_signature(core::operations::analytics_response& resp)
+static auto
+map_signature(core::operations::analytics_response& resp) -> std::optional<std::vector<std::byte>>
 {
   if (!resp.meta.signature) {
     return {};
@@ -119,8 +120,8 @@ map_signature(core::operations::analytics_response& resp)
 
 } // namespace
 
-analytics_error_context
-build_context(core::operations::analytics_response& resp)
+auto
+build_context(core::operations::analytics_response& resp) -> analytics_error_context
 {
   return {
     resp.ctx.ec,
@@ -142,8 +143,8 @@ build_context(core::operations::analytics_response& resp)
   };
 }
 
-analytics_result
-build_result(core::operations::analytics_response& resp)
+auto
+build_result(core::operations::analytics_response& resp) -> analytics_result
 {
   return {
     analytics_meta_data{
@@ -158,11 +159,12 @@ build_result(core::operations::analytics_response& resp)
   };
 }
 
-core::operations::analytics_request
+auto
 build_analytics_request(std::string statement,
                         analytics_options::built options,
                         std::optional<std::string> bucket_name,
                         std::optional<std::string> scope_name)
+  -> core::operations::analytics_request
 {
   core::operations::analytics_request request{
     std::move(statement),

--- a/core/impl/analytics.hxx
+++ b/core/impl/analytics.hxx
@@ -26,15 +26,16 @@
 
 namespace couchbase::core::impl
 {
-analytics_error_context
-build_context(core::operations::analytics_response& resp);
+auto
+build_context(core::operations::analytics_response& resp) -> analytics_error_context;
 
-analytics_result
-build_result(core::operations::analytics_response& resp);
+auto
+build_result(core::operations::analytics_response& resp) -> analytics_result;
 
-core::operations::analytics_request
+auto
 build_analytics_request(std::string statement,
                         analytics_options::built options,
                         std::optional<std::string> bucket_name,
-                        std::optional<std::string> scope_name);
+                        std::optional<std::string> scope_name)
+  -> core::operations::analytics_request;
 } // namespace couchbase::core::impl

--- a/core/impl/analytics_error_category.cxx
+++ b/core/impl/analytics_error_category.cxx
@@ -22,12 +22,12 @@
 namespace couchbase::core::impl
 {
 struct analytics_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.analytics";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::analytics>(ev)) {
       case errc::analytics::compilation_failure:
@@ -54,8 +54,8 @@ struct analytics_error_category : std::error_category {
 
 const inline static analytics_error_category category_instance;
 
-const std::error_category&
-analytics_category() noexcept
+auto
+analytics_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/analytics_index_manager.cxx
+++ b/core/impl/analytics_index_manager.cxx
@@ -43,8 +43,9 @@ namespace couchbase
 {
 namespace
 {
-core::management::analytics::couchbase_remote_link
+auto
 to_core_couchbase_remote_link(const management::analytics_link& link)
+  -> core::management::analytics::couchbase_remote_link
 {
   auto cb_link = dynamic_cast<const management::couchbase_remote_analytics_link&>(link);
   core::management::analytics::couchbase_remote_link core_link{
@@ -77,8 +78,9 @@ to_core_couchbase_remote_link(const management::analytics_link& link)
   return core_link;
 }
 
-core::management::analytics::azure_blob_external_link
+auto
 to_core_azure_blob_external_link(const management::analytics_link& link)
+  -> core::management::analytics::azure_blob_external_link
 {
   auto azure_link = dynamic_cast<const management::azure_blob_external_analytics_link&>(link);
   return core::management::analytics::azure_blob_external_link{
@@ -88,8 +90,9 @@ to_core_azure_blob_external_link(const management::analytics_link& link)
   };
 }
 
-core::management::analytics::s3_external_link
+auto
 to_core_s3_external_link(const management::analytics_link& link)
+  -> core::management::analytics::s3_external_link
 {
   auto s3_link = dynamic_cast<const management::s3_external_analytics_link&>(link);
   return core::management::analytics::s3_external_link{

--- a/core/impl/bucket_manager.cxx
+++ b/core/impl/bucket_manager.cxx
@@ -34,8 +34,9 @@ namespace couchbase
 {
 namespace
 {
-couchbase::management::cluster::bucket_settings
+auto
 map_bucket_settings(const couchbase::core::management::cluster::bucket_settings& bucket)
+  -> couchbase::management::cluster::bucket_settings
 {
   couchbase::management::cluster::bucket_settings bucket_settings{};
   bucket_settings.name = bucket.name;
@@ -139,9 +140,9 @@ map_bucket_settings(const couchbase::core::management::cluster::bucket_settings&
   return bucket_settings;
 }
 
-std::vector<couchbase::management::cluster::bucket_settings>
-map_all_bucket_settings(
-  const std::vector<couchbase::core::management::cluster::bucket_settings>& buckets)
+auto
+map_all_bucket_settings(const std::vector<couchbase::core::management::cluster::bucket_settings>&
+                          buckets) -> std::vector<couchbase::management::cluster::bucket_settings>
 {
   std::vector<couchbase::management::cluster::bucket_settings> buckets_settings{};
   for (const auto& bucket : buckets) {
@@ -151,8 +152,9 @@ map_all_bucket_settings(
   return buckets_settings;
 }
 
-couchbase::core::management::cluster::bucket_settings
+auto
 map_bucket_settings(const couchbase::management::cluster::bucket_settings& bucket)
+  -> couchbase::core::management::cluster::bucket_settings
 {
 
   couchbase::core::management::cluster::bucket_settings bucket_settings{};

--- a/core/impl/collection_manager.cxx
+++ b/core/impl/collection_manager.cxx
@@ -33,9 +33,10 @@ namespace couchbase
 {
 namespace
 {
-management::bucket::collection_spec
+auto
 map_collection(std::string scope_name,
                const core::topology::collections_manifest::collection& collection)
+  -> management::bucket::collection_spec
 {
   management::bucket::collection_spec spec{};
   spec.name = collection.name;
@@ -45,8 +46,9 @@ map_collection(std::string scope_name,
   return spec;
 }
 
-std::vector<couchbase::management::bucket::scope_spec>
+auto
 map_scope_specs(core::topology::collections_manifest& manifest)
+  -> std::vector<couchbase::management::bucket::scope_spec>
 {
   std::vector<couchbase::management::bucket::scope_spec> scope_specs{};
   for (const auto& scope : manifest.scopes) {

--- a/core/impl/common_error_category.cxx
+++ b/core/impl/common_error_category.cxx
@@ -22,12 +22,12 @@
 namespace couchbase::core::impl
 {
 struct common_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.common";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::common>(ev)) {
       case errc::common::unambiguous_timeout:
@@ -83,8 +83,8 @@ struct common_error_category : std::error_category {
 
 const inline static common_error_category category_instance;
 
-const std::error_category&
-common_category() noexcept
+auto
+common_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/date_range.cxx
+++ b/core/impl/date_range.cxx
@@ -55,38 +55,38 @@ date_range::date_range(std::string name,
 {
 }
 
-date_range
-date_range::with_start(std::string name, std::string start)
+auto
+date_range::with_start(std::string name, std::string start) -> date_range
 {
   return { std::move(name), std::move(start), {} };
 }
 
-date_range
-date_range::with_start(std::string name, std::chrono::system_clock::time_point start)
+auto
+date_range::with_start(std::string name, std::chrono::system_clock::time_point start) -> date_range
 {
   return { std::move(name), fmt::format(iso_8601_format, start), {} };
 }
 
-date_range
-date_range::with_start(std::string name, std::tm start)
+auto
+date_range::with_start(std::string name, std::tm start) -> date_range
 {
   return { std::move(name), fmt::format(iso_8601_format, start), {} };
 }
 
-date_range
-date_range::with_end(std::string name, std::string end)
+auto
+date_range::with_end(std::string name, std::string end) -> date_range
 {
   return { std::move(name), {}, std::move(end) };
 }
 
-date_range
-date_range::with_end(std::string name, std::chrono::system_clock::time_point end)
+auto
+date_range::with_end(std::string name, std::chrono::system_clock::time_point end) -> date_range
 {
   return { std::move(name), {}, fmt::format(iso_8601_format, end) };
 }
 
-date_range
-date_range::with_end(std::string name, std::tm end)
+auto
+date_range::with_end(std::string name, std::tm end) -> date_range
 {
   return { std::move(name), {}, fmt::format(iso_8601_format, end) };
 }

--- a/core/impl/diagnostics.cxx
+++ b/core/impl/diagnostics.cxx
@@ -36,8 +36,8 @@ namespace couchbase
 {
 namespace
 {
-std::string
-service_type_as_string(service_type service_type)
+auto
+service_type_as_string(service_type service_type) -> std::string
 {
   switch (service_type) {
     case service_type::key_value:
@@ -58,8 +58,8 @@ service_type_as_string(service_type service_type)
   return "";
 }
 
-std::string
-ping_state_as_string(ping_state state)
+auto
+ping_state_as_string(ping_state state) -> std::string
 {
   switch (state) {
     case ping_state::ok:
@@ -72,8 +72,8 @@ ping_state_as_string(ping_state state)
   return "";
 }
 
-std::string
-endpoint_state_as_string(endpoint_state state)
+auto
+endpoint_state_as_string(endpoint_state state) -> std::string
 {
   switch (state) {
     case endpoint_state::connected:
@@ -88,8 +88,9 @@ endpoint_state_as_string(endpoint_state state)
   return "";
 }
 
-codec::tao_json_serializer::document_type
+auto
 endpoint_ping_report_as_json(const endpoint_ping_report& report)
+  -> codec::tao_json_serializer::document_type
 {
   codec::tao_json_serializer::document_type res{
     { "id", report.id() },
@@ -107,8 +108,9 @@ endpoint_ping_report_as_json(const endpoint_ping_report& report)
   return res;
 }
 
-codec::tao_json_serializer::document_type
+auto
 endpoint_diagnostics_as_json(const endpoint_diagnostics& report)
+  -> codec::tao_json_serializer::document_type
 {
   codec::tao_json_serializer::document_type res{
     { "id", report.id() },
@@ -172,8 +174,8 @@ namespace couchbase::core::impl
 {
 namespace
 {
-couchbase::service_type
-to_public_service_type(core::service_type service_type)
+auto
+to_public_service_type(core::service_type service_type) -> couchbase::service_type
 {
   switch (service_type) {
     case core::service_type::key_value:
@@ -194,8 +196,8 @@ to_public_service_type(core::service_type service_type)
   return {};
 }
 
-couchbase::ping_state
-to_public_ping_state(core::diag::ping_state ping_state)
+auto
+to_public_ping_state(core::diag::ping_state ping_state) -> couchbase::ping_state
 {
   switch (ping_state) {
     case core::diag::ping_state::timeout:
@@ -208,8 +210,8 @@ to_public_ping_state(core::diag::ping_state ping_state)
   return {};
 }
 
-couchbase::endpoint_state
-to_public_endpoint_state(core::diag::endpoint_state endpoint_state)
+auto
+to_public_endpoint_state(core::diag::endpoint_state endpoint_state) -> couchbase::endpoint_state
 {
   switch (endpoint_state) {
     case core::diag::endpoint_state::connected:
@@ -225,8 +227,9 @@ to_public_endpoint_state(core::diag::endpoint_state endpoint_state)
 }
 } // namespace
 
-std::set<core::service_type>
+auto
 to_core_service_types(const std::set<couchbase::service_type>& service_types)
+  -> std::set<core::service_type>
 {
   std::set<core::service_type> res{};
   for (auto s : service_types) {
@@ -257,8 +260,8 @@ to_core_service_types(const std::set<couchbase::service_type>& service_types)
   return res;
 }
 
-couchbase::ping_result
-build_result(const core::diag::ping_result& result)
+auto
+build_result(const core::diag::ping_result& result) -> couchbase::ping_result
 {
   std::map<couchbase::service_type, std::vector<couchbase::endpoint_ping_report>> endpoints{};
   for (const auto& [core_service_type, core_endpoints] : result.services) {
@@ -279,8 +282,8 @@ build_result(const core::diag::ping_result& result)
   return { result.id, static_cast<std::uint16_t>(result.version), result.sdk, endpoints };
 }
 
-couchbase::diagnostics_result
-build_result(const core::diag::diagnostics_result& result)
+auto
+build_result(const core::diag::diagnostics_result& result) -> couchbase::diagnostics_result
 {
   std::map<couchbase::service_type, std::vector<couchbase::endpoint_diagnostics>> endpoints{};
   for (const auto& [core_service_type, core_endpoints] : result.services) {

--- a/core/impl/diagnostics.hxx
+++ b/core/impl/diagnostics.hxx
@@ -28,12 +28,13 @@
 
 namespace couchbase::core::impl
 {
-std::set<core::service_type>
-to_core_service_types(const std::set<couchbase::service_type>& service_types);
+auto
+to_core_service_types(const std::set<couchbase::service_type>& service_types)
+  -> std::set<core::service_type>;
 
-couchbase::ping_result
-build_result(const core::diag::ping_result& result);
+auto
+build_result(const core::diag::ping_result& result) -> couchbase::ping_result;
 
-couchbase::diagnostics_result
-build_result(const core::diag::diagnostics_result& result);
+auto
+build_result(const core::diag::diagnostics_result& result) -> couchbase::diagnostics_result;
 } // namespace couchbase::core::impl

--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -95,59 +95,59 @@ error::operator==(const couchbase::error& other) const -> bool
 
 namespace core::impl
 {
-error
-make_error(const core::error_context::query& core_ctx)
+auto
+make_error(const core::error_context::query& core_ctx) -> error
 {
   return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
-error
-make_error(const query_error_context& core_ctx)
+auto
+make_error(const query_error_context& core_ctx) -> error
 {
   tao::json::value ctx(core_ctx);
   return { core_ctx.ec(), {}, couchbase::error_context(ctx) };
 }
 
-error
-make_error(const core::error_context::search& core_ctx)
+auto
+make_error(const core::error_context::search& core_ctx) -> error
 {
   return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
-error
-make_error(const core::error_context::analytics& core_ctx)
+auto
+make_error(const core::error_context::analytics& core_ctx) -> error
 {
   return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
-error
-make_error(const core::error_context::http& core_ctx)
+auto
+make_error(const core::error_context::http& core_ctx) -> error
 {
   return { core_ctx.ec, "", couchbase::error_context{ internal_error_context(core_ctx) } };
 }
 
-error
-make_error(const couchbase::key_value_error_context& core_ctx)
+auto
+make_error(const couchbase::key_value_error_context& core_ctx) -> error
 {
   tao::json::value ctx(core_ctx);
   return { core_ctx.ec(), "", couchbase::error_context(ctx) };
 }
 
-error
-make_error(const couchbase::subdocument_error_context& core_ctx)
+auto
+make_error(const couchbase::subdocument_error_context& core_ctx) -> error
 {
   tao::json::value ctx(core_ctx);
   return { core_ctx.ec(), "", couchbase::error_context(ctx) };
 }
 
-error
-make_error(const couchbase::transaction_error_context& ctx)
+auto
+make_error(const couchbase::transaction_error_context& ctx) -> error
 {
   return { ctx.ec(), "", {}, { ctx.cause() } };
 }
 
-error
-make_error(const couchbase::transaction_op_error_context& ctx)
+auto
+make_error(const couchbase::transaction_op_error_context& ctx) -> error
 {
   if (std::holds_alternative<key_value_error_context>(ctx.cause())) {
     return { ctx.ec(), "", {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
@@ -158,8 +158,9 @@ make_error(const couchbase::transaction_op_error_context& ctx)
   return ctx.ec();
 }
 
-couchbase::error
+auto
 make_error(const couchbase::core::transactions::transaction_operation_failed& core_tof)
+  -> couchbase::error
 {
 
   return { couchbase::errc::transaction_op::transaction_op_failed,

--- a/core/impl/error.hxx
+++ b/core/impl/error.hxx
@@ -32,33 +32,33 @@
 
 namespace couchbase::core::impl
 {
-error
-make_error(const core::error_context::query& core_ctx);
+auto
+make_error(const core::error_context::query& core_ctx) -> error;
 
-error
-make_error(const core::error_context::search& core_ctx);
+auto
+make_error(const core::error_context::search& core_ctx) -> error;
 
-error
-make_error(const core::error_context::analytics& core_ctx);
+auto
+make_error(const core::error_context::analytics& core_ctx) -> error;
 
-error
-make_error(const core::error_context::http& core_ctx);
+auto
+make_error(const core::error_context::http& core_ctx) -> error;
 
-error
-make_error(const couchbase::key_value_error_context& core_ctx);
+auto
+make_error(const couchbase::key_value_error_context& core_ctx) -> error;
 
-error
-make_error(const couchbase::subdocument_error_context& core_ctx);
+auto
+make_error(const couchbase::subdocument_error_context& core_ctx) -> error;
 
-error
-make_error(const couchbase::query_error_context& core_ctx);
+auto
+make_error(const couchbase::query_error_context& core_ctx) -> error;
 
-error
-make_error(const couchbase::transaction_error_context& core_ctx);
+auto
+make_error(const couchbase::transaction_error_context& core_ctx) -> error;
 
-error
-make_error(const couchbase::transaction_op_error_context& core_ctx);
+auto
+make_error(const couchbase::transaction_op_error_context& core_ctx) -> error;
 
-error
-make_error(const couchbase::core::transactions::transaction_operation_failed& core_tof);
+auto
+make_error(const couchbase::core::transactions::transaction_operation_failed& core_tof) -> error;
 } // namespace couchbase::core::impl

--- a/core/impl/expiry.cxx
+++ b/core/impl/expiry.cxx
@@ -42,14 +42,14 @@ constexpr std::chrono::system_clock::time_point latest_valid_expiry_time_point{
   std::chrono::seconds{ std::numeric_limits<std::uint32_t>::max() }
 };
 
-std::uint32_t
-expiry_none()
+auto
+expiry_none() -> std::uint32_t
 {
   return 0;
 }
 
-std::uint32_t
-expiry_relative(std::chrono::seconds expiry)
+auto
+expiry_relative(std::chrono::seconds expiry) -> std::uint32_t
 {
   if (expiry == std::chrono::seconds::zero()) {
     return expiry_none();
@@ -84,8 +84,8 @@ expiry_relative(std::chrono::seconds expiry)
   return static_cast<std::uint32_t>(seconds.count());
 }
 
-std::uint32_t
-expiry_absolute(std::chrono::system_clock::time_point expiry)
+auto
+expiry_absolute(std::chrono::system_clock::time_point expiry) -> std::uint32_t
 {
   // Basic sanity check, prevent instant from being interpreted as a relative duration.
   // Allow EPOCH (zero instant) because that is how "get with expiry" represents "no expiry"

--- a/core/impl/field_level_encryption_error_category.cxx
+++ b/core/impl/field_level_encryption_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct field_level_encryption_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.field_level_encryption";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::field_level_encryption>(ev)) {
       case errc::field_level_encryption::generic_cryptography_failure:
@@ -56,8 +56,8 @@ struct field_level_encryption_error_category : std::error_category {
 
 const inline static field_level_encryption_error_category category_instance;
 
-const std::error_category&
-field_level_encryption_category() noexcept
+auto
+field_level_encryption_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/get_all_replicas.hxx
+++ b/core/impl/get_all_replicas.hxx
@@ -54,12 +54,12 @@ public:
   {
   }
 
-  [[nodiscard]] const auto& id() const
+  [[nodiscard]] auto id() const -> const auto&
   {
     return id_;
   }
 
-  [[nodiscard]] const auto& timeout() const
+  [[nodiscard]] auto timeout() const -> const auto&
   {
     return timeout_;
   }

--- a/core/impl/get_any_replica.hxx
+++ b/core/impl/get_any_replica.hxx
@@ -50,12 +50,12 @@ public:
   {
   }
 
-  [[nodiscard]] const auto& id() const
+  [[nodiscard]] auto id() const -> const auto&
   {
     return id_;
   }
 
-  [[nodiscard]] const auto& timeout() const
+  [[nodiscard]] auto timeout() const -> const auto&
   {
     return timeout_;
   }

--- a/core/impl/get_replica.cxx
+++ b/core/impl/get_replica.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::impl
 {
-std::error_code
+auto
 get_replica_request::encode_to(get_replica_request::encoded_request_type& encoded,
-                               core::mcbp_context&& /* context */)
+                               core::mcbp_context&& /* context */) -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -31,9 +31,10 @@ get_replica_request::encode_to(get_replica_request::encoded_request_type& encode
   return {};
 }
 
-get_replica_response
+auto
 get_replica_request::make_response(key_value_error_context&& ctx,
                                    const encoded_response_type& encoded) const
+  -> get_replica_response
 {
   get_replica_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/impl/get_replica.hxx
+++ b/core/impl/get_replica.hxx
@@ -47,10 +47,11 @@ struct get_replica_request {
   std::uint32_t opaque{};
   io::retry_context<true> retries{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          core::mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               core::mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] get_replica_response make_response(key_value_error_context&& ctx,
-                                                   const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> get_replica_response;
 };
 } // namespace couchbase::core::impl

--- a/core/impl/internal_date_range_facet_result.cxx
+++ b/core/impl/internal_date_range_facet_result.cxx
@@ -20,8 +20,9 @@
 namespace couchbase
 {
 
-static std::vector<search_date_range>
+static auto
 map_ranges(const core::operations::search_response::search_facet& facet)
+  -> std::vector<search_date_range>
 {
   std::vector<search_date_range> ranges;
   ranges.reserve(facet.date_ranges.size());

--- a/core/impl/internal_numeric_range_facet_result.cxx
+++ b/core/impl/internal_numeric_range_facet_result.cxx
@@ -20,8 +20,9 @@
 namespace couchbase
 {
 
-static std::vector<search_numeric_range>
+static auto
 map_ranges(const core::operations::search_response::search_facet& facet)
+  -> std::vector<search_numeric_range>
 {
   std::vector<search_numeric_range> ranges;
   ranges.reserve(facet.numeric_ranges.size());

--- a/core/impl/internal_search_error_context.cxx
+++ b/core/impl/internal_search_error_context.cxx
@@ -22,8 +22,9 @@ namespace couchbase
 internal_search_error_context::internal_search_error_context(
   internal_search_error_context&& other) noexcept = default;
 
-internal_search_error_context&
-internal_search_error_context::operator=(internal_search_error_context&& other) noexcept = default;
+auto
+internal_search_error_context::operator=(internal_search_error_context&& other) noexcept
+  -> internal_search_error_context& = default;
 
 internal_search_error_context::internal_search_error_context(
   core::operations::search_response& resp)

--- a/core/impl/internal_search_error_context.hxx
+++ b/core/impl/internal_search_error_context.hxx
@@ -28,9 +28,10 @@ class internal_search_error_context
 public:
   explicit internal_search_error_context(core::operations::search_response& resp);
   internal_search_error_context(internal_search_error_context&& other) noexcept;
-  internal_search_error_context& operator=(internal_search_error_context&& other) noexcept;
+  auto operator=(internal_search_error_context&& other) noexcept -> internal_search_error_context&;
   internal_search_error_context(const internal_search_error_context& other) = delete;
-  internal_search_error_context& operator=(const internal_search_error_context& other) = delete;
+  auto operator=(const internal_search_error_context& other) -> internal_search_error_context& =
+                                                                  delete;
 
   [[nodiscard]] auto ec() const -> std::error_code;
   [[nodiscard]] auto last_dispatched_to() const -> const std::optional<std::string>&;

--- a/core/impl/internal_search_meta_data.cxx
+++ b/core/impl/internal_search_meta_data.cxx
@@ -19,8 +19,9 @@
 
 namespace couchbase
 {
-static couchbase::search_metrics
+static auto
 map_metrics(const core::operations::search_response::search_metrics& metrics)
+  -> couchbase::search_metrics
 {
   return {
     metrics.took,

--- a/core/impl/internal_search_result.cxx
+++ b/core/impl/internal_search_result.cxx
@@ -28,8 +28,9 @@
 
 namespace couchbase
 {
-static std::vector<couchbase::search_row>
+static auto
 map_rows(const std::vector<core::operations::search_response::search_row>& rows)
+  -> std::vector<couchbase::search_row>
 {
   std::vector<couchbase::search_row> result{};
   result.reserve(rows.size());
@@ -39,8 +40,9 @@ map_rows(const std::vector<core::operations::search_response::search_row>& rows)
   return result;
 }
 
-static std::map<std::string, std::shared_ptr<search_facet_result>>
+static auto
 map_facets(std::vector<core::operations::search_response::search_facet> facets)
+  -> std::map<std::string, std::shared_ptr<search_facet_result>>
 {
   std::map<std::string, std::shared_ptr<search_facet_result>> result;
 

--- a/core/impl/internal_term_facet_result.cxx
+++ b/core/impl/internal_term_facet_result.cxx
@@ -20,8 +20,9 @@
 namespace couchbase
 {
 
-static std::vector<search_term_range>
+static auto
 map_ranges(const core::operations::search_response::search_facet& facet)
+  -> std::vector<search_term_range>
 {
   std::vector<search_term_range> ranges;
   ranges.reserve(facet.terms.size());

--- a/core/impl/key_value_error_category.cxx
+++ b/core/impl/key_value_error_category.cxx
@@ -22,12 +22,12 @@
 namespace couchbase::core::impl
 {
 struct key_value_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.key_value";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::key_value>(ev)) {
       case errc::key_value::document_not_found:
@@ -98,8 +98,8 @@ struct key_value_error_category : std::error_category {
 
 const inline static key_value_error_category category_instance;
 
-const std::error_category&
-key_value_category() noexcept
+auto
+key_value_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/lookup_in_all_replicas.hxx
+++ b/core/impl/lookup_in_all_replicas.hxx
@@ -47,17 +47,17 @@ public:
   {
   }
 
-  [[nodiscard]] const auto& id() const
+  [[nodiscard]] auto id() const -> const auto&
   {
     return id_;
   }
 
-  [[nodiscard]] const auto& specs() const
+  [[nodiscard]] auto specs() const -> const auto&
   {
     return specs_;
   }
 
-  [[nodiscard]] const auto& timeout() const
+  [[nodiscard]] auto timeout() const -> const auto&
   {
     return timeout_;
   }

--- a/core/impl/lookup_in_any_replica.hxx
+++ b/core/impl/lookup_in_any_replica.hxx
@@ -43,17 +43,17 @@ public:
   {
   }
 
-  [[nodiscard]] const auto& id() const
+  [[nodiscard]] auto id() const -> const auto&
   {
     return id_;
   }
 
-  [[nodiscard]] const auto& specs() const
+  [[nodiscard]] auto specs() const -> const auto&
   {
     return specs_;
   }
 
-  [[nodiscard]] const auto& timeout() const
+  [[nodiscard]] auto timeout() const -> const auto&
   {
     return timeout_;
   }

--- a/core/impl/lookup_in_replica.cxx
+++ b/core/impl/lookup_in_replica.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::impl
 {
-std::error_code
+auto
 lookup_in_replica_request::encode_to(lookup_in_replica_request::encoded_request_type& encoded,
-                                     mcbp_context&& /* context */)
+                                     mcbp_context&& /* context */) -> std::error_code
 {
   for (std::size_t i = 0; i < specs.size(); ++i) {
     specs[i].original_index_ = i;
@@ -43,9 +43,10 @@ lookup_in_replica_request::encode_to(lookup_in_replica_request::encoded_request_
   return {};
 }
 
-lookup_in_replica_response
+auto
 lookup_in_replica_request::make_response(key_value_error_context&& ctx,
                                          const encoded_response_type& encoded) const
+  -> lookup_in_replica_response
 {
 
   bool deleted = false;

--- a/core/impl/lookup_in_replica.hxx
+++ b/core/impl/lookup_in_replica.hxx
@@ -61,10 +61,11 @@ struct lookup_in_replica_request {
   std::uint32_t opaque{};
   io::retry_context<false> retries{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] lookup_in_replica_response make_response(
-    key_value_error_context&& ctx,
-    const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> lookup_in_replica_response;
 };
 } // namespace couchbase::core::impl

--- a/core/impl/management_error_category.cxx
+++ b/core/impl/management_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct management_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.management";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::management>(ev)) {
       case errc::management::collection_exists:
@@ -67,8 +67,8 @@ struct management_error_category : std::error_category {
 
 const inline static management_error_category category_instance;
 
-const std::error_category&
-management_category() noexcept
+auto
+management_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/network_error_category.cxx
+++ b/core/impl/network_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct network_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.network";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::network>(ev)) {
       case errc::network::resolve_failure:
@@ -65,8 +65,8 @@ struct network_error_category : std::error_category {
 
 const inline static network_error_category network_category_instance;
 
-const std::error_category&
-network_category() noexcept
+auto
+network_category() noexcept -> const std::error_category&
 {
   return network_category_instance;
 }

--- a/core/impl/numeric_range.cxx
+++ b/core/impl/numeric_range.cxx
@@ -35,14 +35,14 @@ numeric_range::numeric_range(std::string name, std::optional<double> min, std::o
 {
 }
 
-numeric_range
-numeric_range::with_min(std::string name, double start)
+auto
+numeric_range::with_min(std::string name, double start) -> numeric_range
 {
   return { std::move(name), start, {} };
 }
 
-numeric_range
-numeric_range::with_max(std::string name, double end)
+auto
+numeric_range::with_max(std::string name, double end) -> numeric_range
 {
   return { std::move(name), {}, end };
 }

--- a/core/impl/observe_poll.cxx
+++ b/core/impl/observe_poll.cxx
@@ -31,8 +31,8 @@ namespace couchbase::core::impl
 {
 namespace
 {
-constexpr bool
-touches_replica(couchbase::persist_to persist_to, couchbase::replicate_to replicate_to)
+constexpr auto
+touches_replica(couchbase::persist_to persist_to, couchbase::replicate_to replicate_to) -> bool
 {
 
   switch (replicate_to) {
@@ -59,8 +59,8 @@ touches_replica(couchbase::persist_to persist_to, couchbase::replicate_to replic
   return false;
 }
 
-constexpr std::uint32_t
-number_of_replica_nodes_required(couchbase::persist_to persist_to)
+constexpr auto
+number_of_replica_nodes_required(couchbase::persist_to persist_to) -> std::uint32_t
 {
   switch (persist_to) {
     case persist_to::one:
@@ -78,8 +78,8 @@ number_of_replica_nodes_required(couchbase::persist_to persist_to)
   return 0U;
 }
 
-constexpr std::uint32_t
-number_of_replica_nodes_required(couchbase::replicate_to replicate_to)
+constexpr auto
+number_of_replica_nodes_required(couchbase::replicate_to replicate_to) -> std::uint32_t
 {
   switch (replicate_to) {
     case replicate_to::one:
@@ -94,10 +94,10 @@ number_of_replica_nodes_required(couchbase::replicate_to replicate_to)
   return 0U;
 }
 
-std::pair<std::error_code, std::uint32_t>
+auto
 validate_replicas(const topology::configuration& config,
                   couchbase::persist_to persist_to,
-                  couchbase::replicate_to replicate_to)
+                  couchbase::replicate_to replicate_to) -> std::pair<std::error_code, std::uint32_t>
 {
   if (config.node_locator != topology::configuration::node_locator_type::vbucket) {
     return { errc::common::feature_not_available, {} };
@@ -149,8 +149,8 @@ public:
     persisted_on_active_ |= (response.active && persisted);
   }
 
-  [[nodiscard]] bool meets_condition(couchbase::persist_to persist_to,
-                                     couchbase::replicate_to replicate_to) const
+  [[nodiscard]] auto meets_condition(couchbase::persist_to persist_to,
+                                     couchbase::replicate_to replicate_to) const -> bool
   {
     auto persistence_condition = (persist_to == persist_to::active && persisted_on_active_) ||
                                  (persisted_ >= number_of_replica_nodes_required(persist_to));

--- a/core/impl/observe_seqno.cxx
+++ b/core/impl/observe_seqno.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::impl
 {
-std::error_code
+auto
 observe_seqno_request::encode_to(observe_seqno_request::encoded_request_type& encoded,
-                                 core::mcbp_context&& /* context */)
+                                 core::mcbp_context&& /* context */) -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -31,9 +31,10 @@ observe_seqno_request::encode_to(observe_seqno_request::encoded_request_type& en
   return {};
 }
 
-observe_seqno_response
+auto
 observe_seqno_request::make_response(key_value_error_context&& ctx,
                                      const encoded_response_type& encoded) const
+  -> observe_seqno_response
 {
   observe_seqno_response response{ std::move(ctx), active };
   if (!response.ctx.ec()) {

--- a/core/impl/observe_seqno.hxx
+++ b/core/impl/observe_seqno.hxx
@@ -37,7 +37,7 @@ struct observe_seqno_response {
   std::optional<std::uint64_t> old_partition_uuid{};
   std::optional<std::uint64_t> last_received_sequence_number{};
 
-  [[nodiscard]] bool failed_over() const
+  [[nodiscard]] auto failed_over() const -> bool
   {
     return old_partition_uuid.has_value();
   }
@@ -58,10 +58,11 @@ struct observe_seqno_request {
   std::uint32_t opaque{};
   io::retry_context<true> retries{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          core::mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               core::mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] observe_seqno_response make_response(key_value_error_context&& ctx,
-                                                     const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> observe_seqno_response;
 };
 } // namespace couchbase::core::impl

--- a/core/impl/query.cxx
+++ b/core/impl/query.cxx
@@ -27,8 +27,8 @@ namespace couchbase::core::impl
 {
 namespace
 {
-query_status
-map_status(std::string status)
+auto
+map_status(std::string status) -> query_status
 {
   std::transform(status.cbegin(), status.cend(), status.begin(), [](unsigned char c) {
     return std::tolower(c);
@@ -55,8 +55,8 @@ map_status(std::string status)
   return query_status::unknown;
 }
 
-std::vector<codec::binary>
-map_rows(operations::query_response& resp)
+auto
+map_rows(operations::query_response& resp) -> std::vector<codec::binary>
 {
   std::vector<codec::binary> rows;
   rows.reserve(resp.rows.size());
@@ -66,8 +66,8 @@ map_rows(operations::query_response& resp)
   return rows;
 }
 
-std::vector<query_warning>
-map_warnings(operations::query_response& resp)
+auto
+map_warnings(operations::query_response& resp) -> std::vector<query_warning>
 {
   std::vector<query_warning> warnings;
   if (resp.meta.warnings) {
@@ -84,8 +84,8 @@ map_warnings(operations::query_response& resp)
   return warnings;
 }
 
-std::optional<query_metrics>
-map_metrics(operations::query_response& resp)
+auto
+map_metrics(operations::query_response& resp) -> std::optional<query_metrics>
 {
   if (!resp.meta.metrics) {
     return {};
@@ -99,8 +99,8 @@ map_metrics(operations::query_response& resp)
   };
 }
 
-std::optional<std::vector<std::byte>>
-map_signature(operations::query_response& resp)
+auto
+map_signature(operations::query_response& resp) -> std::optional<std::vector<std::byte>>
 {
   if (!resp.meta.signature) {
     return {};
@@ -108,8 +108,8 @@ map_signature(operations::query_response& resp)
   return utils::to_binary(resp.meta.signature.value());
 }
 
-std::optional<std::vector<std::byte>>
-map_profile(operations::query_response& resp)
+auto
+map_profile(operations::query_response& resp) -> std::optional<std::vector<std::byte>>
 {
   if (!resp.meta.profile) {
     return {};
@@ -118,8 +118,8 @@ map_profile(operations::query_response& resp)
 }
 } // namespace
 
-query_error_context
-build_context(operations::query_response& resp)
+auto
+build_context(operations::query_response& resp) -> query_error_context
 {
   return {
     resp.ctx.ec,
@@ -141,8 +141,8 @@ build_context(operations::query_response& resp)
   };
 }
 
-query_result
-build_result(operations::query_response& resp)
+auto
+build_result(operations::query_response& resp) -> query_result
 {
   return {
     query_meta_data{
@@ -158,10 +158,10 @@ build_result(operations::query_response& resp)
   };
 }
 
-core::operations::query_request
+auto
 build_query_request(std::string statement,
                     std::optional<std::string> query_context,
-                    query_options::built options)
+                    query_options::built options) -> core::operations::query_request
 {
   operations::query_request request{
     std::move(statement),     options.adhoc,
@@ -192,10 +192,11 @@ build_query_request(std::string statement,
   return request;
 }
 
-std::pair<couchbase::transaction_op_error_context,
-          couchbase::transactions::transaction_query_result>
+auto
 build_transaction_query_result(operations::query_response resp,
                                std::error_code txn_ec /*defaults to 0*/)
+  -> std::pair<couchbase::transaction_op_error_context,
+               couchbase::transactions::transaction_query_result>
 {
   if (resp.ctx.ec) {
     if (resp.ctx.ec == errc::common::parsing_failure) {
@@ -222,8 +223,8 @@ build_transaction_query_result(operations::query_response resp,
   };
 }
 
-core::operations::query_request
-build_transaction_query_request(query_options::built opts)
+auto
+build_transaction_query_request(query_options::built opts) -> core::operations::query_request
 {
   return core::impl::build_query_request("", {}, opts);
 }

--- a/core/impl/query.hxx
+++ b/core/impl/query.hxx
@@ -23,14 +23,14 @@
 
 namespace couchbase::core::impl
 {
-core::operations::query_request
+auto
 build_query_request(std::string statement,
                     std::optional<std::string> query_context,
-                    query_options::built options);
+                    query_options::built options) -> core::operations::query_request;
 
-query_result
-build_result(operations::query_response& resp);
+auto
+build_result(operations::query_response& resp) -> query_result;
 
-query_error_context
-build_context(operations::query_response& resp);
+auto
+build_context(operations::query_response& resp) -> query_error_context;
 } // namespace couchbase::core::impl

--- a/core/impl/query_error_category.cxx
+++ b/core/impl/query_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct query_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.query";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::query>(ev)) {
       case errc::query::planning_failure:
@@ -47,8 +47,8 @@ struct query_error_category : std::error_category {
 
 const inline static query_error_category query_category_instance;
 
-const std::error_category&
-query_category() noexcept
+auto
+query_category() noexcept -> const std::error_category&
 {
   return query_category_instance;
 }

--- a/core/impl/query_index_manager.cxx
+++ b/core/impl/query_index_manager.cxx
@@ -111,13 +111,13 @@ private:
     }
   }
 
-  std::chrono::milliseconds remaining() const
+  auto remaining() const -> std::chrono::milliseconds
   {
     return timeout_ - std::chrono::duration_cast<std::chrono::milliseconds>(
                         std::chrono::steady_clock::now() - start_time_);
   }
 
-  bool check(couchbase::core::operations::management::query_index_get_all_response& resp)
+  auto check(couchbase::core::operations::management::query_index_get_all_response& resp) -> bool
   {
     if (resp.ctx.ec == couchbase::errc::common::ambiguous_timeout) {
       return false;

--- a/core/impl/retry_reason.cxx
+++ b/core/impl/retry_reason.cxx
@@ -21,8 +21,8 @@
 
 namespace couchbase
 {
-bool
-allows_non_idempotent_retry(retry_reason reason)
+auto
+allows_non_idempotent_retry(retry_reason reason) -> bool
 {
   switch (reason) {
     case retry_reason::socket_not_available:
@@ -52,8 +52,8 @@ allows_non_idempotent_retry(retry_reason reason)
   return false;
 }
 
-bool
-always_retry(retry_reason reason)
+auto
+always_retry(retry_reason reason) -> bool
 {
   switch (reason) {
     case retry_reason::unknown:

--- a/core/impl/search.cxx
+++ b/core/impl/search.cxx
@@ -35,8 +35,9 @@ namespace couchbase::core::impl
 {
 namespace
 {
-std::optional<core::search_highlight_style>
+auto
 map_highlight_style(const std::optional<couchbase::highlight_style>& style)
+  -> std::optional<core::search_highlight_style>
 {
   if (style) {
     switch (style.value()) {
@@ -49,8 +50,9 @@ map_highlight_style(const std::optional<couchbase::highlight_style>& style)
   return {};
 }
 
-static std::optional<core::search_scan_consistency>
+static auto
 map_scan_consistency(const std::optional<couchbase::search_scan_consistency>& scan_consistency)
+  -> std::optional<core::search_scan_consistency>
 {
   if (scan_consistency == couchbase::search_scan_consistency::not_bounded) {
     return core::search_scan_consistency::not_bounded;
@@ -58,9 +60,9 @@ map_scan_consistency(const std::optional<couchbase::search_scan_consistency>& sc
   return {};
 }
 
-static std::vector<std::string>
+static auto
 map_sort(const std::vector<std::shared_ptr<search_sort>>& sort,
-         const std::vector<std::string>& sort_string)
+         const std::vector<std::string>& sort_string) -> std::vector<std::string>
 {
   std::vector<std::string> sort_specs{};
   sort_specs.reserve(sort.size() + sort_string.size());
@@ -80,8 +82,9 @@ map_sort(const std::vector<std::shared_ptr<search_sort>>& sort,
   return sort_specs;
 }
 
-static std::map<std::string, std::string>
+static auto
 map_facets(const std::map<std::string, std::shared_ptr<search_facet>, std::less<>>& facets)
+  -> std::map<std::string, std::string>
 {
   std::map<std::string, std::string> core_facets{};
 
@@ -96,8 +99,9 @@ map_facets(const std::map<std::string, std::shared_ptr<search_facet>, std::less<
   return core_facets;
 }
 
-static std::map<std::string, couchbase::core::json_string>
+static auto
 map_raw(std::map<std::string, codec::binary, std::less<>>& raw)
+  -> std::map<std::string, couchbase::core::json_string>
 {
   std::map<std::string, couchbase::core::json_string> core_raw{};
   for (const auto& [name, value] : raw) {
@@ -106,8 +110,9 @@ map_raw(std::map<std::string, codec::binary, std::less<>>& raw)
   return core_raw;
 }
 
-static std::optional<core::vector_query_combination>
+static auto
 map_vector_query_combination(const std::optional<couchbase::vector_query_combination>& combination)
+  -> std::optional<core::vector_query_combination>
 {
   if (combination) {
     switch (combination.value()) {
@@ -122,12 +127,12 @@ map_vector_query_combination(const std::optional<couchbase::vector_query_combina
 
 } // namespace
 
-core::operations::search_request
+auto
 build_search_request(std::string index_name,
                      const search_query& query,
                      search_options::built options,
                      std::optional<std::string> bucket_name,
-                     std::optional<std::string> scope_name)
+                     std::optional<std::string> scope_name) -> core::operations::search_request
 {
   auto encoded = query.encode();
   if (encoded.ec) {
@@ -163,12 +168,12 @@ build_search_request(std::string index_name,
   return request;
 }
 
-core::operations::search_request
+auto
 build_search_request(std::string index_name,
                      couchbase::search_request request,
                      search_options::built options,
                      std::optional<std::string> bucket_name,
-                     std::optional<std::string> scope_name)
+                     std::optional<std::string> scope_name) -> core::operations::search_request
 {
   if (!request.search_query().has_value()) {
     request.search_query(couchbase::match_none_query{});

--- a/core/impl/search.hxx
+++ b/core/impl/search.hxx
@@ -28,18 +28,18 @@
 
 namespace couchbase::core::impl
 {
-core::operations::search_request
+auto
 build_search_request(std::string index_name,
                      const search_query& query,
                      search_options::built options,
                      std::optional<std::string> bucket_name,
-                     std::optional<std::string> scope_name);
+                     std::optional<std::string> scope_name) -> core::operations::search_request;
 
-core::operations::search_request
+auto
 build_search_request(std::string index_name,
                      search_request request,
                      search_options::built options,
                      std::optional<std::string> bucket_name,
-                     std::optional<std::string> scope_name);
+                     std::optional<std::string> scope_name) -> core::operations::search_request;
 
 } // namespace couchbase::core::impl

--- a/core/impl/search_error_category.cxx
+++ b/core/impl/search_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct search_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.search";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::search>(ev)) {
       case errc::search::index_not_ready:
@@ -43,8 +43,8 @@ struct search_error_category : std::error_category {
 
 const inline static search_error_category category_instance;
 
-const std::error_category&
-search_category() noexcept
+auto
+search_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/search_error_context.cxx
+++ b/core/impl/search_error_context.cxx
@@ -33,8 +33,8 @@ search_error_context::search_error_context(internal_search_error_context ctx)
 
 search_error_context::search_error_context(search_error_context&& other) = default;
 
-search_error_context&
-search_error_context::operator=(search_error_context&& other) = default;
+auto
+search_error_context::operator=(search_error_context&& other) -> search_error_context& = default;
 
 search_error_context::~search_error_context() = default;
 

--- a/core/impl/search_index_manager.cxx
+++ b/core/impl/search_index_manager.cxx
@@ -39,8 +39,9 @@ namespace couchbase
 {
 namespace
 {
-couchbase::management::search::index
+auto
 map_search_index(const couchbase::core::management::search::index& index)
+  -> couchbase::management::search::index
 {
   couchbase::management::search::index public_index{};
   public_index.uuid = index.uuid;
@@ -58,8 +59,9 @@ map_search_index(const couchbase::core::management::search::index& index)
   return public_index;
 }
 
-std::vector<couchbase::management::search::index>
+auto
 map_all_search_indexes(const std::vector<couchbase::core::management::search::index>& indexes)
+  -> std::vector<couchbase::management::search::index>
 {
   std::vector<couchbase::management::search::index> search_indexes{};
   for (const auto& index : indexes) {
@@ -69,8 +71,9 @@ map_all_search_indexes(const std::vector<couchbase::core::management::search::in
   return search_indexes;
 }
 
-couchbase::core::management::search::index
+auto
 map_search_index(const couchbase::management::search::index& index)
+  -> couchbase::core::management::search::index
 {
   couchbase::core::management::search::index search_index{};
   search_index.name = index.name;
@@ -105,8 +108,8 @@ map_search_index(const couchbase::management::search::index& index)
   return search_index;
 }
 
-std::vector<std::string>
-convert_analysis(const std::string& analysis)
+auto
+convert_analysis(const std::string& analysis) -> std::vector<std::string>
 {
   std::vector<std::string> result;
 

--- a/core/impl/search_request.cxx
+++ b/core/impl/search_request.cxx
@@ -33,7 +33,7 @@ public:
   {
   }
 
-  static search_request_impl create(const search_query& query)
+  static auto create(const search_query& query) -> search_request_impl
   {
     auto encoded = query.encode();
     if (encoded.ec) {
@@ -42,7 +42,7 @@ public:
     return search_request_impl(encoded, {}, {});
   }
 
-  static search_request_impl create(const vector_search& search)
+  static auto create(const vector_search& search) -> search_request_impl
   {
     auto encoded = search.encode();
     if (encoded.ec) {
@@ -68,17 +68,17 @@ public:
     vector_search_options_ = search.options();
   }
 
-  [[nodiscard]] std::optional<encoded_search_query> search_query() const
+  [[nodiscard]] auto search_query() const -> std::optional<encoded_search_query>
   {
     return search_query_;
   }
 
-  [[nodiscard]] std::optional<encoded_search_query> vector_search() const
+  [[nodiscard]] auto vector_search() const -> std::optional<encoded_search_query>
   {
     return vector_search_;
   }
 
-  [[nodiscard]] std::optional<vector_search_options::built> vector_options() const
+  [[nodiscard]] auto vector_options() const -> std::optional<vector_search_options::built>
   {
     return vector_search_options_;
   }
@@ -119,20 +119,20 @@ search_request::vector_search(const couchbase::vector_search& vector_search) -> 
   return *this;
 }
 
-[[nodiscard]] std::optional<encoded_search_query>
-search_request::search_query() const
+[[nodiscard]] auto
+search_request::search_query() const -> std::optional<encoded_search_query>
 {
   return impl_->search_query();
 }
 
-[[nodiscard]] std::optional<encoded_search_query>
-search_request::vector_search() const
+[[nodiscard]] auto
+search_request::vector_search() const -> std::optional<encoded_search_query>
 {
   return impl_->vector_search();
 }
 
-[[nodiscard]] std::optional<couchbase::vector_search_options::built>
-search_request::vector_options()
+[[nodiscard]] auto
+search_request::vector_options() -> std::optional<couchbase::vector_search_options::built>
 {
   return impl_->vector_options();
 }

--- a/core/impl/search_result.cxx
+++ b/core/impl/search_result.cxx
@@ -41,8 +41,8 @@ search_result::search_result(internal_search_result internal)
 
 search_result::~search_result() = default;
 
-search_result&
-search_result::operator=(search_result&&) noexcept = default;
+auto
+search_result::operator=(search_result&&) noexcept -> search_result& = default;
 
 search_result::search_result(search_result&&) noexcept = default;
 

--- a/core/impl/search_row_location.cxx
+++ b/core/impl/search_row_location.cxx
@@ -35,8 +35,9 @@ search_row_location::~search_row_location() = default;
 
 search_row_location::search_row_location(search_row_location&&) noexcept = default;
 
-search_row_location&
-search_row_location::operator=(couchbase::search_row_location&&) noexcept = default;
+auto
+search_row_location::operator=(couchbase::search_row_location&&) noexcept
+  -> search_row_location& = default;
 
 auto
 search_row_location::field() const -> const std::string&

--- a/core/impl/streaming_json_lexer_error_category.cxx
+++ b/core/impl/streaming_json_lexer_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct streaming_json_lexer_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.streaming_json_lexer";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::streaming_json_lexer>(ev)) {
       case errc::streaming_json_lexer::garbage_trailing:
@@ -96,8 +96,8 @@ struct streaming_json_lexer_error_category : std::error_category {
 
 const inline static streaming_json_lexer_error_category category_instance;
 
-const std::error_category&
-streaming_json_lexer_category() noexcept
+auto
+streaming_json_lexer_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/impl/transaction_error_category.cxx
+++ b/core/impl/transaction_error_category.cxx
@@ -22,12 +22,12 @@ namespace couchbase::core::impl
 {
 
 struct transaction_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.transaction";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::transaction>(ev)) {
       case errc::transaction::failed:
@@ -46,8 +46,8 @@ struct transaction_error_category : std::error_category {
 
 const inline static transaction_error_category transaction_category_instance;
 
-const std::error_category&
-transaction_category() noexcept
+auto
+transaction_category() noexcept -> const std::error_category&
 {
   return transaction_category_instance;
 }

--- a/core/impl/transaction_get_result.cxx
+++ b/core/impl/transaction_get_result.cxx
@@ -11,8 +11,8 @@ transaction_get_result::transaction_get_result()
 {
 }
 
-const std::vector<std::byte>&
-transaction_get_result::content() const
+auto
+transaction_get_result::content() const -> const std::vector<std::byte>&
 {
   return base_->content();
 }
@@ -26,28 +26,28 @@ transaction_get_result::content(std::vector<std::byte>&& content)
 {
   return base_->content(content);
 }
-const std::string
-transaction_get_result::key() const
+auto
+transaction_get_result::key() const -> const std::string
 {
   return base_->key();
 }
-const std::string
-transaction_get_result::bucket() const
+auto
+transaction_get_result::bucket() const -> const std::string
 {
   return base_->bucket();
 }
-const std::string
-transaction_get_result::scope() const
+auto
+transaction_get_result::scope() const -> const std::string
 {
   return base_->scope();
 }
-const std::string
-transaction_get_result::collection() const
+auto
+transaction_get_result::collection() const -> const std::string
 {
   return base_->collection();
 }
-const couchbase::cas
-transaction_get_result::cas() const
+auto
+transaction_get_result::cas() const -> const couchbase::cas
 {
   return base_->cas();
 }

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -22,12 +22,12 @@ namespace couchbase::core::impl
 {
 
 struct transaction_op_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.transaction_op";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::transaction_op>(ev)) {
       case errc::transaction_op::unknown:
@@ -84,8 +84,8 @@ struct transaction_op_error_category : std::error_category {
 
 const inline static transaction_op_error_category transaction_op_category_instance;
 
-const std::error_category&
-transaction_op_category() noexcept
+auto
+transaction_op_category() noexcept -> const std::error_category&
 {
   return transaction_op_category_instance;
 }

--- a/core/impl/view_error_category.cxx
+++ b/core/impl/view_error_category.cxx
@@ -23,12 +23,12 @@ namespace couchbase::core::impl
 {
 
 struct view_error_category : std::error_category {
-  [[nodiscard]] const char* name() const noexcept override
+  [[nodiscard]] auto name() const noexcept -> const char* override
   {
     return "couchbase.view";
   }
 
-  [[nodiscard]] std::string message(int ev) const noexcept override
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::view>(ev)) {
       case errc::view::view_not_found:
@@ -42,8 +42,8 @@ struct view_error_category : std::error_category {
 };
 const inline static view_error_category category_instance;
 
-const std::error_category&
-view_category() noexcept
+auto
+view_category() noexcept -> const std::error_category&
 {
   return category_instance;
 }

--- a/core/io/dns_codec.hxx
+++ b/core/io/dns_codec.hxx
@@ -29,7 +29,7 @@ namespace couchbase::core::io::dns
 class dns_codec
 {
 public:
-  static dns_message decode(const std::vector<std::uint8_t>& payload)
+  static auto decode(const std::vector<std::uint8_t>& payload) -> dns_message
   {
     dns_message message{};
     std::size_t offset = 0;
@@ -127,7 +127,7 @@ public:
     return message;
   }
 
-  static std::vector<std::uint8_t> encode(const dns_message& message)
+  static auto encode(const dns_message& message) -> std::vector<std::uint8_t>
   {
     std::vector<std::uint8_t> payload;
     payload.resize(message.request_size(), 0);
@@ -176,7 +176,8 @@ public:
   }
 
 private:
-  static resource_name get_name(const std::vector<std::uint8_t>& payload, std::size_t& offset)
+  static auto get_name(const std::vector<std::uint8_t>& payload,
+                       std::size_t& offset) -> resource_name
   {
     resource_name name{};
     std::optional<std::size_t> save_offset{};

--- a/core/io/dns_config.cxx
+++ b/core/io/dns_config.cxx
@@ -107,8 +107,8 @@ load_resolv_conf()
 #else
 static constexpr auto default_resolv_conf_path = "/etc/resolv.conf";
 
-std::string
-load_resolv_conf(const char* conf_path)
+auto
+load_resolv_conf(const char* conf_path) -> std::string
 {
   if (std::error_code ec{}; std::filesystem::exists(conf_path, ec) && !ec) {
     std::ifstream conf(conf_path);
@@ -145,8 +145,8 @@ load_resolv_conf(const char* conf_path)
 #endif
 static std::once_flag system_config_initialized_flag;
 
-const dns_config&
-dns_config::system_config()
+auto
+dns_config::system_config() -> const dns_config&
 {
   static dns_config instance{};
 
@@ -185,20 +185,20 @@ dns_config::dns_config(std::string nameserver,
 {
 }
 
-std::uint16_t
-dns_config::port() const
+auto
+dns_config::port() const -> std::uint16_t
 {
   return port_;
 }
 
-const std::string&
-dns_config::nameserver() const
+auto
+dns_config::nameserver() const -> const std::string&
 {
   return nameserver_;
 }
 
-std::chrono::milliseconds
-dns_config::timeout() const
+auto
+dns_config::timeout() const -> std::chrono::milliseconds
 {
   return timeout_;
 }

--- a/core/io/dns_config.hxx
+++ b/core/io/dns_config.hxx
@@ -30,16 +30,16 @@ public:
   static constexpr auto default_nameserver = "8.8.8.8";
   static constexpr std::uint16_t default_port = 53;
 
-  static const dns_config& system_config();
+  static auto system_config() -> const dns_config&;
 
   dns_config() = default;
   dns_config(std::string nameserver,
              std::uint16_t port,
              std::chrono::milliseconds timeout = timeout_defaults::dns_srv_timeout);
 
-  [[nodiscard]] std::uint16_t port() const;
-  [[nodiscard]] const std::string& nameserver() const;
-  [[nodiscard]] std::chrono::milliseconds timeout() const;
+  [[nodiscard]] auto port() const -> std::uint16_t;
+  [[nodiscard]] auto nameserver() const -> const std::string&;
+  [[nodiscard]] auto timeout() const -> std::chrono::milliseconds;
 
 private:
   std::string nameserver_{};

--- a/core/io/dns_message.hxx
+++ b/core/io/dns_message.hxx
@@ -316,7 +316,7 @@ struct dns_header {
     recursion_available ra{ recursion_available::no };
     response_code rcode{ response_code::no_error };
 
-    [[nodiscard]] std::uint16_t encode() const
+    [[nodiscard]] auto encode() const -> std::uint16_t
     {
       return std::uint16_t(
         (static_cast<std::uint32_t>(qr) & 1U) << 15U |
@@ -437,7 +437,7 @@ struct question_record {
    */
   resource_class klass{};
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     std::size_t res = 2 * sizeof(std::uint16_t); // type + class
     for (const auto& label : name.labels) {
@@ -566,7 +566,7 @@ struct dns_message {
   std::vector<srv_record> answers{};
   // the implementation only cares about SRV answers, so ignore everything else
 
-  [[nodiscard]] std::size_t request_size() const
+  [[nodiscard]] auto request_size() const -> std::size_t
   {
     std::size_t res = 6 * sizeof(std::uint16_t); // header
     for (const auto& question : questions) {

--- a/core/io/http_message.hxx
+++ b/core/io/http_message.hxx
@@ -83,17 +83,17 @@ public:
     }
   }
 
-  [[nodiscard]] const std::string& data() const
+  [[nodiscard]] auto data() const -> const std::string&
   {
     return storage_->data_;
   }
 
-  [[nodiscard]] const std::size_t& number_of_rows() const
+  [[nodiscard]] auto number_of_rows() const -> const std::size_t&
   {
     return storage_->number_of_rows_;
   }
 
-  [[nodiscard]] const std::error_code& ec() const
+  [[nodiscard]] auto ec() const -> const std::error_code&
   {
     return storage_->ec_;
   }
@@ -109,7 +109,7 @@ struct http_response {
   std::map<std::string, std::string> headers;
   http_response_body body{};
 
-  [[nodiscard]] bool must_close_connection() const
+  [[nodiscard]] auto must_close_connection() const -> bool
   {
     if (const auto it = headers.find("connection"); it != headers.end()) {
       return it->second == "close";

--- a/core/io/http_parser.cxx
+++ b/core/io/http_parser.cxx
@@ -24,8 +24,8 @@
 
 namespace
 {
-inline int
-static_on_status(llhttp_t* parser, const char* at, std::size_t length)
+inline auto
+static_on_status(llhttp_t* parser, const char* at, std::size_t length) -> int
 {
   auto* wrapper = static_cast<couchbase::core::io::http_parser*>(parser->data);
   wrapper->response.status_message.assign(at, length);
@@ -33,8 +33,8 @@ static_on_status(llhttp_t* parser, const char* at, std::size_t length)
   return 0;
 }
 
-inline int
-static_on_header_field(llhttp_t* parser, const char* at, std::size_t length)
+inline auto
+static_on_header_field(llhttp_t* parser, const char* at, std::size_t length) -> int
 {
   auto* wrapper = static_cast<couchbase::core::io::http_parser*>(parser->data);
   wrapper->header_field.assign(at, length);
@@ -47,24 +47,24 @@ static_on_header_field(llhttp_t* parser, const char* at, std::size_t length)
   return 0;
 }
 
-inline int
-static_on_header_value(llhttp_t* parser, const char* at, std::size_t length)
+inline auto
+static_on_header_value(llhttp_t* parser, const char* at, std::size_t length) -> int
 {
   auto* wrapper = static_cast<couchbase::core::io::http_parser*>(parser->data);
   wrapper->response.headers[wrapper->header_field] = std::string(at, length);
   return 0;
 }
 
-inline int
-static_on_body(llhttp_t* parser, const char* at, std::size_t length)
+inline auto
+static_on_body(llhttp_t* parser, const char* at, std::size_t length) -> int
 {
   auto* wrapper = static_cast<couchbase::core::io::http_parser*>(parser->data);
   wrapper->response.body.append(std::string_view{ at, length });
   return 0;
 }
 
-inline int
-static_on_message_complete(llhttp_t* parser)
+inline auto
+static_on_message_complete(llhttp_t* parser) -> int
 {
   auto* wrapper = static_cast<couchbase::core::io::http_parser*>(parser->data);
   wrapper->complete = true;
@@ -103,8 +103,8 @@ http_parser::http_parser(http_parser&& other) noexcept
   }
 }
 
-http_parser&
-http_parser::operator=(http_parser&& other) noexcept
+auto
+http_parser::operator=(http_parser&& other) noexcept -> http_parser&
 {
   response = std::move(other.response);
   header_field = std::move(other.header_field);
@@ -124,14 +124,14 @@ http_parser::reset()
   llhttp_init(&state_->parser_, HTTP_RESPONSE, &state_->settings_);
 }
 
-const char*
-http_parser::error_message() const
+auto
+http_parser::error_message() const -> const char*
 {
   return llhttp_errno_name(llhttp_get_errno(&state_->parser_));
 }
 
-http_parser::feeding_result
-http_parser::feed(const char* data, size_t data_len) const
+auto
+http_parser::feed(const char* data, size_t data_len) const -> http_parser::feeding_result
 {
   auto error = llhttp_execute(&state_->parser_, data, data_len);
   if (error != HPE_OK) {

--- a/core/io/http_parser.hxx
+++ b/core/io/http_parser.hxx
@@ -41,15 +41,15 @@ struct http_parser {
 
   http_parser();
   http_parser(http_parser&& other) noexcept;
-  http_parser& operator=(http_parser&& other) noexcept;
+  auto operator=(http_parser&& other) noexcept -> http_parser&;
   http_parser(const http_parser& other) = delete;
-  http_parser& operator=(const http_parser& other) = delete;
+  auto operator=(const http_parser& other) -> http_parser& = delete;
 
   void reset();
 
-  [[nodiscard]] const char* error_message() const;
+  [[nodiscard]] auto error_message() const -> const char*;
 
-  feeding_result feed(const char* data, size_t data_len) const;
+  auto feed(const char* data, size_t data_len) const -> feeding_result;
 
 private:
   std::shared_ptr<http_parser_state> state_{};

--- a/core/io/http_session.hxx
+++ b/core/io/http_session.hxx
@@ -81,27 +81,27 @@ public:
                               remote_endpoint_.port());
   }
 
-  [[nodiscard]] const asio::ip::tcp::endpoint& remote_endpoint() const
+  [[nodiscard]] auto remote_endpoint() const -> const asio::ip::tcp::endpoint&
   {
     return remote_endpoint_;
   }
 
-  [[nodiscard]] const std::string& remote_address() const
+  [[nodiscard]] auto remote_address() const -> const std::string&
   {
     return remote_endpoint_address_;
   }
 
-  [[nodiscard]] const asio::ip::tcp::endpoint& local_endpoint() const
+  [[nodiscard]] auto local_endpoint() const -> const asio::ip::tcp::endpoint&
   {
     return local_endpoint_;
   }
 
-  [[nodiscard]] const std::string& local_address() const
+  [[nodiscard]] auto local_address() const -> const std::string&
   {
     return local_endpoint_address_;
   }
 
-  [[nodiscard]] const std::string& log_prefix() const
+  [[nodiscard]] auto log_prefix() const -> const std::string&
   {
     return log_prefix_;
   }
@@ -176,24 +176,24 @@ public:
     return stream_->get_executor();
   }
 
-  [[nodiscard]] couchbase::core::http_context& http_context()
+  [[nodiscard]] auto http_context() -> couchbase::core::http_context&
   {
     return http_ctx_;
   }
 
-  [[nodiscard]] std::string remote_address()
+  [[nodiscard]] auto remote_address() -> std::string
   {
     std::scoped_lock lock(info_mutex_);
     return info_.remote_address();
   }
 
-  [[nodiscard]] std::string local_address()
+  [[nodiscard]] auto local_address() -> std::string
   {
     std::scoped_lock lock(info_mutex_);
     return info_.local_address();
   }
 
-  [[nodiscard]] diag::endpoint_diag_info diag_info()
+  [[nodiscard]] auto diag_info() -> diag::endpoint_diag_info
   {
     return { type_,
              id_,
@@ -219,33 +219,33 @@ public:
                             std::placeholders::_2));
   }
 
-  [[nodiscard]] std::string log_prefix()
+  [[nodiscard]] auto log_prefix() -> std::string
   {
     std::scoped_lock lock(info_mutex_);
     return info_.log_prefix();
   }
 
-  [[nodiscard]] const std::string& id() const
+  [[nodiscard]] auto id() const -> const std::string&
   {
     return id_;
   }
 
-  [[nodiscard]] service_type type() const
+  [[nodiscard]] auto type() const -> service_type
   {
     return type_;
   }
 
-  [[nodiscard]] const std::string& hostname() const
+  [[nodiscard]] auto hostname() const -> const std::string&
   {
     return hostname_;
   }
 
-  [[nodiscard]] const std::string& port() const
+  [[nodiscard]] auto port() const -> const std::string&
   {
     return service_;
   }
 
-  [[nodiscard]] const asio::ip::tcp::endpoint& endpoint()
+  [[nodiscard]] auto endpoint() -> const asio::ip::tcp::endpoint&
   {
     std::scoped_lock lock(info_mutex_);
     return info_.remote_endpoint();
@@ -284,12 +284,12 @@ public:
     state_ = diag::endpoint_state::disconnected;
   }
 
-  bool keep_alive() const
+  auto keep_alive() const -> bool
   {
     return keep_alive_;
   }
 
-  bool is_stopped() const
+  auto is_stopped() const -> bool
   {
     return stopped_;
   }
@@ -375,7 +375,7 @@ public:
     });
   }
 
-  bool reset_idle()
+  auto reset_idle() -> bool
   {
     // Return true if cancel() is successful. Since the idle_timer_ has a single pending
     // wait per session, we know the timer has already expired if cancel() returns 0.

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -211,10 +211,10 @@ public:
     }
   }
 
-  std::pair<std::error_code, std::shared_ptr<http_session>> check_out(
-    service_type type,
-    const couchbase::core::cluster_credentials& credentials,
-    const std::string& preferred_node)
+  auto check_out(service_type type,
+                 const couchbase::core::cluster_credentials& credentials,
+                 const std::string& preferred_node)
+    -> std::pair<std::error_code, std::shared_ptr<http_session>>
   {
     std::scoped_lock lock(sessions_mutex_);
     idle_sessions_[type].remove_if([](const auto& s) {
@@ -353,11 +353,10 @@ public:
   }
 
 private:
-  std::shared_ptr<http_session> bootstrap_session(
-    service_type type,
-    const couchbase::core::cluster_credentials& credentials,
-    const std::string& hostname,
-    std::uint16_t port)
+  auto bootstrap_session(service_type type,
+                         const couchbase::core::cluster_credentials& credentials,
+                         const std::string& hostname,
+                         std::uint16_t port) -> std::shared_ptr<http_session>
   {
     std::shared_ptr<http_session> session;
     if (options_.enable_tls) {
@@ -394,7 +393,7 @@ private:
     return session;
   }
 
-  std::pair<std::string, std::uint16_t> next_node(service_type type)
+  auto next_node(service_type type) -> std::pair<std::string, std::uint16_t>
   {
     std::scoped_lock lock(config_mutex_);
     auto candidates = config_.nodes.size();
@@ -411,7 +410,7 @@ private:
     return { "", static_cast<std::uint16_t>(0U) };
   }
 
-  std::pair<std::string, std::uint16_t> split_host_port(const std::string& address)
+  auto split_host_port(const std::string& address) -> std::pair<std::string, std::uint16_t>
   {
     auto last_colon = address.find_last_of(':');
     if (last_colon == std::string::npos || address.size() - 1 == last_colon) {
@@ -422,8 +421,8 @@ private:
     return { hostname, port };
   }
 
-  std::pair<std::string, std::uint16_t> lookup_node(service_type type,
-                                                    const std::string& preferred_node)
+  auto lookup_node(service_type type,
+                   const std::string& preferred_node) -> std::pair<std::string, std::uint16_t>
   {
     std::scoped_lock lock(config_mutex_);
     auto [hostname, port] = split_host_port(preferred_node);

--- a/core/io/mcbp_context.hxx
+++ b/core/io/mcbp_context.hxx
@@ -31,7 +31,7 @@ struct mcbp_context {
   const std::optional<topology::configuration>& config;
   const std::vector<protocol::hello_feature>& supported_features;
 
-  [[nodiscard]] bool supports_feature(protocol::hello_feature feature) const
+  [[nodiscard]] auto supports_feature(protocol::hello_feature feature) const -> bool
   {
     return std::find(supported_features.begin(), supported_features.end(), feature) !=
            supported_features.end();

--- a/core/io/mcbp_message.cxx
+++ b/core/io/mcbp_message.cxx
@@ -23,14 +23,14 @@
 
 namespace couchbase::core::io
 {
-std::uint16_t
-binary_header::status() const
+auto
+binary_header::status() const -> std::uint16_t
 {
   return utils::byte_swap(specific);
 }
 
-protocol::header_buffer
-mcbp_message::header_data() const
+auto
+mcbp_message::header_data() const -> protocol::header_buffer
 {
   protocol::header_buffer buf;
   std::memcpy(buf.data(), &header, sizeof(header));

--- a/core/io/mcbp_message.hxx
+++ b/core/io/mcbp_message.hxx
@@ -42,7 +42,7 @@ struct binary_header {
   std::uint32_t opaque;
   std::uint64_t cas;
 
-  [[nodiscard]] std::uint16_t status() const;
+  [[nodiscard]] auto status() const -> std::uint16_t;
 };
 
 struct mcbp_message {
@@ -51,11 +51,11 @@ struct mcbp_message {
 
   mcbp_message() = default;
   mcbp_message(const mcbp_message& other) = delete;
-  mcbp_message& operator=(const mcbp_message& other) = delete;
+  auto operator=(const mcbp_message& other) -> mcbp_message& = delete;
   mcbp_message(mcbp_message&& other) = default;
-  mcbp_message& operator=(mcbp_message&& other) = default;
+  auto operator=(mcbp_message&& other) -> mcbp_message& = default;
 
-  [[nodiscard]] protocol::header_buffer header_data() const;
+  [[nodiscard]] auto header_data() const -> protocol::header_buffer;
 };
 } // namespace io
 } // namespace couchbase::core

--- a/core/io/mcbp_parser.cxx
+++ b/core/io/mcbp_parser.cxx
@@ -30,8 +30,8 @@
 
 namespace couchbase::core::io
 {
-mcbp_parser::result
-mcbp_parser::next(mcbp_message& msg)
+auto
+mcbp_parser::next(mcbp_message& msg) -> mcbp_parser::result
 {
   static const std::size_t header_size = 24;
   if (buf.size() < header_size) {

--- a/core/io/mcbp_parser.hxx
+++ b/core/io/mcbp_parser.hxx
@@ -42,7 +42,7 @@ struct mcbp_parser {
     buf.clear();
   }
 
-  result next(mcbp_message& msg);
+  auto next(mcbp_message& msg) -> result;
 
   std::vector<std::byte> buf;
 };

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -182,7 +182,7 @@ private:
   std::map<std::string, std::uint32_t> cid_map_{ { "_default._default", 0 } };
 
 public:
-  [[nodiscard]] std::optional<std::uint32_t> get(const std::string& path)
+  [[nodiscard]] auto get(const std::string& path) -> std::optional<std::uint32_t>
   {
     Expects(!path.empty());
     if (auto ptr = cid_map_.find(path); ptr != cid_map_.end()) {
@@ -241,12 +241,12 @@ class mcbp_session_impl
       return { "SCRAM-SHA512", "SCRAM-SHA256", "SCRAM-SHA1" };
     }
 
-    std::string last_error_message() &&
+    auto last_error_message() && -> std::string
     {
       return std::move(last_error_message_);
     }
 
-    [[nodiscard]] const std::string& last_error_message() const&
+    [[nodiscard]] auto last_error_message() const& -> const std::string&
     {
       return last_error_message_;
     }
@@ -833,22 +833,22 @@ public:
     stop(retry_reason::do_not_retry);
   }
 
-  [[nodiscard]] const std::string& log_prefix() const
+  [[nodiscard]] auto log_prefix() const -> const std::string&
   {
     return log_prefix_;
   }
 
-  std::string remote_address() const
+  auto remote_address() const -> std::string
   {
     return connection_endpoints_.remote_address_with_port;
   }
 
-  std::string local_address() const
+  auto local_address() const -> std::string
   {
     return connection_endpoints_.local_address_with_port;
   }
 
-  [[nodiscard]] diag::endpoint_diag_info diag_info() const
+  [[nodiscard]] auto diag_info() const -> diag::endpoint_diag_info
   {
     return { service_type::key_value,
              id_,
@@ -923,7 +923,7 @@ public:
       });
   }
 
-  [[nodiscard]] mcbp_context context() const
+  [[nodiscard]] auto context() const -> mcbp_context
   {
     return { config_, supported_features_ };
   }
@@ -1012,17 +1012,17 @@ public:
                             std::placeholders::_2));
   }
 
-  [[nodiscard]] const std::string& id() const
+  [[nodiscard]] auto id() const -> const std::string&
   {
     return id_;
   }
 
-  [[nodiscard]] bool is_stopped() const
+  [[nodiscard]] auto is_stopped() const -> bool
   {
     return stopped_;
   }
 
-  [[nodiscard]] bool is_bootstrapped() const
+  [[nodiscard]] auto is_bootstrapped() const -> bool
   {
     return bootstrapped_;
   }
@@ -1259,7 +1259,7 @@ public:
     }
   }
 
-  [[nodiscard]] bool cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason)
+  [[nodiscard]] auto cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason) -> bool
   {
     if (stopped_) {
       return false;
@@ -1283,71 +1283,71 @@ public:
     return false;
   }
 
-  [[nodiscard]] bool supports_feature(protocol::hello_feature feature)
+  [[nodiscard]] auto supports_feature(protocol::hello_feature feature) -> bool
   {
     return std::find(supported_features_.begin(), supported_features_.end(), feature) !=
            supported_features_.end();
   }
 
-  [[nodiscard]] std::vector<protocol::hello_feature> supported_features() const
+  [[nodiscard]] auto supported_features() const -> std::vector<protocol::hello_feature>
   {
     return supported_features_;
   }
 
-  [[nodiscard]] bool supports_gcccp() const
+  [[nodiscard]] auto supports_gcccp() const -> bool
   {
     return supports_gcccp_;
   }
 
-  std::optional<topology::configuration> config() const
+  auto config() const -> std::optional<topology::configuration>
   {
     return config_;
   }
 
-  [[nodiscard]] bool has_config() const
+  [[nodiscard]] auto has_config() const -> bool
   {
     return configured_;
   }
 
-  [[nodiscard]] topology::configuration config()
+  [[nodiscard]] auto config() -> topology::configuration
   {
     std::scoped_lock lock(config_mutex_);
     return config_.value();
   }
 
-  [[nodiscard]] std::size_t index() const
+  [[nodiscard]] auto index() const -> std::size_t
   {
     std::scoped_lock lock(config_mutex_);
     Expects(config_.has_value());
     return config_->index_for_this_node();
   }
 
-  [[nodiscard]] const std::string& bootstrap_address() const
+  [[nodiscard]] auto bootstrap_address() const -> const std::string&
   {
     return bootstrap_address_;
   }
 
-  [[nodiscard]] const std::string& bootstrap_hostname() const
+  [[nodiscard]] auto bootstrap_hostname() const -> const std::string&
   {
     return bootstrap_hostname_;
   }
 
-  [[nodiscard]] const std::string& bootstrap_port() const
+  [[nodiscard]] auto bootstrap_port() const -> const std::string&
   {
     return bootstrap_port_;
   }
 
-  [[nodiscard]] std::uint16_t bootstrap_port_number() const
+  [[nodiscard]] auto bootstrap_port_number() const -> std::uint16_t
   {
     return bootstrap_port_number_;
   }
 
-  [[nodiscard]] std::uint32_t next_opaque()
+  [[nodiscard]] auto next_opaque() -> std::uint32_t
   {
     return ++opaque_;
   }
 
-  std::optional<key_value_error_map_info> decode_error_code(std::uint16_t code)
+  auto decode_error_code(std::uint16_t code) -> std::optional<key_value_error_map_info>
   {
     if (error_map_) {
       auto info = error_map_->errors.find(code);
@@ -1474,7 +1474,7 @@ public:
     }
   }
 
-  std::optional<std::uint32_t> get_collection_uid(const std::string& collection_path)
+  auto get_collection_uid(const std::string& collection_path) -> std::optional<std::uint32_t>
   {
     return collection_cache_.get(collection_path);
   }
@@ -1921,92 +1921,92 @@ mcbp_session::mcbp_session(std::string client_id,
 {
 }
 
-const std::string&
-mcbp_session::log_prefix() const
+auto
+mcbp_session::log_prefix() const -> const std::string&
 {
   return impl_->log_prefix();
 }
 
-bool
-mcbp_session::cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason)
+auto
+mcbp_session::cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason) -> bool
 {
   return impl_->cancel(opaque, ec, reason);
 }
 
-bool
-mcbp_session::is_stopped() const
+auto
+mcbp_session::is_stopped() const -> bool
 {
   return impl_->is_stopped();
 }
 
-bool
-mcbp_session::is_bootstrapped() const
+auto
+mcbp_session::is_bootstrapped() const -> bool
 {
   return impl_->is_bootstrapped();
 }
 
-std::uint32_t
-mcbp_session::next_opaque()
+auto
+mcbp_session::next_opaque() -> std::uint32_t
 {
   return impl_->next_opaque();
 }
 
-std::optional<std::uint32_t>
-mcbp_session::get_collection_uid(const std::string& collection_path)
+auto
+mcbp_session::get_collection_uid(const std::string& collection_path) -> std::optional<std::uint32_t>
 {
   return impl_->get_collection_uid(collection_path);
 }
 
-mcbp_context
-mcbp_session::context() const
+auto
+mcbp_session::context() const -> mcbp_context
 {
   return impl_->context();
 }
 
-bool
-mcbp_session::supports_feature(protocol::hello_feature feature)
+auto
+mcbp_session::supports_feature(protocol::hello_feature feature) -> bool
 {
   return impl_->supports_feature(feature);
 }
 
-const std::string&
-mcbp_session::id() const
+auto
+mcbp_session::id() const -> const std::string&
 {
   return impl_->id();
 }
 
-const std::string&
-mcbp_session::bootstrap_address() const
+auto
+mcbp_session::bootstrap_address() const -> const std::string&
 {
   return impl_->bootstrap_address();
 }
 
-std::string
-mcbp_session::remote_address() const
+auto
+mcbp_session::remote_address() const -> std::string
 {
   return impl_->remote_address();
 }
 
-std::string
-mcbp_session::local_address() const
+auto
+mcbp_session::local_address() const -> std::string
 {
   return impl_->local_address();
 }
 
-const std::string&
-mcbp_session::bootstrap_hostname() const
+auto
+mcbp_session::bootstrap_hostname() const -> const std::string&
 {
   return impl_->bootstrap_hostname();
 }
 
-const std::string&
-mcbp_session::bootstrap_port() const
+auto
+mcbp_session::bootstrap_port() const -> const std::string&
 {
   return impl_->bootstrap_port();
 }
 
-std::uint16_t
-mcbp_session::bootstrap_port_number() const
+auto
+mcbp_session::bootstrap_port_number() const -> std::uint16_t
 {
   return impl_->bootstrap_port_number();
 }
@@ -2039,26 +2039,26 @@ mcbp_session::stop(retry_reason reason)
   return impl_->stop(reason);
 }
 
-std::size_t
-mcbp_session::index() const
+auto
+mcbp_session::index() const -> std::size_t
 {
   return impl_->index();
 }
 
-std::optional<topology::configuration>
-mcbp_session::config() const
+auto
+mcbp_session::config() const -> std::optional<topology::configuration>
 {
   return impl_->config();
 }
 
-bool
-mcbp_session::has_config() const
+auto
+mcbp_session::has_config() const -> bool
 {
   return impl_->has_config();
 }
 
-diag::endpoint_diag_info
-mcbp_session::diag_info() const
+auto
+mcbp_session::diag_info() const -> diag::endpoint_diag_info
 {
   return impl_->diag_info();
 }
@@ -2069,8 +2069,8 @@ mcbp_session::on_configuration_update(std::shared_ptr<config_listener> handler)
   return impl_->on_configuration_update(std::move(handler));
 }
 
-std::vector<protocol::hello_feature>
-mcbp_session::supported_features() const
+auto
+mcbp_session::supported_features() const -> std::vector<protocol::hello_feature>
 {
   return impl_->supported_features();
 }
@@ -2082,14 +2082,14 @@ mcbp_session::ping(std::shared_ptr<diag::ping_reporter> handler,
   return impl_->ping(std::move(handler), std::move(timeout));
 }
 
-bool
-mcbp_session::supports_gcccp() const
+auto
+mcbp_session::supports_gcccp() const -> bool
 {
   return impl_->supports_gcccp();
 }
 
-std::optional<key_value_error_map_info>
-mcbp_session::decode_error_code(std::uint16_t code)
+auto
+mcbp_session::decode_error_code(std::uint16_t code) -> std::optional<key_value_error_map_info>
 {
   return impl_->decode_error_code(code);
 }

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -75,9 +75,9 @@ public:
   mcbp_session() = delete;
   ~mcbp_session() = default;
   mcbp_session(const mcbp_session& other) = default;
-  mcbp_session& operator=(const mcbp_session& other) = default;
+  auto operator=(const mcbp_session& other) -> mcbp_session& = default;
   mcbp_session(mcbp_session&& other) = default;
-  mcbp_session& operator=(mcbp_session&& other) = default;
+  auto operator=(mcbp_session&& other) -> mcbp_session& = default;
 
   mcbp_session(std::string client_id,
                asio::io_context& ctx,
@@ -94,22 +94,23 @@ public:
                std::optional<std::string> bucket_name = {},
                std::vector<protocol::hello_feature> known_features = {});
 
-  [[nodiscard]] const std::string& log_prefix() const;
-  [[nodiscard]] bool cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason);
-  [[nodiscard]] bool is_stopped() const;
-  [[nodiscard]] bool is_bootstrapped() const;
-  [[nodiscard]] std::uint32_t next_opaque();
-  [[nodiscard]] std::optional<std::uint32_t> get_collection_uid(const std::string& collection_path);
-  [[nodiscard]] mcbp_context context() const;
-  [[nodiscard]] bool supports_feature(protocol::hello_feature feature);
-  [[nodiscard]] std::vector<protocol::hello_feature> supported_features() const;
-  [[nodiscard]] const std::string& id() const;
-  [[nodiscard]] std::string remote_address() const;
-  [[nodiscard]] std::string local_address() const;
-  [[nodiscard]] const std::string& bootstrap_address() const;
-  [[nodiscard]] const std::string& bootstrap_hostname() const;
-  [[nodiscard]] const std::string& bootstrap_port() const;
-  [[nodiscard]] std::uint16_t bootstrap_port_number() const;
+  [[nodiscard]] auto log_prefix() const -> const std::string&;
+  [[nodiscard]] auto cancel(std::uint32_t opaque, std::error_code ec, retry_reason reason) -> bool;
+  [[nodiscard]] auto is_stopped() const -> bool;
+  [[nodiscard]] auto is_bootstrapped() const -> bool;
+  [[nodiscard]] auto next_opaque() -> std::uint32_t;
+  [[nodiscard]] auto get_collection_uid(const std::string& collection_path)
+    -> std::optional<std::uint32_t>;
+  [[nodiscard]] auto context() const -> mcbp_context;
+  [[nodiscard]] auto supports_feature(protocol::hello_feature feature) -> bool;
+  [[nodiscard]] auto supported_features() const -> std::vector<protocol::hello_feature>;
+  [[nodiscard]] auto id() const -> const std::string&;
+  [[nodiscard]] auto remote_address() const -> std::string;
+  [[nodiscard]] auto local_address() const -> std::string;
+  [[nodiscard]] auto bootstrap_address() const -> const std::string&;
+  [[nodiscard]] auto bootstrap_hostname() const -> const std::string&;
+  [[nodiscard]] auto bootstrap_port() const -> const std::string&;
+  [[nodiscard]] auto bootstrap_port_number() const -> std::uint16_t;
   void write_and_flush(std::vector<std::byte>&& buffer);
   void write_and_subscribe(std::shared_ptr<mcbp::queue_request>,
                            std::shared_ptr<response_handler> handler);
@@ -120,15 +121,16 @@ public:
                  bool retry_on_bucket_not_found = false);
   void on_stop(utils::movable_function<void()> handler);
   void stop(retry_reason reason);
-  [[nodiscard]] std::size_t index() const;
-  [[nodiscard]] bool has_config() const;
-  [[nodiscard]] std::optional<topology::configuration> config() const;
-  [[nodiscard]] diag::endpoint_diag_info diag_info() const;
+  [[nodiscard]] auto index() const -> std::size_t;
+  [[nodiscard]] auto has_config() const -> bool;
+  [[nodiscard]] auto config() const -> std::optional<topology::configuration>;
+  [[nodiscard]] auto diag_info() const -> diag::endpoint_diag_info;
   void on_configuration_update(std::shared_ptr<config_listener> handler);
   void ping(std::shared_ptr<diag::ping_reporter> handler,
             std::optional<std::chrono::milliseconds> = {}) const;
-  [[nodiscard]] bool supports_gcccp() const;
-  [[nodiscard]] std::optional<key_value_error_map_info> decode_error_code(std::uint16_t code);
+  [[nodiscard]] auto supports_gcccp() const -> bool;
+  [[nodiscard]] auto decode_error_code(std::uint16_t code)
+    -> std::optional<key_value_error_map_info>;
   void handle_not_my_vbucket(const io::mcbp_message& msg) const;
   void update_collection_uid(const std::string& path, std::uint32_t uid);
 

--- a/core/io/query_cache.hxx
+++ b/core/io/query_cache.hxx
@@ -54,7 +54,7 @@ public:
     store_.try_emplace(statement, entry{ name, encoded_plan });
   }
 
-  std::optional<entry> get(const std::string& statement)
+  auto get(const std::string& statement) -> std::optional<entry>
   {
     std::scoped_lock lock(store_mutex_);
     auto it = store_.find(statement);

--- a/core/io/retry_orchestrator.hxx
+++ b/core/io/retry_orchestrator.hxx
@@ -32,8 +32,9 @@ namespace couchbase::core::io::retry_orchestrator
 namespace priv
 {
 template<class Command>
-std::chrono::milliseconds
-cap_duration(std::chrono::milliseconds uncapped, std::shared_ptr<Command> command)
+auto
+cap_duration(std::chrono::milliseconds uncapped,
+             std::shared_ptr<Command> command) -> std::chrono::milliseconds
 {
   auto theoretical_deadline = std::chrono::steady_clock::now() + uncapped;
   auto absolute_deadline = command->deadline.expiry();

--- a/core/io/streams.hxx
+++ b/core/io/streams.hxx
@@ -70,17 +70,17 @@ public:
 
   virtual ~stream_impl() = default;
 
-  [[nodiscard]] std::string_view log_prefix() const
+  [[nodiscard]] auto log_prefix() const -> std::string_view
   {
     return tls_ ? "tls" : "plain";
   }
 
-  [[nodiscard]] const std::string& id() const
+  [[nodiscard]] auto id() const -> const std::string&
   {
     return id_;
   }
 
-  [[nodiscard]] bool is_open() const
+  [[nodiscard]] auto is_open() const -> bool
   {
     return open_;
   }
@@ -90,7 +90,7 @@ public:
     return strand_;
   }
 
-  [[nodiscard]] virtual asio::ip::tcp::endpoint local_endpoint() const = 0;
+  [[nodiscard]] virtual auto local_endpoint() const -> asio::ip::tcp::endpoint = 0;
 
   virtual void close(std::function<void(std::error_code)>&& handler) = 0;
 
@@ -120,7 +120,7 @@ public:
   {
   }
 
-  [[nodiscard]] asio::ip::tcp::endpoint local_endpoint() const override
+  [[nodiscard]] auto local_endpoint() const -> asio::ip::tcp::endpoint override
   {
     std::error_code ec;
     auto res = stream_->local_endpoint(ec);
@@ -197,7 +197,7 @@ public:
   {
   }
 
-  [[nodiscard]] asio::ip::tcp::endpoint local_endpoint() const override
+  [[nodiscard]] auto local_endpoint() const -> asio::ip::tcp::endpoint override
   {
     std::error_code ec;
     auto res = stream_->lowest_layer().local_endpoint(ec);

--- a/core/logger/custom_rotating_file_sink.cxx
+++ b/core/logger/custom_rotating_file_sink.cxx
@@ -28,8 +28,8 @@
 #include <memory>
 #include <spdlog/details/file_helper.h>
 
-static unsigned long
-find_first_logfile_id(const std::string& basename)
+static auto
+find_first_logfile_id(const std::string& basename) -> unsigned long
 {
   unsigned long id = 0;
 
@@ -138,8 +138,8 @@ custom_rotating_file_sink<Mutex>::add_hook(const std::string& hook)
 }
 
 template<class Mutex>
-std::unique_ptr<spdlog::details::file_helper>
-custom_rotating_file_sink<Mutex>::open_file()
+auto
+custom_rotating_file_sink<Mutex>::open_file() -> std::unique_ptr<spdlog::details::file_helper>
 {
   auto ret = std::make_unique<spdlog::details::file_helper>();
   do {

--- a/core/logger/custom_rotating_file_sink.hxx
+++ b/core/logger/custom_rotating_file_sink.hxx
@@ -61,7 +61,7 @@ protected:
 private:
   void add_hook(const std::string& hook);
   // Calculate the full filename to use the next time
-  std::unique_ptr<spdlog::details::file_helper> open_file();
+  auto open_file() -> std::unique_ptr<spdlog::details::file_helper>;
 
   const spdlog::filename_t base_filename_;
   const std::size_t max_size_;

--- a/core/logger/logger.cxx
+++ b/core/logger/logger.cxx
@@ -49,8 +49,8 @@ static std::shared_ptr<spdlog::logger> protocol_logger{};
 
 namespace couchbase::core::logger
 {
-spdlog::level::level_enum
-translate_level(level level)
+auto
+translate_level(level level) -> spdlog::level::level_enum
 {
   switch (level) {
     case level::trace:
@@ -71,8 +71,8 @@ translate_level(level level)
   return spdlog::level::level_enum::trace;
 }
 
-level
-level_from_str(const std::string& str)
+auto
+level_from_str(const std::string& str) -> level
 {
   switch (spdlog::level::from_str(str)) {
     case spdlog::level::level_enum::trace:
@@ -96,8 +96,8 @@ level_from_str(const std::string& str)
   return level::trace;
 }
 
-bool
-should_log(level lvl)
+auto
+should_log(level lvl) -> bool
 {
   if (is_initialized()) {
     return file_logger->should_log(translate_level(lvl));
@@ -146,14 +146,15 @@ shutdown()
   spdlog::details::registry::instance().shutdown();
 }
 
-bool
-is_initialized()
+auto
+is_initialized() -> bool
 {
   return file_logger != nullptr;
 }
 
-std::pair<std::optional<std::string>, std::shared_ptr<spdlog::logger>>
+auto
 create_file_logger_impl(const std::string logger_name, const configuration& logger_settings)
+  -> std::pair<std::optional<std::string>, std::shared_ptr<spdlog::logger>>
 {
   std::shared_ptr<spdlog::logger> logger{};
 
@@ -252,8 +253,8 @@ create_file_logger_impl(const std::string logger_name, const configuration& logg
  * Initialises the loggers. Called if the logger configuration is
  * specified in a separate settings object.
  */
-std::optional<std::string>
-create_file_logger(const configuration& logger_settings)
+auto
+create_file_logger(const configuration& logger_settings) -> std::optional<std::string>
 {
   auto [error, logger] = create_file_logger_impl(file_logger_name, logger_settings);
   if (error) {
@@ -263,8 +264,8 @@ create_file_logger(const configuration& logger_settings)
   return {};
 }
 
-std::optional<std::string>
-create_protocol_logger(const configuration& logger_settings)
+auto
+create_protocol_logger(const configuration& logger_settings) -> std::optional<std::string>
 {
   if (logger_settings.filename.empty()) {
     return "File name is missing";
@@ -279,8 +280,8 @@ create_protocol_logger(const configuration& logger_settings)
   return {};
 }
 
-bool
-should_log_protocol()
+auto
+should_log_protocol() -> bool
 {
   return protocol_logger != nullptr;
 }
@@ -297,8 +298,8 @@ log_protocol(const char* file, int line, const char* function, std::string_view 
 }
 } // namespace detail
 
-spdlog::logger*
-get()
+auto
+get() -> spdlog::logger*
 {
   return file_logger.get();
 }
@@ -364,8 +365,8 @@ unregister_spdlog_logger(const std::string& n)
   spdlog::drop(n);
 }
 
-bool
-check_log_levels(level lvl)
+auto
+check_log_levels(level lvl) -> bool
 {
   auto level = translate_level(lvl);
   bool correct = true;

--- a/core/logger/logger.hxx
+++ b/core/logger/logger.hxx
@@ -38,8 +38,8 @@ namespace couchbase::core::logger
 {
 struct configuration;
 
-level
-level_from_str(const std::string& str);
+auto
+level_from_str(const std::string& str) -> level;
 
 /**
  * Initialize the logger.
@@ -51,8 +51,8 @@ level_from_str(const std::string& str);
  * @param logger_settings the configuration for the logger
  * @return optional error message if something goes wrong
  */
-std::optional<std::string>
-create_file_logger(const configuration& logger_settings);
+auto
+create_file_logger(const configuration& logger_settings) -> std::optional<std::string>;
 
 /**
  * Protocol logger writes only communication logs with the nodes.
@@ -62,8 +62,8 @@ create_file_logger(const configuration& logger_settings);
  * @param logger_settings
  * @return
  */
-std::optional<std::string>
-create_protocol_logger(const configuration& logger_settings);
+auto
+create_protocol_logger(const configuration& logger_settings) -> std::optional<std::string>;
 
 /**
  * Initialize the logger with the blackhole logger object
@@ -102,8 +102,8 @@ create_console_logger();
  * - create_blackhole_logger()
  * - create_console_logger()
  */
-spdlog::logger*
-get();
+auto
+get() -> spdlog::logger*;
 
 /**
  * Reset the underlying logger object
@@ -138,8 +138,8 @@ unregister_spdlog_logger(const std::string& n);
  * @param log severity level
  * @return true if all registered loggers have the specified severity level
  */
-bool
-check_log_levels(level lvl);
+auto
+check_log_levels(level lvl) -> bool;
 
 /**
  * Set the log level of all registered spdLoggers
@@ -154,11 +154,11 @@ set_log_levels(level lvl);
  * @param level severity level to check
  * @return true if we should log at this level
  */
-bool
-should_log(level lvl);
+auto
+should_log(level lvl) -> bool;
 
-bool
-should_log_protocol();
+auto
+should_log_protocol() -> bool;
 
 namespace detail
 {
@@ -219,8 +219,8 @@ shutdown();
 /**
  * @return whether or not the logger has been initialized
  */
-bool
-is_initialized();
+auto
+is_initialized() -> bool;
 
 } // namespace couchbase::core::logger
 

--- a/core/management/analytics_link_azure_blob_external.cxx
+++ b/core/management/analytics_link_azure_blob_external.cxx
@@ -25,8 +25,8 @@
 
 namespace couchbase::core::management::analytics
 {
-std::error_code
-azure_blob_external_link::validate() const
+auto
+azure_blob_external_link::validate() const -> std::error_code
 {
   if (dataverse.empty() || link_name.empty()) {
     return errc::common::invalid_argument;
@@ -39,8 +39,8 @@ azure_blob_external_link::validate() const
   return errc::common::invalid_argument;
 }
 
-std::string
-azure_blob_external_link::encode() const
+auto
+azure_blob_external_link::encode() const -> std::string
 {
   std::map<std::string, std::string> values{
     { "type", "azureblob" },

--- a/core/management/analytics_link_azure_blob_external.hxx
+++ b/core/management/analytics_link_azure_blob_external.hxx
@@ -70,8 +70,8 @@ struct azure_blob_external_link {
    */
   std::optional<std::string> endpoint_suffix{};
 
-  [[nodiscard]] std::error_code validate() const;
+  [[nodiscard]] auto validate() const -> std::error_code;
 
-  [[nodiscard]] std::string encode() const;
+  [[nodiscard]] auto encode() const -> std::string;
 };
 } // namespace couchbase::core::management::analytics

--- a/core/management/analytics_link_azure_blob_external_json.hxx
+++ b/core/management/analytics_link_azure_blob_external_json.hxx
@@ -26,8 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::analytics::azure_blob_external_link> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::analytics::azure_blob_external_link as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::analytics::azure_blob_external_link
   {
     couchbase::core::management::analytics::azure_blob_external_link result{};
 

--- a/core/management/analytics_link_couchbase_remote.cxx
+++ b/core/management/analytics_link_couchbase_remote.cxx
@@ -25,8 +25,8 @@
 
 namespace couchbase::core::management::analytics
 {
-std::error_code
-couchbase_remote_link::validate() const
+auto
+couchbase_remote_link::validate() const -> std::error_code
 {
   if (dataverse.empty() || link_name.empty() || hostname.empty()) {
     return errc::common::invalid_argument;
@@ -58,8 +58,8 @@ couchbase_remote_link::validate() const
   return {};
 }
 
-std::string
-couchbase_remote_link::encode() const
+auto
+couchbase_remote_link::encode() const -> std::string
 {
   std::map<std::string, std::string> values{
     { "type", "couchbase" },
@@ -88,8 +88,8 @@ couchbase_remote_link::encode() const
   return utils::string_codec::v2::form_encode(values);
 }
 
-std::string
-to_string(couchbase_link_encryption_level level)
+auto
+to_string(couchbase_link_encryption_level level) -> std::string
 {
   switch (level) {
     case couchbase_link_encryption_level::none:

--- a/core/management/analytics_link_couchbase_remote.hxx
+++ b/core/management/analytics_link_couchbase_remote.hxx
@@ -45,8 +45,8 @@ enum class couchbase_link_encryption_level {
   full,
 };
 
-std::string
-to_string(couchbase_link_encryption_level level);
+auto
+to_string(couchbase_link_encryption_level level) -> std::string;
 
 struct couchbase_link_encryption_settings {
   /**
@@ -107,8 +107,8 @@ struct couchbase_remote_link {
 
   couchbase_link_encryption_settings encryption{};
 
-  [[nodiscard]] std::error_code validate() const;
+  [[nodiscard]] auto validate() const -> std::error_code;
 
-  [[nodiscard]] std::string encode() const;
+  [[nodiscard]] auto encode() const -> std::string;
 };
 } // namespace couchbase::core::management::analytics

--- a/core/management/analytics_link_couchbase_remote_json.hxx
+++ b/core/management/analytics_link_couchbase_remote_json.hxx
@@ -26,8 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::analytics::couchbase_remote_link> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::analytics::couchbase_remote_link as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::analytics::couchbase_remote_link
   {
     couchbase::core::management::analytics::couchbase_remote_link result{};
 

--- a/core/management/analytics_link_s3_external.cxx
+++ b/core/management/analytics_link_s3_external.cxx
@@ -25,8 +25,8 @@
 
 namespace couchbase::core::management::analytics
 {
-std::error_code
-s3_external_link::validate() const
+auto
+s3_external_link::validate() const -> std::error_code
 {
   if (dataverse.empty() || link_name.empty() || access_key_id.empty() ||
       secret_access_key.empty() || region.empty()) {
@@ -35,8 +35,8 @@ s3_external_link::validate() const
   return {};
 }
 
-std::string
-s3_external_link::encode() const
+auto
+s3_external_link::encode() const -> std::string
 {
   std::map<std::string, std::string> values{
     { "type", "s3" },

--- a/core/management/analytics_link_s3_external.hxx
+++ b/core/management/analytics_link_s3_external.hxx
@@ -62,8 +62,8 @@ struct s3_external_link {
    */
   std::optional<std::string> service_endpoint{};
 
-  [[nodiscard]] std::error_code validate() const;
+  [[nodiscard]] auto validate() const -> std::error_code;
 
-  [[nodiscard]] std::string encode() const;
+  [[nodiscard]] auto encode() const -> std::string;
 };
 } // namespace couchbase::core::management::analytics

--- a/core/management/analytics_link_s3_external_json.hxx
+++ b/core/management/analytics_link_s3_external_json.hxx
@@ -26,8 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::analytics::s3_external_link> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::analytics::s3_external_link as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::analytics::s3_external_link
   {
     couchbase::core::management::analytics::s3_external_link result{};
 

--- a/core/management/bucket_settings_json.hxx
+++ b/core/management/bucket_settings_json.hxx
@@ -26,8 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::cluster::bucket_settings> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::cluster::bucket_settings as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::cluster::bucket_settings
   {
     couchbase::core::management::cluster::bucket_settings result;
     result.name = v.at("name").get_string();

--- a/core/management/eventing_function_json.hxx
+++ b/core/management/eventing_function_json.hxx
@@ -26,7 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::eventing::function> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::eventing::function as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::eventing::function
   {
     couchbase::core::management::eventing::function result;
     result.version = v.at("version").get_string();

--- a/core/management/eventing_status_json.hxx
+++ b/core/management/eventing_status_json.hxx
@@ -26,7 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::eventing::status> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::eventing::status as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::eventing::status
   {
     couchbase::core::management::eventing::status result;
     result.num_eventing_nodes = v.at("num_eventing_nodes").get_unsigned();

--- a/core/management/rbac_json.hxx
+++ b/core/management/rbac_json.hxx
@@ -28,8 +28,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::rbac::user_and_metadata> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::rbac::user_and_metadata as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::rbac::user_and_metadata
   {
     couchbase::core::management::rbac::user_and_metadata result;
     if (const std::string& domain = v.at("domain").get_string(); domain == "local") {
@@ -103,8 +103,8 @@ struct traits<couchbase::core::management::rbac::user_and_metadata> {
 template<>
 struct traits<couchbase::core::management::rbac::role_and_description> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::rbac::role_and_description as(
-    const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::rbac::role_and_description
   {
     couchbase::core::management::rbac::role_and_description result;
     result.name = v.at("role").get_string();
@@ -135,7 +135,8 @@ struct traits<couchbase::core::management::rbac::role_and_description> {
 template<>
 struct traits<couchbase::core::management::rbac::group> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::rbac::group as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::rbac::group
   {
     couchbase::core::management::rbac::group result;
     result.name = v.at("id").get_string();

--- a/core/management/search_index.cxx
+++ b/core/management/search_index.cxx
@@ -21,8 +21,8 @@
 
 namespace
 {
-bool
-has_vector_mapping_properties(tao::json::value properties)
+auto
+has_vector_mapping_properties(tao::json::value properties) -> bool
 {
   if (!properties.is_object()) {
     return false;

--- a/core/management/search_index_json.hxx
+++ b/core/management/search_index_json.hxx
@@ -28,7 +28,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::management::search::index> {
   template<template<typename...> class Traits>
-  static couchbase::core::management::search::index as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::management::search::index
   {
     couchbase::core::management::search::index result;
     result.uuid = v.at("uuid").get_string();

--- a/core/mcbp/codec.cxx
+++ b/core/mcbp/codec.cxx
@@ -43,8 +43,8 @@ codec::enable_feature(protocol::hello_feature feature)
   }
 }
 
-bool
-codec::is_feature_enabled(protocol::hello_feature feature) const
+auto
+codec::is_feature_enabled(protocol::hello_feature feature) const -> bool
 {
   return enabled_features_.count(feature) > 0;
 }
@@ -315,8 +315,8 @@ codec::encode_packet(const couchbase::core::mcbp::packet& packet)
   return buffer.store_;
 }
 
-std::tuple<packet, std::size_t, std::error_code>
-codec::decode_packet(gsl::span<std::byte> input)
+auto
+codec::decode_packet(gsl::span<std::byte> input) -> std::tuple<packet, std::size_t, std::error_code>
 {
   if (input.empty()) {
     return { {}, {}, errc::network::end_of_stream };
@@ -340,8 +340,9 @@ codec::decode_packet(gsl::span<std::byte> input)
   return decode_packet(header, body);
 }
 
-std::tuple<packet, std::size_t, std::error_code>
-codec::decode_packet(gsl::span<std::byte> header, gsl::span<std::byte> body)
+auto
+codec::decode_packet(gsl::span<std::byte> header,
+                     gsl::span<std::byte> body) -> std::tuple<packet, std::size_t, std::error_code>
 {
   packet pkt;
 

--- a/core/mcbp/command_code.cxx
+++ b/core/mcbp/command_code.cxx
@@ -42,8 +42,8 @@ is_idempotent(protocol::client_opcode opcode) -> bool
   return false;
 }
 
-bool
-supports_collection_id(protocol::client_opcode command)
+auto
+supports_collection_id(protocol::client_opcode command) -> bool
 {
   switch (command) {
     case protocol::client_opcode::get:

--- a/core/mcbp/completion_token.hxx
+++ b/core/mcbp/completion_token.hxx
@@ -30,32 +30,32 @@ struct completion_token {
   std::error_code ec{};
 
   template<std::size_t index>
-  auto&& get() &
+  auto get() & -> auto&&
   {
     return get_impl<index>(*this);
   }
 
   template<std::size_t index>
-  auto&& get() &&
+  auto get() && -> auto&&
   {
     return get_impl<index>(*this);
   }
 
   template<std::size_t index>
-  auto&& get() const&
+  auto get() const& -> auto&&
   {
     return get_impl<index>(*this);
   }
 
   template<std::size_t index>
-  auto&& get() const&&
+  auto get() const&& -> auto&&
   {
     return get_impl<index>(*this);
   }
 
 private:
   template<std::size_t index, typename T>
-  auto&& get_impl(T&& t)
+  auto get_impl(T&& t) -> auto&&
   {
     static_assert(index < 2, "index out of bounds for completion_token");
     if constexpr (index == 0) {

--- a/core/mcbp/datatype.hxx
+++ b/core/mcbp/datatype.hxx
@@ -32,8 +32,8 @@ static constexpr datatype datatype_compressed{ 0x02 };
 // indicates the inclusion of xattr data in the value payload.
 static constexpr datatype datatype_xattrs{ 0x04 };
 
-static constexpr bool
-has_json_datatype(std::byte flags)
+static constexpr auto
+has_json_datatype(std::byte flags) -> bool
 {
   return (flags & datatype_json) == datatype_json;
 }

--- a/core/mcbp/packet.cxx
+++ b/core/mcbp/packet.cxx
@@ -27,8 +27,8 @@
 
 namespace couchbase::core::mcbp
 {
-std::string
-packet::debug_string() const
+auto
+packet::debug_string() const -> std::string
 {
   std::vector<char> out;
   fmt::format_to(

--- a/core/mcbp/packet.hxx
+++ b/core/mcbp/packet.hxx
@@ -41,7 +41,7 @@ namespace couchbase::core::mcbp
 class packet
 {
 public:
-  [[nodiscard]] std::string debug_string() const;
+  [[nodiscard]] auto debug_string() const -> std::string;
 
   protocol::magic magic_;
   protocol::client_opcode command_;

--- a/core/mcbp/queue_request.cxx
+++ b/core/mcbp/queue_request.cxx
@@ -35,27 +35,27 @@ queue_request::queue_request(protocol::magic magic,
 {
 }
 
-std::size_t
-queue_request::retry_attempts() const
+auto
+queue_request::retry_attempts() const -> std::size_t
 {
   std::scoped_lock lock(retry_mutex_);
   return retry_count_;
 }
 
-std::string
-queue_request::identifier() const
+auto
+queue_request::identifier() const -> std::string
 {
   return std::to_string(opaque_);
 }
 
-bool
-queue_request::idempotent() const
+auto
+queue_request::idempotent() const -> bool
 {
   return mcbp::is_idempotent(command_);
 }
 
-std::set<retry_reason>
-queue_request::retry_reasons() const
+auto
+queue_request::retry_reasons() const -> std::set<retry_reason>
 {
   std::scoped_lock lock(retry_mutex_);
   return retry_reasons_;

--- a/core/meta/version.cxx
+++ b/core/meta/version.cxx
@@ -39,8 +39,8 @@
 
 namespace couchbase::core::meta
 {
-std::map<std::string, std::string>
-sdk_build_info()
+auto
+sdk_build_info() -> std::map<std::string, std::string>
 {
   std::map<std::string, std::string> info{};
   info["build_timestamp"] = COUCHBASE_CXX_CLIENT_BUILD_TIMESTAMP;
@@ -165,8 +165,8 @@ sdk_build_info()
   return info;
 }
 
-std::string
-sdk_build_info_json()
+auto
+sdk_build_info_json() -> std::string
 {
   tao::json::value info;
   for (const auto& [name, value] : sdk_build_info()) {
@@ -183,8 +183,8 @@ sdk_build_info_json()
   return utils::json::generate(info);
 }
 
-std::string
-sdk_build_info_short()
+auto
+sdk_build_info_short() -> std::string
 {
   return fmt::format(R"(rev="{}", compiler="{}", system="{}", date="{}")",
                      COUCHBASE_CXX_CLIENT_GIT_REVISION,
@@ -193,16 +193,16 @@ sdk_build_info_short()
                      COUCHBASE_CXX_CLIENT_BUILD_TIMESTAMP);
 }
 
-const std::string&
-sdk_id()
+auto
+sdk_id() -> const std::string&
 {
   static const std::string identifier{ sdk_version() + ";" + COUCHBASE_CXX_CLIENT_SYSTEM_NAME +
                                        "/" + COUCHBASE_CXX_CLIENT_SYSTEM_PROCESSOR };
   return identifier;
 }
 
-std::string
-parse_git_describe_output(const std::string& git_describe_output)
+auto
+parse_git_describe_output(const std::string& git_describe_output) -> std::string
 {
   if (git_describe_output.empty() || git_describe_output == "unknown") {
     return "";
@@ -233,8 +233,8 @@ parse_git_describe_output(const std::string& git_describe_output)
   return "";
 }
 
-const std::string&
-sdk_semver()
+auto
+sdk_semver() -> const std::string&
 {
   static const std::string simple_version{
     std::to_string(COUCHBASE_CXX_CLIENT_VERSION_MAJOR) + "." +
@@ -250,16 +250,16 @@ sdk_semver()
   return semantic_version;
 }
 
-const std::string&
-sdk_version()
+auto
+sdk_version() -> const std::string&
 {
   static const std::string version{ sdk_version_short() + "/" +
                                     COUCHBASE_CXX_CLIENT_GIT_REVISION_SHORT };
   return version;
 }
 
-const std::string&
-sdk_version_short()
+auto
+sdk_version_short() -> const std::string&
 {
   static const std::string version{ std::string("cxx/") +
                                     std::to_string(COUCHBASE_CXX_CLIENT_VERSION_MAJOR) + "." +
@@ -268,8 +268,8 @@ sdk_version_short()
   return version;
 }
 
-const std::string&
-os()
+auto
+os() -> const std::string&
 {
   static const std::string system{ COUCHBASE_CXX_CLIENT_SYSTEM };
   return system;
@@ -283,10 +283,10 @@ constexpr const char* ssl_lib_id =
 #endif
   ;
 
-std::string
+auto
 user_agent_for_http(const std::string& client_id,
                     const std::string& session_id,
-                    const std::string& extra)
+                    const std::string& extra) -> std::string
 {
   auto user_agent = fmt::format("{};{}/0x{:x};client/{};session/{};{}",
                                 couchbase::core::meta::sdk_id(),
@@ -306,11 +306,11 @@ user_agent_for_http(const std::string& client_id,
   return user_agent;
 }
 
-std::string
+auto
 user_agent_for_mcbp(const std::string& client_id,
                     const std::string& session_id,
                     const std::string& extra,
-                    std::size_t max_length)
+                    std::size_t max_length) -> std::string
 {
   tao::json::value user_agent{
     { "i", fmt::format("{}/{}", client_id, session_id) },

--- a/core/meta/version.hxx
+++ b/core/meta/version.hxx
@@ -24,38 +24,38 @@
 
 namespace couchbase::core::meta
 {
-const std::string&
-sdk_id();
+auto
+sdk_id() -> const std::string&;
 
-const std::string&
-sdk_semver();
+auto
+sdk_semver() -> const std::string&;
 
-const std::string&
-sdk_version();
+auto
+sdk_version() -> const std::string&;
 
-const std::string&
-sdk_version_short();
+auto
+sdk_version_short() -> const std::string&;
 
-std::map<std::string, std::string>
-sdk_build_info();
+auto
+sdk_build_info() -> std::map<std::string, std::string>;
 
-std::string
-sdk_build_info_short();
+auto
+sdk_build_info_short() -> std::string;
 
-std::string
-sdk_build_info_json();
+auto
+sdk_build_info_json() -> std::string;
 
-const std::string&
-os();
+auto
+os() -> const std::string&;
 
-std::string
+auto
 user_agent_for_http(const std::string& client_id,
                     const std::string& session_id,
-                    const std::string& extra = "");
+                    const std::string& extra = "") -> std::string;
 
-std::string
+auto
 user_agent_for_mcbp(const std::string& client_id,
                     const std::string& session_id,
                     const std::string& extra = "",
-                    std::size_t max_length = 0);
+                    std::size_t max_length = 0) -> std::string;
 } // namespace couchbase::core::meta

--- a/core/metrics/logging_meter.cxx
+++ b/core/metrics/logging_meter.cxx
@@ -74,7 +74,7 @@ public:
     initialize_histogram();
   }
 
-  logging_value_recorder& operator=(const logging_value_recorder& other)
+  auto operator=(const logging_value_recorder& other) -> logging_value_recorder&
   {
     if (this == &other) {
       return *this;
@@ -85,7 +85,7 @@ public:
     return *this;
   }
 
-  logging_value_recorder& operator=(logging_value_recorder&& other) noexcept
+  auto operator=(logging_value_recorder&& other) noexcept -> logging_value_recorder&
   {
     if (this == &other) {
       return *this;
@@ -112,7 +112,7 @@ public:
     hdr_record_value_atomic(histogram_, value);
   }
 
-  [[nodiscard]] tao::json::value emit() const
+  [[nodiscard]] auto emit() const -> tao::json::value
   {
     auto total_count = histogram_->total_count;
     auto val_50_0 = hdr_value_at_percentile(histogram_, 50.0);
@@ -200,9 +200,10 @@ logging_meter::stop()
   emit_report_.cancel();
 }
 
-std::shared_ptr<couchbase::metrics::value_recorder>
+auto
 logging_meter::get_value_recorder(const std::string& name,
                                   const std::map<std::string, std::string>& tags)
+  -> std::shared_ptr<couchbase::metrics::value_recorder>
 {
   static std::shared_ptr<noop_value_recorder> noop_recorder{
     std::make_shared<noop_value_recorder>()

--- a/core/metrics/logging_meter.hxx
+++ b/core/metrics/logging_meter.hxx
@@ -54,9 +54,8 @@ public:
 
   void stop() override;
 
-  std::shared_ptr<couchbase::metrics::value_recorder> get_value_recorder(
-    const std::string& name,
-    const std::map<std::string, std::string>& tags) override;
+  auto get_value_recorder(const std::string& name, const std::map<std::string, std::string>& tags)
+    -> std::shared_ptr<couchbase::metrics::value_recorder> override;
 };
 
 } // namespace couchbase::core::metrics

--- a/core/metrics/noop_meter.hxx
+++ b/core/metrics/noop_meter.hxx
@@ -25,7 +25,7 @@ namespace couchbase::core::metrics
 class noop_value_recorder : public couchbase::metrics::value_recorder
 {
 public:
-  void record_value(std::int64_t /* value */) override
+  void record_value(int64_t /* value */) override
   {
     /* do nothing */
   }
@@ -37,9 +37,9 @@ private:
   std::shared_ptr<noop_value_recorder> instance_{ std::make_shared<noop_value_recorder>() };
 
 public:
-  std::shared_ptr<couchbase::metrics::value_recorder> get_value_recorder(
-    const std::string& /* name */,
-    const std::map<std::string, std::string>& /* tags */) override
+  auto get_value_recorder(const std::string& /* name */,
+                          const std::map<std::string, std::string>& /* tags */)
+    -> std::shared_ptr<couchbase::metrics::value_recorder> override
   {
     return instance_;
   }

--- a/core/operations/document_analytics.cxx
+++ b/core/operations/document_analytics.cxx
@@ -27,9 +27,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 analytics_request::encode_to(analytics_request::encoded_request_type& encoded,
-                             http_context& context)
+                             http_context& context) -> std::error_code
 {
   tao::json::value body{ { "statement", statement },
                          { "client_context_id", encoded.client_context_id },
@@ -99,9 +99,9 @@ analytics_request::encode_to(analytics_request::encoded_request_type& encoded,
   return {};
 }
 
-analytics_response
+auto
 analytics_request::make_response(error_context::analytics&& ctx,
-                                 const encoded_response_type& encoded) const
+                                 const encoded_response_type& encoded) const -> analytics_response
 {
   analytics_response response{ std::move(ctx) };
   response.ctx.statement = statement;

--- a/core/operations/document_analytics.hxx
+++ b/core/operations/document_analytics.hxx
@@ -98,9 +98,11 @@ struct analytics_request {
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
-  [[nodiscard]] analytics_response make_response(error_context::analytics&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               http_context& context) -> std::error_code;
+  [[nodiscard]] auto make_response(error_context::analytics&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> analytics_response;
 
   std::string body_str{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };

--- a/core/operations/document_append.cxx
+++ b/core/operations/document_append.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 append_request::encode_to(protocol::client_request<protocol::append_request_body>& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -33,9 +33,9 @@ append_request::encode_to(protocol::client_request<protocol::append_request_body
   return {};
 }
 
-append_response
+auto
 append_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> append_response
 {
   append_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_append.hxx
+++ b/core/operations/document_append.hxx
@@ -53,11 +53,11 @@ struct append_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] append_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> append_response;
 };
 
 using append_request_with_legacy_durability = impl::with_legacy_durability<append_request>;

--- a/core/operations/document_decrement.cxx
+++ b/core/operations/document_decrement.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 decrement_request::encode_to(decrement_request::encoded_request_type& encoded,
-                             mcbp_context&& /* context */) const
+                             mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -40,9 +40,9 @@ decrement_request::encode_to(decrement_request::encoded_request_type& encoded,
   return {};
 }
 
-decrement_response
+auto
 decrement_request::make_response(key_value_error_context&& ctx,
-                                 const encoded_response_type& encoded) const
+                                 const encoded_response_type& encoded) const -> decrement_response
 {
   decrement_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_decrement.hxx
+++ b/core/operations/document_decrement.hxx
@@ -56,11 +56,12 @@ struct decrement_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] decrement_response make_response(key_value_error_context&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> decrement_response;
 };
 
 using decrement_request_with_legacy_durability = impl::with_legacy_durability<decrement_request>;

--- a/core/operations/document_exists.cxx
+++ b/core/operations/document_exists.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 exists_request::encode_to(exists_request::encoded_request_type& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -31,9 +31,9 @@ exists_request::encode_to(exists_request::encoded_request_type& encoded,
   return {};
 }
 
-exists_response
+auto
 exists_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> exists_response
 {
   exists_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_exists.hxx
+++ b/core/operations/document_exists.hxx
@@ -39,7 +39,7 @@ struct exists_response {
   std::uint8_t datatype{};
   bool document_exists{ false };
 
-  [[nodiscard]] inline bool exists() const
+  [[nodiscard]] inline auto exists() const -> bool
   {
     return document_exists;
   }
@@ -57,11 +57,11 @@ struct exists_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] exists_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> exists_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_get.cxx
+++ b/core/operations/document_get.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 get_request::encode_to(get_request::encoded_request_type& encoded,
-                       mcbp_context&& /* context */) const
+                       mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -31,9 +31,9 @@ get_request::encode_to(get_request::encoded_request_type& encoded,
   return {};
 }
 
-get_response
+auto
 get_request::make_response(key_value_error_context&& ctx,
-                           const encoded_response_type& encoded) const
+                           const encoded_response_type& encoded) const -> get_response
 {
   get_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_get.hxx
+++ b/core/operations/document_get.hxx
@@ -48,11 +48,11 @@ struct get_request {
   io::retry_context<true> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] get_response make_response(key_value_error_context&& ctx,
-                                           const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> get_response;
 };
 } // namespace couchbase::core::operations
 

--- a/core/operations/document_get_and_lock.cxx
+++ b/core/operations/document_get_and_lock.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 get_and_lock_request::encode_to(get_and_lock_request::encoded_request_type& encoded,
-                                mcbp_context&& /* context */) const
+                                mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -32,9 +32,10 @@ get_and_lock_request::encode_to(get_and_lock_request::encoded_request_type& enco
   return {};
 }
 
-get_and_lock_response
+auto
 get_and_lock_request::make_response(key_value_error_context&& ctx,
                                     const encoded_response_type& encoded) const
+  -> get_and_lock_response
 {
   get_and_lock_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_get_and_lock.hxx
+++ b/core/operations/document_get_and_lock.hxx
@@ -49,11 +49,12 @@ struct get_and_lock_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] get_and_lock_response make_response(key_value_error_context&& ctx,
-                                                    const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> get_and_lock_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_get_and_touch.cxx
+++ b/core/operations/document_get_and_touch.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 get_and_touch_request::encode_to(get_and_touch_request::encoded_request_type& encoded,
-                                 mcbp_context&& /* context */) const
+                                 mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -32,9 +32,10 @@ get_and_touch_request::encode_to(get_and_touch_request::encoded_request_type& en
   return {};
 }
 
-get_and_touch_response
+auto
 get_and_touch_request::make_response(key_value_error_context&& ctx,
                                      const encoded_response_type& encoded) const
+  -> get_and_touch_response
 {
   get_and_touch_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_get_and_touch.hxx
+++ b/core/operations/document_get_and_touch.hxx
@@ -50,11 +50,12 @@ struct get_and_touch_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] get_and_touch_response make_response(key_value_error_context&& ctx,
-                                                     const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> get_and_touch_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_get_projected.cxx
+++ b/core/operations/document_get_projected.cxx
@@ -26,8 +26,8 @@
 namespace couchbase::core::operations
 {
 
-static std::optional<tao::json::value>
-subdoc_lookup(tao::json::value& root, const std::string& path)
+static auto
+subdoc_lookup(tao::json::value& root, const std::string& path) -> std::optional<tao::json::value>
 {
   std::string::size_type offset = 0;
   tao::json::value* cur = &root;
@@ -140,9 +140,9 @@ subdoc_apply_projection(tao::json::value& root,
   }
 }
 
-std::error_code
+auto
 get_projected_request::encode_to(get_projected_request::encoded_request_type& encoded,
-                                 mcbp_context&& /* context */)
+                                 mcbp_context&& /* context */) -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -176,9 +176,10 @@ get_projected_request::encode_to(get_projected_request::encoded_request_type& en
   return {};
 }
 
-get_projected_response
+auto
 get_projected_request::make_response(key_value_error_context&& ctx,
                                      const encoded_response_type& encoded) const
+  -> get_projected_response
 {
   get_projected_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_get_projected.hxx
+++ b/core/operations/document_get_projected.hxx
@@ -53,10 +53,12 @@ struct get_projected_request {
   io::retry_context<true> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] get_projected_response make_response(key_value_error_context&& ctx,
-                                                     const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> get_projected_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_increment.cxx
+++ b/core/operations/document_increment.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 increment_request::encode_to(increment_request::encoded_request_type& encoded,
-                             mcbp_context&& /* context */) const
+                             mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -40,9 +40,9 @@ increment_request::encode_to(increment_request::encoded_request_type& encoded,
   return {};
 }
 
-increment_response
+auto
 increment_request::make_response(key_value_error_context&& ctx,
-                                 const encoded_response_type& encoded) const
+                                 const encoded_response_type& encoded) const -> increment_response
 {
   increment_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_increment.hxx
+++ b/core/operations/document_increment.hxx
@@ -56,11 +56,12 @@ struct increment_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] increment_response make_response(key_value_error_context&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> increment_response;
 };
 
 using increment_request_with_legacy_durability = impl::with_legacy_durability<increment_request>;

--- a/core/operations/document_insert.cxx
+++ b/core/operations/document_insert.cxx
@@ -23,9 +23,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 insert_request::encode_to(insert_request::encoded_request_type& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -39,9 +39,9 @@ insert_request::encode_to(insert_request::encoded_request_type& encoded,
   return {};
 }
 
-insert_response
+auto
 insert_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> insert_response
 {
   insert_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_insert.hxx
+++ b/core/operations/document_insert.hxx
@@ -55,11 +55,11 @@ struct insert_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] insert_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> insert_response;
 };
 
 using insert_request_with_legacy_durability = impl::with_legacy_durability<insert_request>;

--- a/core/operations/document_lookup_in.cxx
+++ b/core/operations/document_lookup_in.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 lookup_in_request::encode_to(lookup_in_request::encoded_request_type& encoded,
-                             mcbp_context&& /* context */)
+                             mcbp_context&& /* context */) -> std::error_code
 {
   for (std::size_t i = 0; i < specs.size(); ++i) {
     specs[i].original_index_ = i;
@@ -43,9 +43,9 @@ lookup_in_request::encode_to(lookup_in_request::encoded_request_type& encoded,
   return {};
 }
 
-lookup_in_response
+auto
 lookup_in_request::make_response(key_value_error_context&& ctx,
-                                 const encoded_response_type& encoded) const
+                                 const encoded_response_type& encoded) const -> lookup_in_response
 {
 
   bool deleted = false;

--- a/core/operations/document_lookup_in.hxx
+++ b/core/operations/document_lookup_in.hxx
@@ -62,10 +62,12 @@ struct lookup_in_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] lookup_in_response make_response(key_value_error_context&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> lookup_in_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_mutate_in.cxx
+++ b/core/operations/document_mutate_in.cxx
@@ -25,9 +25,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 mutate_in_request::encode_to(mutate_in_request::encoded_request_type& encoded,
-                             mcbp_context&& context)
+                             mcbp_context&& context) -> std::error_code
 {
   if (store_semantics == couchbase::store_semantics::upsert && !cas.empty()) {
     return errc::common::invalid_argument;
@@ -63,9 +63,9 @@ mutate_in_request::encode_to(mutate_in_request::encoded_request_type& encoded,
   return {};
 }
 
-mutate_in_response
+auto
 mutate_in_request::make_response(key_value_error_context&& ctx,
-                                 const encoded_response_type& encoded) const
+                                 const encoded_response_type& encoded) const -> mutate_in_response
 {
   bool deleted = false;
   couchbase::cas response_cas{};

--- a/core/operations/document_mutate_in.hxx
+++ b/core/operations/document_mutate_in.hxx
@@ -70,10 +70,12 @@ struct mutate_in_request {
   bool preserve_expiry{ false };
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, mcbp_context&& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) -> std::error_code;
 
-  [[nodiscard]] mutate_in_response make_response(key_value_error_context&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const
+    -> mutate_in_response;
 };
 
 using mutate_in_request_with_legacy_durability = impl::with_legacy_durability<mutate_in_request>;

--- a/core/operations/document_prepend.cxx
+++ b/core/operations/document_prepend.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 prepend_request::encode_to(prepend_request::encoded_request_type& encoded,
-                           mcbp_context&& /* context */) const
+                           mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -33,9 +33,9 @@ prepend_request::encode_to(prepend_request::encoded_request_type& encoded,
   return {};
 }
 
-prepend_response
+auto
 prepend_request::make_response(key_value_error_context&& ctx,
-                               const encoded_response_type& encoded) const
+                               const encoded_response_type& encoded) const -> prepend_response
 {
   prepend_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_prepend.hxx
+++ b/core/operations/document_prepend.hxx
@@ -53,11 +53,11 @@ struct prepend_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] prepend_response make_response(key_value_error_context&& ctx,
-                                               const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> prepend_response;
 };
 
 using prepend_request_with_legacy_durability = impl::with_legacy_durability<prepend_request>;

--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -30,8 +30,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
-query_request::encode_to(query_request::encoded_request_type& encoded, http_context& context)
+auto
+query_request::encode_to(query_request::encoded_request_type& encoded,
+                         http_context& context) -> std::error_code
 {
   ctx_.emplace(context);
   tao::json::value body{
@@ -204,8 +205,9 @@ query_request::encode_to(query_request::encoded_request_type& encoded, http_cont
   return {};
 }
 
-query_response
-query_request::make_response(error_context::query&& ctx, const encoded_response_type& encoded)
+auto
+query_request::make_response(error_context::query&& ctx,
+                             const encoded_response_type& encoded) -> query_response
 {
   query_response response{ std::move(ctx) };
   response.ctx.statement = statement;

--- a/core/operations/document_query.hxx
+++ b/core/operations/document_query.hxx
@@ -111,10 +111,11 @@ struct query_request {
   std::optional<std::function<utils::json::stream_control(std::string)>> row_callback{};
   std::optional<std::string> send_to_node{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               http_context& context) -> std::error_code;
 
-  [[nodiscard]] query_response make_response(error_context::query&& ctx,
-                                             const encoded_response_type& encoded);
+  [[nodiscard]] auto make_response(error_context::query&& ctx,
+                                   const encoded_response_type& encoded) -> query_response;
 
   std::optional<http_context> ctx_{};
   bool extract_encoded_plan_{ false };

--- a/core/operations/document_remove.cxx
+++ b/core/operations/document_remove.cxx
@@ -22,9 +22,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 remove_request::encode_to(remove_request::encoded_request_type& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -33,9 +33,9 @@ remove_request::encode_to(remove_request::encoded_request_type& encoded,
   return {};
 }
 
-remove_response
+auto
 remove_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> remove_response
 {
   remove_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_remove.hxx
+++ b/core/operations/document_remove.hxx
@@ -53,11 +53,11 @@ struct remove_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] remove_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> remove_response;
 };
 
 using remove_request_with_legacy_durability = impl::with_legacy_durability<remove_request>;

--- a/core/operations/document_replace.cxx
+++ b/core/operations/document_replace.cxx
@@ -23,9 +23,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 replace_request::encode_to(replace_request::encoded_request_type& encoded,
-                           mcbp_context&& /* context */) const
+                           mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -43,9 +43,9 @@ replace_request::encode_to(replace_request::encoded_request_type& encoded,
   return {};
 }
 
-replace_response
+auto
 replace_request::make_response(key_value_error_context&& ctx,
-                               const encoded_response_type& encoded) const
+                               const encoded_response_type& encoded) const -> replace_response
 {
   replace_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_replace.hxx
+++ b/core/operations/document_replace.hxx
@@ -57,11 +57,11 @@ struct replace_request {
   bool preserve_expiry{ false };
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] replace_response make_response(key_value_error_context&& ctx,
-                                               const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> replace_response;
 };
 
 using replace_request_with_legacy_durability = impl::with_legacy_durability<replace_request>;

--- a/core/operations/document_search.cxx
+++ b/core/operations/document_search.cxx
@@ -27,8 +27,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
-search_request::encode_to(search_request::encoded_request_type& encoded, http_context& context)
+auto
+search_request::encode_to(search_request::encoded_request_type& encoded,
+                          http_context& context) -> std::error_code
 {
   auto body = tao::json::value{
     { "query", utils::json::parse(query) },
@@ -152,9 +153,9 @@ search_request::encode_to(search_request::encoded_request_type& encoded, http_co
   return {};
 }
 
-search_response
+auto
 search_request::make_response(error_context::search&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> search_response
 {
   search_response response{ std::move(ctx) };
   response.meta.client_context_id = response.ctx.client_context_id;

--- a/core/operations/document_search.hxx
+++ b/core/operations/document_search.hxx
@@ -163,10 +163,11 @@ struct search_request {
   std::optional<bool> log_request{ false };
   std::optional<bool> log_response{ false };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               http_context& context) -> std::error_code;
 
-  [[nodiscard]] search_response make_response(error_context::search&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(error_context::search&& ctx,
+                                   const encoded_response_type& encoded) const -> search_response;
 
   std::string body_str{};
 

--- a/core/operations/document_touch.cxx
+++ b/core/operations/document_touch.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 touch_request::encode_to(touch_request::encoded_request_type& encoded,
-                         mcbp_context&& /* context */) const
+                         mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -32,9 +32,9 @@ touch_request::encode_to(touch_request::encoded_request_type& encoded,
   return {};
 }
 
-touch_response
+auto
 touch_request::make_response(key_value_error_context&& ctx,
-                             const encoded_response_type& encoded) const
+                             const encoded_response_type& encoded) const -> touch_response
 {
   touch_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_touch.hxx
+++ b/core/operations/document_touch.hxx
@@ -47,11 +47,11 @@ struct touch_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] touch_response make_response(key_value_error_context&& ctx,
-                                             const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> touch_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_unlock.cxx
+++ b/core/operations/document_unlock.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 unlock_request::encode_to(unlock_request::encoded_request_type& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -32,9 +32,9 @@ unlock_request::encode_to(unlock_request::encoded_request_type& encoded,
   return {};
 }
 
-unlock_response
+auto
 unlock_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> unlock_response
 {
   unlock_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_unlock.hxx
+++ b/core/operations/document_unlock.hxx
@@ -47,11 +47,11 @@ struct unlock_request {
   io::retry_context<false> retries{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] unlock_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> unlock_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/document_upsert.cxx
+++ b/core/operations/document_upsert.cxx
@@ -23,9 +23,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 upsert_request::encode_to(upsert_request::encoded_request_type& encoded,
-                          mcbp_context&& /* context */) const
+                          mcbp_context&& /* context */) const -> std::error_code
 {
   encoded.opaque(opaque);
   encoded.partition(partition);
@@ -42,9 +42,9 @@ upsert_request::encode_to(upsert_request::encoded_request_type& encoded,
   return {};
 }
 
-upsert_response
+auto
 upsert_request::make_response(key_value_error_context&& ctx,
-                              const encoded_response_type& encoded) const
+                              const encoded_response_type& encoded) const -> upsert_response
 {
   upsert_response response{ std::move(ctx) };
   if (!response.ctx.ec()) {

--- a/core/operations/document_upsert.hxx
+++ b/core/operations/document_upsert.hxx
@@ -56,11 +56,11 @@ struct upsert_request {
   bool preserve_expiry{ false };
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
-                                          mcbp_context&& context) const;
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               mcbp_context&& context) const -> std::error_code;
 
-  [[nodiscard]] upsert_response make_response(key_value_error_context&& ctx,
-                                              const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(key_value_error_context&& ctx,
+                                   const encoded_response_type& encoded) const -> upsert_response;
 };
 
 using upsert_request_with_legacy_durability = impl::with_legacy_durability<upsert_request>;

--- a/core/operations/document_view.cxx
+++ b/core/operations/document_view.cxx
@@ -25,9 +25,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 document_view_request::encode_to(document_view_request::encoded_request_type& encoded,
-                                 http_context& /* context */)
+                                 http_context& /* context */) -> std::error_code
 {
   if (debug) {
     query_string.emplace_back("debug=true");
@@ -139,9 +139,10 @@ document_view_request::encode_to(document_view_request::encoded_request_type& en
   return {};
 }
 
-document_view_response
+auto
 document_view_request::make_response(error_context::view&& ctx,
                                      const encoded_response_type& encoded) const
+  -> document_view_response
 {
   document_view_response response{ std::move(ctx) };
   response.ctx.design_document_name = document_name;

--- a/core/operations/document_view.hxx
+++ b/core/operations/document_view.hxx
@@ -96,10 +96,11 @@ struct document_view_request {
   std::optional<std::chrono::milliseconds> timeout{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               http_context& context) -> std::error_code;
 
-  [[nodiscard]] document_view_response make_response(error_context::view&& ctx,
-                                                     const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(error_context::view&& ctx, const encoded_response_type& encoded)
+    const -> document_view_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/operations/http_noop.cxx
+++ b/core/operations/http_noop.cxx
@@ -21,9 +21,9 @@
 
 namespace couchbase::core::operations
 {
-std::error_code
+auto
 http_noop_request::encode_to(http_noop_request::encoded_request_type& encoded,
-                             http_context& /* context */)
+                             http_context& /* context */) -> std::error_code
 {
   encoded.headers["connection"] = "keep-alive";
   encoded.method = "GET";
@@ -56,9 +56,10 @@ http_noop_request::encode_to(http_noop_request::encoded_request_type& encoded,
   return {};
 }
 
-http_noop_response
+auto
 http_noop_request::make_response(error_context::http&& ctx,
                                  const encoded_response_type& /* encoded */) const
+  -> http_noop_response
 {
   http_noop_response response{ std::move(ctx) };
   return response;

--- a/core/operations/http_noop.hxx
+++ b/core/operations/http_noop.hxx
@@ -40,10 +40,11 @@ struct http_noop_request {
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
 
-  [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded, http_context& context);
+  [[nodiscard]] auto encode_to(encoded_request_type& encoded,
+                               http_context& context) -> std::error_code;
 
-  [[nodiscard]] http_noop_response make_response(error_context::http&& ctx,
-                                                 const encoded_response_type& encoded) const;
+  [[nodiscard]] auto make_response(error_context::http&& ctx, const encoded_response_type& encoded)
+    const -> http_noop_response;
 };
 
 } // namespace couchbase::core::operations

--- a/core/protocol/client_opcode.hxx
+++ b/core/protocol/client_opcode.hxx
@@ -266,8 +266,8 @@ enum class subdoc_opcode : std::uint8_t {
   replace_body_with_xattr = 0xd3,
 };
 
-constexpr bool
-is_valid_client_opcode(std::uint8_t code)
+constexpr auto
+is_valid_client_opcode(std::uint8_t code) -> bool
 {
   switch (static_cast<client_opcode>(code)) {
     case client_opcode::get:
@@ -348,8 +348,8 @@ is_valid_client_opcode(std::uint8_t code)
   return false;
 }
 
-constexpr bool
-is_valid_subdoc_opcode(std::uint8_t code)
+constexpr auto
+is_valid_subdoc_opcode(std::uint8_t code) -> bool
 {
   switch (static_cast<subdoc_opcode>(code)) {
     case subdoc_opcode::get:

--- a/core/protocol/client_request.cxx
+++ b/core/protocol/client_request.cxx
@@ -22,8 +22,9 @@
 
 namespace couchbase::core::protocol
 {
-std::pair<bool, std::uint32_t>
-compress_value(const std::vector<std::byte>& value, std::vector<std::byte>::iterator& output)
+auto
+compress_value(const std::vector<std::byte>& value,
+               std::vector<std::byte>::iterator& output) -> std::pair<bool, std::uint32_t>
 {
   static const double min_ratio = 0.83;
 

--- a/core/protocol/client_request.hxx
+++ b/core/protocol/client_request.hxx
@@ -33,8 +33,9 @@
 
 namespace couchbase::core::protocol
 {
-std::pair<bool, std::uint32_t>
-compress_value(const std::vector<std::byte>& value, std::vector<std::byte>::iterator& output);
+auto
+compress_value(const std::vector<std::byte>& value,
+               std::vector<std::byte>::iterator& output) -> std::pair<bool, std::uint32_t>;
 
 template<typename Body>
 class client_request
@@ -56,7 +57,7 @@ private:
   Body body_;
 
 public:
-  [[nodiscard]] client_opcode opcode() const
+  [[nodiscard]] auto opcode() const -> client_opcode
   {
     return opcode_;
   }
@@ -76,7 +77,7 @@ public:
     cas_ = utils::byte_swap(val.value());
   }
 
-  [[nodiscard]] std::uint32_t opaque() const
+  [[nodiscard]] auto opaque() const -> std::uint32_t
   {
     return utils::byte_swap(opaque_);
   }
@@ -96,12 +97,12 @@ public:
     return partition_;
   }
 
-  Body& body()
+  auto body() -> Body&
   {
     return body_;
   }
 
-  [[nodiscard]] std::vector<std::byte> data(bool try_to_compress = false)
+  [[nodiscard]] auto data(bool try_to_compress = false) -> std::vector<std::byte>
   {
     switch (opcode_) {
       case protocol::client_opcode::insert:
@@ -115,7 +116,7 @@ public:
   }
 
 private:
-  [[nodiscard]] std::vector<std::byte> generate_payload(bool try_to_compress)
+  [[nodiscard]] auto generate_payload(bool try_to_compress) -> std::vector<std::byte>
   {
     // SA: for some reason GCC 8.5.0 on CentOS 8 sees here null-pointer dereference
     // JC: BoringSSL changes, noticed the same when building w/ GCC 11.3.0; TODO:  is 12 okay?

--- a/core/protocol/client_response.cxx
+++ b/core/protocol/client_response.cxx
@@ -24,8 +24,8 @@
 
 namespace couchbase::core::protocol
 {
-double
-parse_server_duration_us(const io::mcbp_message& msg)
+auto
+parse_server_duration_us(const io::mcbp_message& msg) -> double
 {
   if (msg.header.magic != static_cast<std::uint8_t>(magic::alt_client_response)) {
     return 0;
@@ -52,8 +52,8 @@ parse_server_duration_us(const io::mcbp_message& msg)
   return 0;
 }
 
-bool
-parse_enhanced_error(std::string_view str, key_value_extended_error_info& info)
+auto
+parse_enhanced_error(std::string_view str, key_value_extended_error_info& info) -> bool
 {
   if (auto error = utils::json::parse(str); error.is_object()) {
     if (const auto* err_obj = error.find("error"); err_obj != nullptr && err_obj->is_object()) {

--- a/core/protocol/client_response.hxx
+++ b/core/protocol/client_response.hxx
@@ -43,11 +43,11 @@
 namespace couchbase::core::protocol
 {
 
-double
-parse_server_duration_us(const io::mcbp_message& msg);
+auto
+parse_server_duration_us(const io::mcbp_message& msg) -> double;
 
-bool
-parse_enhanced_error(std::string_view str, key_value_extended_error_info& info);
+auto
+parse_enhanced_error(std::string_view str, key_value_extended_error_info& info) -> bool;
 
 template<typename Body>
 class client_response
@@ -85,37 +85,37 @@ public:
     parse_body();
   }
 
-  [[nodiscard]] client_opcode opcode() const
+  [[nodiscard]] auto opcode() const -> client_opcode
   {
     return opcode_;
   }
 
-  [[nodiscard]] key_value_status_code status() const
+  [[nodiscard]] auto status() const -> key_value_status_code
   {
     return status_;
   }
 
-  [[nodiscard]] couchbase::cas cas() const
+  [[nodiscard]] auto cas() const -> couchbase::cas
   {
     return couchbase::cas{ cas_ };
   }
 
-  [[nodiscard]] std::uint32_t opaque() const
+  [[nodiscard]] auto opaque() const -> std::uint32_t
   {
     return opaque_;
   }
 
-  Body& body()
+  auto body() -> Body&
   {
     return body_;
   }
 
-  [[nodiscard]] const Body& body() const
+  [[nodiscard]] auto body() const -> const Body&
   {
     return body_;
   }
 
-  [[nodiscard]] header_buffer& header()
+  [[nodiscard]] auto header() -> header_buffer&
   {
     return header_;
   }
@@ -155,12 +155,12 @@ public:
     cas_ = utils::byte_swap(cas_);
   }
 
-  [[nodiscard]] std::optional<key_value_extended_error_info> error_info() const
+  [[nodiscard]] auto error_info() const -> std::optional<key_value_extended_error_info>
   {
     return error_;
   }
 
-  [[nodiscard]] std::string error_message() const
+  [[nodiscard]] auto error_message() const -> std::string
   {
     if (error_) {
       return fmt::format(
@@ -207,7 +207,7 @@ public:
     }
   }
 
-  [[nodiscard]] std::vector<std::byte>& data()
+  [[nodiscard]] auto data() -> std::vector<std::byte>&
   {
     return data_;
   }

--- a/core/protocol/cmd_append.cxx
+++ b/core/protocol/cmd_append.cxx
@@ -27,14 +27,14 @@
 namespace couchbase::core::protocol
 {
 
-bool
+auto
 protocol::append_response_body::parse(key_value_status_code status,
                                       const header_buffer& header,
                                       std::uint8_t framing_extras_size,
                                       std::uint16_t /* key_size */,
                                       std::uint8_t extras_size,
                                       const std::vector<std::byte>& body,
-                                      const cmd_info& /* info */)
+                                      const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_append.hxx
+++ b/core/protocol/cmd_append.hxx
@@ -40,18 +40,18 @@ private:
   mutation_token token_{};
 
 public:
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class append_request_body
@@ -78,27 +78,27 @@ public:
     content_ = { content.begin(), content.end() };
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return content_;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return framing_extras_.size() + key_.size() + content_.size();
   }

--- a/core/protocol/cmd_cluster_map_change_notification.cxx
+++ b/core/protocol/cmd_cluster_map_change_notification.cxx
@@ -26,10 +26,10 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 cluster_map_change_notification_request_body::parse(const header_buffer& header,
                                                     const std::vector<std::byte>& body,
-                                                    const cmd_info& info)
+                                                    const cmd_info& info) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   using offset_type = std::vector<std::byte>::difference_type;

--- a/core/protocol/cmd_cluster_map_change_notification.hxx
+++ b/core/protocol/cmd_cluster_map_change_notification.hxx
@@ -37,27 +37,29 @@ private:
   std::optional<std::string_view> config_text_;
 
 public:
-  [[nodiscard]] std::uint32_t protocol_revision() const
+  [[nodiscard]] auto protocol_revision() const -> std::uint32_t
   {
     return protocol_revision_;
   }
 
-  [[nodiscard]] const std::string& bucket() const
+  [[nodiscard]] auto bucket() const -> const std::string&
   {
     return bucket_;
   }
 
-  [[nodiscard]] std::optional<topology::configuration> config()
+  [[nodiscard]] auto config() -> std::optional<topology::configuration>
   {
     return config_;
   }
 
-  [[nodiscard]] const std::optional<std::string_view>& config_text() const
+  [[nodiscard]] auto config_text() const -> const std::optional<std::string_view>&
   {
     return config_text_;
   }
 
-  bool parse(const header_buffer& header, const std::vector<std::byte>& body, const cmd_info& info);
+  auto parse(const header_buffer& header,
+             const std::vector<std::byte>& body,
+             const cmd_info& info) -> bool;
 };
 
 } // namespace couchbase::core::protocol

--- a/core/protocol/cmd_decrement.cxx
+++ b/core/protocol/cmd_decrement.cxx
@@ -26,14 +26,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 decrement_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_decrement.hxx
+++ b/core/protocol/cmd_decrement.hxx
@@ -39,23 +39,23 @@ private:
   std::uint64_t content_{};
 
 public:
-  [[nodiscard]] std::uint64_t content() const
+  [[nodiscard]] auto content() const -> std::uint64_t
   {
     return content_;
   }
 
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class decrement_request_body
@@ -92,17 +92,17 @@ public:
 
   void durability(durability_level level, std::optional<std::uint16_t> timeout);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -110,12 +110,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_get.cxx
+++ b/core/protocol/cmd_get.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_response_body::parse(key_value_status_code status,
                          const header_buffer& header,
                          std::uint8_t framing_extras_size,
                          std::uint16_t key_size,
                          std::uint8_t extras_size,
                          const std::vector<std::byte>& body,
-                         const cmd_info& /* info */)
+                         const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get.hxx
+++ b/core/protocol/cmd_get.hxx
@@ -36,23 +36,23 @@ private:
   std::vector<std::byte> value_;
 
 public:
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::uint32_t flags() const
+  [[nodiscard]] auto flags() const -> std::uint32_t
   {
     return flags_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_request_body
@@ -67,27 +67,27 @@ private:
 public:
   void id(const document_id& id);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size();
   }

--- a/core/protocol/cmd_get_and_lock.cxx
+++ b/core/protocol/cmd_get_and_lock.cxx
@@ -24,14 +24,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_and_lock_response_body::parse(key_value_status_code status,
                                   const header_buffer& header,
                                   std::uint8_t framing_extras_size,
                                   std::uint16_t key_size,
                                   std::uint8_t extras_size,
                                   const std::vector<std::byte>& body,
-                                  const cmd_info& /* info */)
+                                  const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_and_lock.hxx
+++ b/core/protocol/cmd_get_and_lock.hxx
@@ -36,23 +36,23 @@ private:
   std::vector<std::byte> value_;
 
 public:
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::uint32_t flags() const
+  [[nodiscard]] auto flags() const -> std::uint32_t
   {
     return flags_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_and_lock_request_body
@@ -74,17 +74,17 @@ public:
     lock_time_ = seconds;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -92,12 +92,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_get_and_touch.cxx
+++ b/core/protocol/cmd_get_and_touch.cxx
@@ -24,14 +24,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_and_touch_response_body::parse(key_value_status_code status,
                                    const header_buffer& header,
                                    std::uint8_t framing_extras_size,
                                    std::uint16_t key_size,
                                    std::uint8_t extras_size,
                                    const std::vector<std::byte>& body,
-                                   const cmd_info& /* info */)
+                                   const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_and_touch.hxx
+++ b/core/protocol/cmd_get_and_touch.hxx
@@ -36,23 +36,23 @@ private:
   std::vector<std::byte> value_;
 
 public:
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::uint32_t flags() const
+  [[nodiscard]] auto flags() const -> std::uint32_t
   {
     return flags_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_and_touch_request_body
@@ -74,17 +74,17 @@ public:
     expiry_ = seconds;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -92,12 +92,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_get_cluster_config.cxx
+++ b/core/protocol/cmd_get_cluster_config.cxx
@@ -25,8 +25,10 @@
 
 namespace couchbase::core::protocol
 {
-topology::configuration
-parse_config(std::string_view input, std::string_view endpoint_address, std::uint16_t endpoint_port)
+auto
+parse_config(std::string_view input,
+             std::string_view endpoint_address,
+             std::uint16_t endpoint_port) -> topology::configuration
 {
   auto config = utils::json::parse(input).as<topology::configuration>();
   for (auto& node : config.nodes) {
@@ -61,14 +63,14 @@ parse_config(std::string_view input, std::string_view endpoint_address, std::uin
   return config;
 }
 
-bool
+auto
 get_cluster_config_response_body::parse(key_value_status_code status,
                                         const header_buffer& header,
                                         std::uint8_t framing_extras_size,
                                         std::uint16_t key_size,
                                         std::uint8_t extras_size,
                                         const std::vector<std::byte>& body,
-                                        const cmd_info& info)
+                                        const cmd_info& info) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_cluster_config.hxx
+++ b/core/protocol/cmd_get_cluster_config.hxx
@@ -28,10 +28,10 @@
 namespace couchbase::core::protocol
 {
 
-topology::configuration
+auto
 parse_config(std::string_view input,
              std::string_view endpoint_address,
-             std::uint16_t endpoint_port);
+             std::uint16_t endpoint_port) -> topology::configuration;
 
 class get_cluster_config_response_body
 {
@@ -43,23 +43,23 @@ private:
   std::optional<std::string_view> config_text_;
 
 public:
-  [[nodiscard]] topology::configuration&& config()
+  [[nodiscard]] auto config() -> topology::configuration&&
   {
     return std::move(config_);
   }
 
-  [[nodiscard]] const std::optional<std::string_view>& config_text() const
+  [[nodiscard]] auto config_text() const -> const std::optional<std::string_view>&
   {
     return config_text_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_cluster_config_request_body
@@ -68,27 +68,27 @@ public:
   using response_body_type = get_cluster_config_response_body;
   static const inline client_opcode opcode = client_opcode::get_cluster_config;
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return 0;
   }

--- a/core/protocol/cmd_get_collection_id.cxx
+++ b/core/protocol/cmd_get_collection_id.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_collection_id_response_body::parse(key_value_status_code status,
                                        const header_buffer& header,
                                        std::uint8_t framing_extras_size,
                                        std::uint16_t key_size,
                                        std::uint8_t extras_size,
                                        const std::vector<std::byte>& body,
-                                       const cmd_info& /* info */)
+                                       const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success && extras_size == 12) {

--- a/core/protocol/cmd_get_collection_id.hxx
+++ b/core/protocol/cmd_get_collection_id.hxx
@@ -35,23 +35,23 @@ private:
   std::uint32_t collection_uid_{};
 
 public:
-  [[nodiscard]] std::uint64_t manifest_uid() const
+  [[nodiscard]] auto manifest_uid() const -> std::uint64_t
   {
     return manifest_uid_;
   }
 
-  [[nodiscard]] std::uint32_t collection_uid() const
+  [[nodiscard]] auto collection_uid() const -> std::uint32_t
   {
     return collection_uid_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_collection_id_request_body
@@ -66,27 +66,27 @@ private:
 public:
   void collection_path(const std::string_view& path);
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return value_.size();
   }

--- a/core/protocol/cmd_get_collections_manifest.cxx
+++ b/core/protocol/cmd_get_collections_manifest.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_collections_manifest_response_body::parse(key_value_status_code status,
                                               const header_buffer& header,
                                               std::uint8_t framing_extras_size,
                                               std::uint16_t key_size,
                                               std::uint8_t extras_size,
                                               const std::vector<std::byte>& body,
-                                              const cmd_info& /* info */)
+                                              const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_collections_manifest.hxx
+++ b/core/protocol/cmd_get_collections_manifest.hxx
@@ -35,18 +35,18 @@ private:
   topology::collections_manifest manifest_;
 
 public:
-  [[nodiscard]] const couchbase::core::topology::collections_manifest& manifest() const
+  [[nodiscard]] auto manifest() const -> const couchbase::core::topology::collections_manifest&
   {
     return manifest_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_collections_manifest_request_body
@@ -55,27 +55,27 @@ public:
   using response_body_type = get_collections_manifest_response_body;
   static const inline client_opcode opcode = client_opcode::get_collections_manifest;
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return 0;
   }

--- a/core/protocol/cmd_get_error_map.cxx
+++ b/core/protocol/cmd_get_error_map.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_error_map_response_body::parse(key_value_status_code status,
                                    const header_buffer& header,
                                    std::uint8_t framing_extras_size,
                                    std::uint16_t key_size,
                                    std::uint8_t extras_size,
                                    const std::vector<std::byte>& body,
-                                   const cmd_info& /* info */)
+                                   const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_error_map.hxx
+++ b/core/protocol/cmd_get_error_map.hxx
@@ -35,18 +35,18 @@ private:
   error_map errmap_{};
 
 public:
-  [[nodiscard]] const couchbase::core::error_map& errmap() const
+  [[nodiscard]] auto errmap() const -> const couchbase::core::error_map&
   {
     return errmap_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_error_map_request_body
@@ -65,22 +65,22 @@ public:
     version_ = version;
   }
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_body();
@@ -88,7 +88,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (value_.empty()) {
       fill_body();

--- a/core/protocol/cmd_get_meta.cxx
+++ b/core/protocol/cmd_get_meta.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 get_meta_response_body::parse(key_value_status_code status,
                               const header_buffer& header,
                               std::uint8_t framing_extras_size,
                               std::uint16_t /* key_size */,
                               std::uint8_t extras_size,
                               const std::vector<std::byte>& body,
-                              const cmd_info& /* info */)
+                              const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_get_meta.hxx
+++ b/core/protocol/cmd_get_meta.hxx
@@ -40,38 +40,38 @@ private:
   std::uint8_t datatype_{};
 
 public:
-  [[nodiscard]] bool is_deleted() const
+  [[nodiscard]] auto is_deleted() const -> bool
   {
     return deleted_ != 0;
   }
 
-  [[nodiscard]] std::uint32_t flags() const
+  [[nodiscard]] auto flags() const -> std::uint32_t
   {
     return flags_;
   }
 
-  [[nodiscard]] std::uint32_t expiry() const
+  [[nodiscard]] auto expiry() const -> std::uint32_t
   {
     return expiry_;
   }
 
-  [[nodiscard]] std::uint64_t sequence_number() const
+  [[nodiscard]] auto sequence_number() const -> std::uint64_t
   {
     return sequence_number_;
   }
 
-  [[nodiscard]] std::uint8_t datatype() const
+  [[nodiscard]] auto datatype() const -> std::uint8_t
   {
     return datatype_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class get_meta_request_body
@@ -90,27 +90,27 @@ private:
 public:
   void id(const document_id& id);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return extras_;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     return extras_.size() + key_.size();
   }

--- a/core/protocol/cmd_get_replica.cxx
+++ b/core/protocol/cmd_get_replica.cxx
@@ -25,20 +25,20 @@
 
 namespace couchbase::core::protocol
 {
-std::uint32_t
-get_replica_response_body::flags() const
+auto
+get_replica_response_body::flags() const -> std::uint32_t
 {
   return flags_;
 }
 
-bool
+auto
 get_replica_response_body::parse(key_value_status_code status,
                                  const header_buffer& header,
                                  std::uint8_t framing_extras_size,
                                  std::uint16_t key_size,
                                  std::uint8_t extras_size,
                                  const std::vector<std::byte>& body,
-                                 const cmd_info& /* info */)
+                                 const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {
@@ -63,8 +63,8 @@ get_replica_request_body::id(const document_id& id)
   key_ = make_protocol_key(id);
 }
 
-std::size_t
-get_replica_request_body::size() const
+auto
+get_replica_request_body::size() const -> std::size_t
 {
   return key_.size();
 }

--- a/core/protocol/cmd_get_replica.hxx
+++ b/core/protocol/cmd_get_replica.hxx
@@ -35,20 +35,20 @@ private:
 public:
   static const inline client_opcode opcode = client_opcode::get_replica;
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::uint32_t flags() const;
+  [[nodiscard]] auto flags() const -> std::uint32_t;
 
-  [[nodiscard]] bool parse(key_value_status_code status,
+  [[nodiscard]] auto parse(key_value_status_code status,
                            const header_buffer& header,
                            std::uint8_t framing_extras_size,
                            std::uint16_t key_size,
                            std::uint8_t extras_size,
                            const std::vector<std::byte>& body,
-                           const cmd_info& info);
+                           const cmd_info& info) -> bool;
 };
 
 class get_replica_request_body
@@ -62,27 +62,27 @@ public:
 
   void id(const document_id& id);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const;
+  [[nodiscard]] auto size() const -> std::size_t;
 };
 
 } // namespace couchbase::core::protocol

--- a/core/protocol/cmd_hello.cxx
+++ b/core/protocol/cmd_hello.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 hello_response_body::parse(key_value_status_code status,
                            const header_buffer& header,
                            std::uint8_t framing_extras_size,
                            std::uint16_t key_size,
                            std::uint8_t extras_size,
                            const std::vector<std::byte>& body,
-                           const cmd_info& /* info */)
+                           const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_hello.hxx
+++ b/core/protocol/cmd_hello.hxx
@@ -35,18 +35,18 @@ private:
   std::vector<hello_feature> supported_features_;
 
 public:
-  [[nodiscard]] const std::vector<hello_feature>& supported_features() const
+  [[nodiscard]] auto supported_features() const -> const std::vector<hello_feature>&
   {
     return supported_features_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class hello_request_body
@@ -103,27 +103,27 @@ public:
     features_.emplace_back(hello_feature::mutation_seqno);
   }
 
-  [[nodiscard]] const std::vector<hello_feature>& features() const
+  [[nodiscard]] auto features() const -> const std::vector<hello_feature>&
   {
     return features_;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_body();
@@ -131,7 +131,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (value_.empty()) {
       fill_body();

--- a/core/protocol/cmd_increment.cxx
+++ b/core/protocol/cmd_increment.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 increment_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_increment.hxx
+++ b/core/protocol/cmd_increment.hxx
@@ -39,23 +39,23 @@ private:
   std::uint64_t content_{ 0 };
 
 public:
-  [[nodiscard]] std::uint64_t content() const
+  [[nodiscard]] auto content() const -> std::uint64_t
   {
     return content_;
   }
 
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class increment_request_body
@@ -92,17 +92,17 @@ public:
 
   void durability(durability_level level, std::optional<std::uint16_t> timeout);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -110,12 +110,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_insert.cxx
+++ b/core/protocol/cmd_insert.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 insert_response_body::parse(key_value_status_code status,
                             const header_buffer& header,
                             std::uint8_t framing_extras_size,
                             std::uint16_t /* key_size */,
                             std::uint8_t extras_size,
                             const std::vector<std::byte>& body,
-                            const cmd_info& /* info */)
+                            const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_insert.hxx
+++ b/core/protocol/cmd_insert.hxx
@@ -38,18 +38,18 @@ private:
   mutation_token token_;
 
 public:
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class insert_request_body
@@ -86,17 +86,17 @@ public:
     expiry_ = value;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -104,12 +104,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return content_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_lookup_in.cxx
+++ b/core/protocol/cmd_lookup_in.cxx
@@ -26,14 +26,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 lookup_in_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success ||

--- a/core/protocol/cmd_lookup_in.hxx
+++ b/core/protocol/cmd_lookup_in.hxx
@@ -43,18 +43,18 @@ private:
   std::vector<lookup_in_field> fields_;
 
 public:
-  [[nodiscard]] const std::vector<lookup_in_field>& fields() const
+  [[nodiscard]] auto fields() const -> const std::vector<lookup_in_field>&
   {
     return fields_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class lookup_in_request_body
@@ -93,17 +93,17 @@ public:
     specs_ = specs;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -111,7 +111,7 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_value();
@@ -119,7 +119,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_lookup_in_replica.cxx
+++ b/core/protocol/cmd_lookup_in_replica.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 lookup_in_replica_response_body::parse(key_value_status_code status,
                                        const header_buffer& header,
                                        std::uint8_t framing_extras_size,
                                        std::uint16_t key_size,
                                        std::uint8_t extras_size,
                                        const std::vector<std::byte>& body,
-                                       const cmd_info& /* info */)
+                                       const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success ||

--- a/core/protocol/cmd_lookup_in_replica.hxx
+++ b/core/protocol/cmd_lookup_in_replica.hxx
@@ -43,18 +43,18 @@ private:
   std::vector<lookup_in_field> fields_{};
 
 public:
-  [[nodiscard]] const std::vector<lookup_in_field>& fields() const
+  [[nodiscard]] auto fields() const -> const std::vector<lookup_in_field>&
   {
     return fields_;
   }
 
-  [[nodiscard]] bool parse(key_value_status_code status,
+  [[nodiscard]] auto parse(key_value_status_code status,
                            const header_buffer& header,
                            std::uint8_t framing_extras_size,
                            std::uint16_t key_size,
                            std::uint8_t extras_size,
                            const std::vector<std::byte>& body,
-                           const cmd_info& info);
+                           const cmd_info& info) -> bool;
 };
 
 class lookup_in_replica_request_body
@@ -91,17 +91,17 @@ public:
     specs_ = specs;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -109,7 +109,7 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_value();
@@ -117,7 +117,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_mutate_in.cxx
+++ b/core/protocol/cmd_mutate_in.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 mutate_in_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success ||

--- a/core/protocol/cmd_mutate_in.hxx
+++ b/core/protocol/cmd_mutate_in.hxx
@@ -51,23 +51,23 @@ private:
   mutation_token token_;
 
 public:
-  [[nodiscard]] const std::vector<mutate_in_field>& fields() const
+  [[nodiscard]] auto fields() const -> const std::vector<mutate_in_field>&
   {
     return fields_;
   }
 
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& /* info */);
+             const cmd_info& /* info */) -> bool;
 };
 
 class mutate_in_request_body
@@ -170,17 +170,17 @@ public:
 
   void preserve_expiry();
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -188,7 +188,7 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_value();
@@ -196,7 +196,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_noop.cxx
+++ b/core/protocol/cmd_noop.cxx
@@ -21,14 +21,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 mcbp_noop_response_body::parse(key_value_status_code /* status */,
                                const header_buffer& header,
                                std::uint8_t /* framing_extras_size */,
                                std::uint16_t /* key_size */,
                                std::uint8_t /* extras_size */,
                                const std::vector<std::byte>& /* body */,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   return false;

--- a/core/protocol/cmd_noop.hxx
+++ b/core/protocol/cmd_noop.hxx
@@ -31,13 +31,13 @@ class mcbp_noop_response_body
 public:
   static const inline client_opcode opcode = client_opcode::noop;
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class mcbp_noop_request_body
@@ -46,27 +46,27 @@ public:
   using response_body_type = mcbp_noop_response_body;
   static const inline client_opcode opcode = client_opcode::noop;
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return 0;
   }

--- a/core/protocol/cmd_observe_seqno.cxx
+++ b/core/protocol/cmd_observe_seqno.cxx
@@ -26,14 +26,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 observe_seqno_response_body::parse(key_value_status_code status,
                                    const header_buffer& header,
                                    std::uint8_t framing_extras_size,
                                    std::uint16_t key_size,
                                    std::uint8_t extras_size,
                                    const std::vector<std::byte>& body,
-                                   const cmd_info& /* info */)
+                                   const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_observe_seqno.hxx
+++ b/core/protocol/cmd_observe_seqno.hxx
@@ -42,43 +42,43 @@ private:
   std::optional<std::uint64_t> last_received_sequence_number_{};
 
 public:
-  [[nodiscard]] std::uint16_t partition_id() const
+  [[nodiscard]] auto partition_id() const -> std::uint16_t
   {
     return partition_id_;
   }
 
-  [[nodiscard]] std::uint64_t partition_uuid() const
+  [[nodiscard]] auto partition_uuid() const -> std::uint64_t
   {
     return partition_uuid_;
   }
 
-  [[nodiscard]] std::uint64_t last_persisted_sequence_number() const
+  [[nodiscard]] auto last_persisted_sequence_number() const -> std::uint64_t
   {
     return last_persisted_sequence_number_;
   }
 
-  [[nodiscard]] std::uint64_t current_sequence_number() const
+  [[nodiscard]] auto current_sequence_number() const -> std::uint64_t
   {
     return current_sequence_number_;
   }
 
-  [[nodiscard]] const std::optional<std::uint64_t>& old_partition_uuid() const
+  [[nodiscard]] auto old_partition_uuid() const -> const std::optional<std::uint64_t>&
   {
     return old_partition_uuid_;
   }
 
-  [[nodiscard]] const std::optional<std::uint64_t>& last_received_sequence_number() const
+  [[nodiscard]] auto last_received_sequence_number() const -> const std::optional<std::uint64_t>&
   {
     return last_received_sequence_number_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class observe_seqno_request_body
@@ -94,22 +94,22 @@ private:
 public:
   void partition_uuid(const std::uint64_t& uuid);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value()
+  [[nodiscard]] auto value() -> const auto&
   {
     if (value_.empty()) {
       fill_body();
@@ -117,7 +117,7 @@ public:
     return value_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (value_.empty()) {
       fill_body();

--- a/core/protocol/cmd_prepend.cxx
+++ b/core/protocol/cmd_prepend.cxx
@@ -26,14 +26,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 prepend_response_body::parse(key_value_status_code status,
                              const header_buffer& header,
                              std::uint8_t framing_extras_size,
                              std::uint16_t /* key_size */,
                              std::uint8_t extras_size,
                              const std::vector<std::byte>& body,
-                             const cmd_info& /* info */)
+                             const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_prepend.hxx
+++ b/core/protocol/cmd_prepend.hxx
@@ -38,18 +38,18 @@ private:
   mutation_token token_;
 
 public:
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class prepend_request_body
@@ -74,27 +74,27 @@ public:
     content_ = { content.begin(), content.end() };
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return content_;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return framing_extras_.size() + key_.size() + content_.size();
   }

--- a/core/protocol/cmd_remove.cxx
+++ b/core/protocol/cmd_remove.cxx
@@ -26,14 +26,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 remove_response_body::parse(key_value_status_code status,
                             const header_buffer& header,
                             std::uint8_t framing_extras_size,
                             std::uint16_t /* key_size */,
                             std::uint8_t extras_size,
                             const std::vector<std::byte>& body,
-                            const cmd_info& /* info */)
+                            const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_remove.hxx
+++ b/core/protocol/cmd_remove.hxx
@@ -36,18 +36,18 @@ public:
 
   mutation_token token_;
 
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class remove_request_body
@@ -65,27 +65,27 @@ public:
 
   void durability(durability_level level, std::optional<std::uint16_t> timeout);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size() + framing_extras_.size();
   }

--- a/core/protocol/cmd_replace.cxx
+++ b/core/protocol/cmd_replace.cxx
@@ -27,14 +27,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 replace_response_body::parse(key_value_status_code status,
                              const header_buffer& header,
                              std::uint8_t framing_extras_size,
                              std::uint16_t /* key_size */,
                              std::uint8_t extras_size,
                              const std::vector<std::byte>& body,
-                             const cmd_info& /* info */)
+                             const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_replace.hxx
+++ b/core/protocol/cmd_replace.hxx
@@ -38,23 +38,23 @@ private:
   mutation_token token_;
 
 public:
-  mutation_token& token()
+  auto token() -> mutation_token&
   {
     return token_;
   }
 
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class replace_request_body
@@ -93,17 +93,17 @@ public:
     expiry_ = value;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -111,12 +111,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return content_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/cmd_sasl_auth.cxx
+++ b/core/protocol/cmd_sasl_auth.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 sasl_auth_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success || status == key_value_status_code::auth_continue) {

--- a/core/protocol/cmd_sasl_auth.hxx
+++ b/core/protocol/cmd_sasl_auth.hxx
@@ -33,15 +33,15 @@ private:
   std::string value_;
 
 public:
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 
-  [[nodiscard]] std::string_view value() const
+  [[nodiscard]] auto value() const -> std::string_view
   {
     return value_;
   }
@@ -62,27 +62,27 @@ public:
 
   void sasl_data(std::string_view data);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size() + value_.size();
   }

--- a/core/protocol/cmd_sasl_list_mechs.cxx
+++ b/core/protocol/cmd_sasl_list_mechs.cxx
@@ -22,14 +22,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 sasl_list_mechs_response_body::parse(key_value_status_code status,
                                      const header_buffer& header,
                                      std::uint8_t framing_extras_size,
                                      std::uint16_t key_size,
                                      std::uint8_t extras_size,
                                      const std::vector<std::byte>& body,
-                                     const cmd_info& /* info */)
+                                     const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_sasl_list_mechs.hxx
+++ b/core/protocol/cmd_sasl_list_mechs.hxx
@@ -33,18 +33,18 @@ private:
   std::vector<std::string> supported_mechs_;
 
 public:
-  [[nodiscard]] const std::vector<std::string>& supported_mechs() const
+  [[nodiscard]] auto supported_mechs() const -> const std::vector<std::string>&
   {
     return supported_mechs_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class sasl_list_mechs_request_body
@@ -53,27 +53,27 @@ public:
   using response_body_type = sasl_list_mechs_response_body;
   static const inline client_opcode opcode = client_opcode::sasl_list_mechs;
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return empty_string;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return 0;
   }

--- a/core/protocol/cmd_sasl_step.cxx
+++ b/core/protocol/cmd_sasl_step.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 sasl_step_response_body::parse(key_value_status_code status,
                                const header_buffer& header,
                                std::uint8_t framing_extras_size,
                                std::uint16_t key_size,
                                std::uint8_t extras_size,
                                const std::vector<std::byte>& body,
-                               const cmd_info& /* info */)
+                               const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_sasl_step.hxx
+++ b/core/protocol/cmd_sasl_step.hxx
@@ -33,15 +33,15 @@ private:
   std::string value_;
 
 public:
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 
-  [[nodiscard]] std::string_view value() const
+  [[nodiscard]] auto value() const -> std::string_view
   {
     return value_;
   }
@@ -62,27 +62,27 @@ public:
 
   void sasl_data(std::string_view data);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return value_;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size() + value_.size();
   }

--- a/core/protocol/cmd_select_bucket.cxx
+++ b/core/protocol/cmd_select_bucket.cxx
@@ -23,14 +23,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 select_bucket_response_body::parse(key_value_status_code /* status */,
                                    const header_buffer& header,
                                    std::uint8_t /* framing_extras_size */,
                                    std::uint16_t /* key_size */,
                                    std::uint8_t /* extras_size */,
                                    const std::vector<std::byte>& /* body */,
-                                   const cmd_info& /* info */)
+                                   const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   return false;

--- a/core/protocol/cmd_select_bucket.hxx
+++ b/core/protocol/cmd_select_bucket.hxx
@@ -29,13 +29,13 @@ class select_bucket_response_body
 public:
   static const inline client_opcode opcode = client_opcode::select_bucket;
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class select_bucket_request_body
@@ -50,27 +50,27 @@ private:
 public:
   void bucket_name(std::string_view name);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size();
   }

--- a/core/protocol/cmd_touch.cxx
+++ b/core/protocol/cmd_touch.cxx
@@ -25,14 +25,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 touch_response_body::parse(key_value_status_code /* status */,
                            const header_buffer& header,
                            std::uint8_t /* framing_extras_size */,
                            std::uint16_t /* key_size */,
                            std::uint8_t /* extras_size */,
                            const std::vector<std::byte>& /* body */,
-                           const cmd_info& /* info */)
+                           const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   return false;

--- a/core/protocol/cmd_touch.hxx
+++ b/core/protocol/cmd_touch.hxx
@@ -31,13 +31,13 @@ class touch_response_body
 public:
   static const inline client_opcode opcode = client_opcode::touch;
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class touch_request_body
@@ -55,27 +55,27 @@ public:
 
   void expiry(std::uint32_t seconds);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size() + extras_.size();
   }

--- a/core/protocol/cmd_unlock.cxx
+++ b/core/protocol/cmd_unlock.cxx
@@ -23,14 +23,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 unlock_response_body::parse(key_value_status_code /* status */,
                             const header_buffer& header,
                             std::uint8_t /* framing_extras_size */,
                             std::uint16_t /* key_size */,
                             std::uint8_t /* extras_size */,
                             const std::vector<std::byte>& /* body */,
-                            const cmd_info& /* info */)
+                            const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   return false;

--- a/core/protocol/cmd_unlock.hxx
+++ b/core/protocol/cmd_unlock.hxx
@@ -31,13 +31,13 @@ class unlock_response_body
 public:
   static const inline client_opcode opcode = client_opcode::unlock;
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class unlock_request_body
@@ -52,27 +52,27 @@ private:
 public:
   void id(const document_id& id);
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& extras() const
+  [[nodiscard]] auto extras() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return empty_buffer;
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return key_.size();
   }

--- a/core/protocol/cmd_upsert.cxx
+++ b/core/protocol/cmd_upsert.cxx
@@ -28,14 +28,14 @@
 
 namespace couchbase::core::protocol
 {
-bool
+auto
 upsert_response_body::parse(key_value_status_code status,
                             const header_buffer& header,
                             std::uint8_t framing_extras_size,
                             std::uint16_t /* key_size */,
                             std::uint8_t extras_size,
                             const std::vector<std::byte>& body,
-                            const cmd_info& /* info */)
+                            const cmd_info& /* info */) -> bool
 {
   Expects(header[1] == static_cast<std::byte>(opcode));
   if (status == key_value_status_code::success) {

--- a/core/protocol/cmd_upsert.hxx
+++ b/core/protocol/cmd_upsert.hxx
@@ -38,18 +38,18 @@ private:
   mutation_token token_;
 
 public:
-  [[nodiscard]] const mutation_token& token() const
+  [[nodiscard]] auto token() const -> const mutation_token&
   {
     return token_;
   }
 
-  bool parse(key_value_status_code status,
+  auto parse(key_value_status_code status,
              const header_buffer& header,
              std::uint8_t framing_extras_size,
              std::uint16_t key_size,
              std::uint8_t extras_size,
              const std::vector<std::byte>& body,
-             const cmd_info& info);
+             const cmd_info& info) -> bool;
 };
 
 class upsert_request_body
@@ -88,17 +88,17 @@ public:
     expiry_ = value;
   }
 
-  [[nodiscard]] const auto& key() const
+  [[nodiscard]] auto key() const -> const auto&
   {
     return key_;
   }
 
-  [[nodiscard]] const auto& framing_extras() const
+  [[nodiscard]] auto framing_extras() const -> const auto&
   {
     return framing_extras_;
   }
 
-  [[nodiscard]] const auto& extras()
+  [[nodiscard]] auto extras() -> const auto&
   {
     if (extras_.empty()) {
       fill_extras();
@@ -106,12 +106,12 @@ public:
     return extras_;
   }
 
-  [[nodiscard]] const auto& value() const
+  [[nodiscard]] auto value() const -> const auto&
   {
     return content_;
   }
 
-  [[nodiscard]] std::size_t size()
+  [[nodiscard]] auto size() -> std::size_t
   {
     if (extras_.empty()) {
       fill_extras();

--- a/core/protocol/datatype.hxx
+++ b/core/protocol/datatype.hxx
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace couchbase::core::protocol
 {
 enum class datatype : std::uint8_t {
@@ -26,8 +28,8 @@ enum class datatype : std::uint8_t {
   xattr = 0x04,
 };
 
-constexpr bool
-is_valid_datatype(std::uint8_t code)
+constexpr auto
+is_valid_datatype(std::uint8_t code) -> bool
 {
   switch (static_cast<datatype>(code)) {
     case datatype::raw:
@@ -39,8 +41,8 @@ is_valid_datatype(std::uint8_t code)
   return false;
 }
 
-constexpr bool
-has_json_datatype(std::uint8_t code)
+constexpr auto
+has_json_datatype(std::uint8_t code) -> bool
 {
   return (code & static_cast<std::uint8_t>(datatype::json)) != 0;
 }

--- a/core/protocol/frame_info_id.hxx
+++ b/core/protocol/frame_info_id.hxx
@@ -98,8 +98,8 @@ enum class request_frame_info_id : std::uint8_t {
   preserve_ttl = 0x05,
 };
 
-constexpr bool
-is_valid_request_frame_info_id(std::uint8_t value)
+constexpr auto
+is_valid_request_frame_info_id(std::uint8_t value) -> bool
 {
   switch (request_frame_info_id(value)) {
     case request_frame_info_id::barrier:
@@ -134,8 +134,8 @@ enum class response_frame_info_id : std::uint8_t {
   server_duration = 0x00,
 };
 
-constexpr bool
-is_valid_response_frame_info_id(std::uint8_t value)
+constexpr auto
+is_valid_response_frame_info_id(std::uint8_t value) -> bool
 {
   switch (response_frame_info_id(value)) {
     case response_frame_info_id::server_duration:

--- a/core/protocol/hello_feature.hxx
+++ b/core/protocol/hello_feature.hxx
@@ -180,8 +180,8 @@ enum class hello_feature : std::uint16_t {
   deduplicate_not_my_vbucket_clustermap = 0x1e,
 };
 
-constexpr bool
-is_valid_hello_feature(std::uint16_t code)
+constexpr auto
+is_valid_hello_feature(std::uint16_t code) -> bool
 {
   switch (static_cast<hello_feature>(code)) {
     case hello_feature::tls:

--- a/core/protocol/magic.hxx
+++ b/core/protocol/magic.hxx
@@ -36,8 +36,8 @@ enum class magic : std::uint8_t {
   server_response = 0x83
 };
 
-constexpr bool
-is_valid_magic(std::uint8_t code)
+constexpr auto
+is_valid_magic(std::uint8_t code) -> bool
 {
   switch (magic(code)) {
     case magic::client_request:

--- a/core/protocol/server_opcode.hxx
+++ b/core/protocol/server_opcode.hxx
@@ -24,8 +24,8 @@ enum class server_opcode : std::uint8_t {
   invalid = 0xff,
 };
 
-constexpr bool
-is_valid_server_request_opcode(std::uint8_t code)
+constexpr auto
+is_valid_server_request_opcode(std::uint8_t code) -> bool
 {
   switch (server_opcode(code)) {
     case server_opcode::cluster_map_change_notification:

--- a/core/protocol/server_request.hxx
+++ b/core/protocol/server_request.hxx
@@ -17,14 +17,18 @@
 
 #pragma once
 
+#include "../io/mcbp_message.hxx"
 #include "cmd_info.hxx"
 #include "datatype.hxx"
 #include "magic.hxx"
 #include "server_opcode.hxx"
 #include "status.hxx"
 
-#include <cstring>
+#include <couchbase/cas.hxx>
+
 #include <gsl/assert>
+
+#include <cstring>
 
 namespace couchbase::core::protocol
 {
@@ -37,13 +41,13 @@ private:
 
   Body body_;
   server_opcode opcode_{ server_opcode::invalid };
-  header_buffer header_;
-  std::uint8_t data_type_;
+  header_buffer header_{};
+  std::uint8_t data_type_{};
   std::vector<std::byte> data_;
-  std::size_t body_size_;
-  std::uint32_t opaque_;
-  std::uint64_t cas_;
-  cmd_info info_;
+  std::size_t body_size_{};
+  std::uint32_t opaque_{};
+  std::uint64_t cas_{};
+  cmd_info info_{};
 
 public:
   server_request() = default;
@@ -61,32 +65,32 @@ public:
     parse_body();
   }
 
-  [[nodiscard]] server_opcode opcode() const
+  [[nodiscard]] auto opcode() const -> server_opcode
   {
     return opcode_;
   }
 
-  [[nodiscard]] std::size_t body_size() const
+  [[nodiscard]] auto body_size() const -> std::size_t
   {
     return body_size_;
   }
 
-  [[nodiscard]] couchbase::cas cas() const
+  [[nodiscard]] auto cas() const -> couchbase::cas
   {
     return couchbase::cas{ cas_ };
   }
 
-  [[nodiscard]] std::uint32_t opaque() const
+  [[nodiscard]] auto opaque() const -> std::uint32_t
   {
     return opaque_;
   }
 
-  Body& body()
+  [[nodiscard]] auto body() -> Body&
   {
     return body_;
   }
 
-  [[nodiscard]] header_buffer& header()
+  [[nodiscard]] auto header() -> header_buffer&
   {
     return header_;
   }
@@ -113,7 +117,7 @@ public:
     body_.parse(header_, data_, info_);
   }
 
-  [[nodiscard]] std::vector<std::byte>& data()
+  [[nodiscard]] auto data() -> std::vector<std::byte>&
   {
     return data_;
   }

--- a/core/protocol/status.cxx
+++ b/core/protocol/status.cxx
@@ -23,8 +23,8 @@
 
 namespace couchbase::core::protocol
 {
-std::string
-status_to_string(std::uint16_t code)
+auto
+status_to_string(std::uint16_t code) -> std::string
 {
   if (is_valid_status(code)) {
     return fmt::format("{} ({})", code, static_cast<key_value_status_code>(code));
@@ -32,8 +32,8 @@ status_to_string(std::uint16_t code)
   return fmt::format("{} (unknown)", code);
 }
 
-[[nodiscard]] std::error_code
-map_status_code(protocol::client_opcode opcode, std::uint16_t status)
+[[nodiscard]] auto
+map_status_code(protocol::client_opcode opcode, std::uint16_t status) -> std::error_code
 {
   switch (static_cast<key_value_status_code>(status)) {
     case key_value_status_code::success:

--- a/core/protocol/status.hxx
+++ b/core/protocol/status.hxx
@@ -27,8 +27,8 @@
 
 namespace couchbase::core::protocol
 {
-constexpr bool
-is_valid_status(std::uint16_t code)
+constexpr auto
+is_valid_status(std::uint16_t code) -> bool
 {
   switch (static_cast<key_value_status_code>(code)) {
     case key_value_status_code::success:
@@ -111,10 +111,10 @@ is_valid_status(std::uint16_t code)
   return false;
 }
 
-[[nodiscard]] std::string
-status_to_string(std::uint16_t code);
+[[nodiscard]] auto
+status_to_string(std::uint16_t code) -> std::string;
 
-[[nodiscard]] std::error_code
-map_status_code(protocol::client_opcode opcode, std::uint16_t status);
+[[nodiscard]] auto
+map_status_code(protocol::client_opcode opcode, std::uint16_t status) -> std::error_code;
 
 } // namespace couchbase::core::protocol

--- a/core/topology/capabilities.hxx
+++ b/core/topology/capabilities.hxx
@@ -60,54 +60,54 @@ struct configuration_capabilities {
   std::set<bucket_capability> bucket{};
   std::set<cluster_capability> cluster{};
 
-  [[nodiscard]] bool has_cluster_capability(cluster_capability cap) const
+  [[nodiscard]] auto has_cluster_capability(cluster_capability cap) const -> bool
   {
     return cluster.find(cap) != cluster.end();
   }
 
-  [[nodiscard]] bool has_bucket_capability(bucket_capability cap) const
+  [[nodiscard]] auto has_bucket_capability(bucket_capability cap) const -> bool
   {
     return bucket.find(cap) != bucket.end();
   }
 
-  [[nodiscard]] bool supports_enhanced_prepared_statements() const
+  [[nodiscard]] auto supports_enhanced_prepared_statements() const -> bool
   {
     return has_cluster_capability(cluster_capability::n1ql_enhanced_prepared_statements);
   }
 
-  [[nodiscard]] bool supports_read_from_replica() const
+  [[nodiscard]] auto supports_read_from_replica() const -> bool
   {
     return has_cluster_capability(cluster_capability::n1ql_read_from_replica);
   }
 
-  [[nodiscard]] bool supports_range_scan() const
+  [[nodiscard]] auto supports_range_scan() const -> bool
   {
     return has_bucket_capability(bucket_capability::range_scan);
   }
 
-  [[nodiscard]] bool ephemeral() const
+  [[nodiscard]] auto ephemeral() const -> bool
   {
     // Use bucket capabilities to identify if couchapi is missing (then its ephemeral). If its null
     // then we are running an old version of couchbase which doesn't have ephemeral buckets at all.
     return has_bucket_capability(bucket_capability::couchapi);
   }
 
-  [[nodiscard]] bool supports_subdoc_read_replica() const
+  [[nodiscard]] auto supports_subdoc_read_replica() const -> bool
   {
     return has_bucket_capability(bucket_capability::subdoc_replica_read);
   }
 
-  [[nodiscard]] bool supports_non_deduped_history() const
+  [[nodiscard]] auto supports_non_deduped_history() const -> bool
   {
     return has_bucket_capability(bucket_capability::non_deduped_history);
   }
 
-  [[nodiscard]] bool supports_scoped_search_indexes() const
+  [[nodiscard]] auto supports_scoped_search_indexes() const -> bool
   {
     return has_cluster_capability(cluster_capability::search_scoped_search_index);
   }
 
-  [[nodiscard]] bool supports_vector_search() const
+  [[nodiscard]] auto supports_vector_search() const -> bool
   {
     return has_cluster_capability(cluster_capability::search_vector_search);
   }

--- a/core/topology/collections_manifest_json.hxx
+++ b/core/topology/collections_manifest_json.hxx
@@ -26,7 +26,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::topology::collections_manifest> {
   template<template<typename...> class Traits>
-  static couchbase::core::topology::collections_manifest as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::topology::collections_manifest
   {
     (void)v;
     couchbase::core::topology::collections_manifest result;

--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -28,8 +28,10 @@
 
 namespace couchbase::core::topology
 {
-std::uint16_t
-configuration::node::port_or(service_type type, bool is_tls, std::uint16_t default_value) const
+auto
+configuration::node::port_or(service_type type,
+                             bool is_tls,
+                             std::uint16_t default_value) const -> std::uint16_t
 {
   if (is_tls) {
     switch (type) {
@@ -80,8 +82,8 @@ configuration::node::port_or(service_type type, bool is_tls, std::uint16_t defau
   return default_value;
 }
 
-const std::string&
-configuration::node::hostname_for(const std::string& network) const
+auto
+configuration::node::hostname_for(const std::string& network) const -> const std::string&
 {
   if (network == "default") {
     return hostname;
@@ -94,11 +96,11 @@ configuration::node::hostname_for(const std::string& network) const
   return address->second.hostname;
 }
 
-std::uint16_t
+auto
 configuration::node::port_or(const std::string& network,
                              service_type type,
                              bool is_tls,
-                             std::uint16_t default_value) const
+                             std::uint16_t default_value) const -> std::uint16_t
 {
   if (network == "default") {
     return port_or(type, is_tls, default_value);
@@ -160,8 +162,10 @@ configuration::node::port_or(const std::string& network,
   return default_value;
 }
 
-std::optional<std::string>
-configuration::node::endpoint(const std::string& network, service_type type, bool is_tls) const
+auto
+configuration::node::endpoint(const std::string& network,
+                              service_type type,
+                              bool is_tls) const -> std::optional<std::string>
 {
   auto p = port_or(type, is_tls, 0);
   if (p == 0) {
@@ -170,12 +174,12 @@ configuration::node::endpoint(const std::string& network, service_type type, boo
   return fmt::format("{}:{}", hostname_for(network), p);
 }
 
-bool
+auto
 configuration::has_node(const std::string& network,
                         service_type type,
                         bool is_tls,
                         const std::string& hostname,
-                        const std::string& port) const
+                        const std::string& port) const -> bool
 {
   std::uint16_t port_number{ 0 };
   try {
@@ -191,8 +195,8 @@ configuration::has_node(const std::string& network,
   });
 }
 
-std::string
-configuration::select_network(const std::string& bootstrap_hostname) const
+auto
+configuration::select_network(const std::string& bootstrap_hostname) const -> std::string
 {
   for (const auto& n : nodes) {
     if (n.this_node) {
@@ -209,8 +213,8 @@ configuration::select_network(const std::string& bootstrap_hostname) const
   return "default";
 }
 
-std::string
-configuration::rev_str() const
+auto
+configuration::rev_str() const -> std::string
 {
   if (epoch) {
     return fmt::format("{}:{}", epoch.value(), rev.value_or(0));
@@ -218,8 +222,8 @@ configuration::rev_str() const
   return rev ? fmt::format("{}", *rev) : "(none)";
 }
 
-std::size_t
-configuration::index_for_this_node() const
+auto
+configuration::index_for_this_node() const -> std::size_t
 {
   for (const auto& n : nodes) {
     if (n.this_node) {
@@ -229,8 +233,9 @@ configuration::index_for_this_node() const
   throw std::runtime_error("no nodes marked as this_node");
 }
 
-std::optional<std::size_t>
-configuration::server_by_vbucket(std::uint16_t vbucket, std::size_t index) const
+auto
+configuration::server_by_vbucket(std::uint16_t vbucket,
+                                 std::size_t index) const -> std::optional<std::size_t>
 {
   if (!vbmap.has_value() || vbucket >= vbmap->size()) {
     return {};
@@ -241,8 +246,9 @@ configuration::server_by_vbucket(std::uint16_t vbucket, std::size_t index) const
   return {};
 }
 
-std::pair<std::uint16_t, std::optional<std::size_t>>
+auto
 configuration::map_key(const std::string& key, std::size_t index) const
+  -> std::pair<std::uint16_t, std::optional<std::size_t>>
 {
   if (!vbmap.has_value()) {
     return { 0, {} };
@@ -252,8 +258,9 @@ configuration::map_key(const std::string& key, std::size_t index) const
   return { vbucket, server_by_vbucket(vbucket, index) };
 }
 
-std::pair<std::uint16_t, std::optional<std::size_t>>
+auto
 configuration::map_key(const std::vector<std::byte>& key, std::size_t index) const
+  -> std::pair<std::uint16_t, std::optional<std::size_t>>
 {
   if (!vbmap.has_value()) {
     return { 0, {} };
@@ -263,10 +270,10 @@ configuration::map_key(const std::vector<std::byte>& key, std::size_t index) con
   return { vbucket, server_by_vbucket(vbucket, index) };
 }
 
-configuration
+auto
 make_blank_configuration(const std::string& hostname,
                          std::uint16_t plain_port,
-                         std::uint16_t tls_port)
+                         std::uint16_t tls_port) -> configuration
 {
   configuration result;
   result.id = couchbase::core::uuid::random();
@@ -280,10 +287,10 @@ make_blank_configuration(const std::string& hostname,
   return result;
 }
 
-configuration
+auto
 make_blank_configuration(const std::vector<std::pair<std::string, std::string>>& endpoints,
                          bool use_tls,
-                         bool force)
+                         bool force) -> configuration
 {
   configuration result;
   result.force = force;

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -62,30 +62,30 @@ struct configuration {
     std::map<std::string, alternate_address> alt{};
     std::string server_group{};
 
-    bool operator!=(const node& other) const
+    auto operator!=(const node& other) const -> bool
     {
       return hostname != other.hostname ||
              services_plain.key_value != other.services_plain.key_value ||
              services_tls.key_value != other.services_tls.key_value;
     }
 
-    [[nodiscard]] std::uint16_t port_or(service_type type,
-                                        bool is_tls,
-                                        std::uint16_t default_value) const;
+    [[nodiscard]] auto port_or(service_type type,
+                               bool is_tls,
+                               std::uint16_t default_value) const -> std::uint16_t;
 
-    [[nodiscard]] std::uint16_t port_or(const std::string& network,
-                                        service_type type,
-                                        bool is_tls,
-                                        std::uint16_t default_value) const;
+    [[nodiscard]] auto port_or(const std::string& network,
+                               service_type type,
+                               bool is_tls,
+                               std::uint16_t default_value) const -> std::uint16_t;
 
-    [[nodiscard]] const std::string& hostname_for(const std::string& network) const;
+    [[nodiscard]] auto hostname_for(const std::string& network) const -> const std::string&;
 
-    [[nodiscard]] std::optional<std::string> endpoint(const std::string& network,
-                                                      service_type type,
-                                                      bool is_tls) const;
+    [[nodiscard]] auto endpoint(const std::string& network,
+                                service_type type,
+                                bool is_tls) const -> std::optional<std::string>;
   };
 
-  [[nodiscard]] std::string select_network(const std::string& bootstrap_hostname) const;
+  [[nodiscard]] auto select_network(const std::string& bootstrap_hostname) const -> std::string;
 
   using vbucket_map = typename std::vector<std::vector<std::int16_t>>;
 
@@ -102,45 +102,48 @@ struct configuration {
   node_locator_type node_locator{ node_locator_type::unknown };
   bool force{ false };
 
-  bool operator==(const configuration& other) const
+  auto operator==(const configuration& other) const -> bool
   {
     return epoch == other.epoch && rev == other.rev;
   }
 
-  bool operator<(const configuration& other) const
+  auto operator<(const configuration& other) const -> bool
   {
     return epoch < other.epoch || (epoch == other.epoch && rev < other.rev);
   }
 
-  bool operator>(const configuration& other) const
+  auto operator>(const configuration& other) const -> bool
   {
     return other < *this;
   }
 
-  [[nodiscard]] std::string rev_str() const;
+  [[nodiscard]] auto rev_str() const -> std::string;
 
-  [[nodiscard]] std::size_t index_for_this_node() const;
-  [[nodiscard]] bool has_node(const std::string& network,
+  [[nodiscard]] auto index_for_this_node() const -> std::size_t;
+  [[nodiscard]] auto has_node(const std::string& network,
                               service_type type,
                               bool is_tls,
                               const std::string& hostname,
-                              const std::string& port) const;
+                              const std::string& port) const -> bool;
 
-  std::pair<std::uint16_t, std::optional<std::size_t>> map_key(const std::string& key,
-                                                               std::size_t index) const;
-  std::pair<std::uint16_t, std::optional<std::size_t>> map_key(const std::vector<std::byte>& key,
-                                                               std::size_t index) const;
+  auto map_key(const std::string& key,
+               std::size_t index) const -> std::pair<std::uint16_t, std::optional<std::size_t>>;
+  auto map_key(const std::vector<std::byte>& key,
+               std::size_t index) const -> std::pair<std::uint16_t, std::optional<std::size_t>>;
 
-  std::optional<std::size_t> server_by_vbucket(std::uint16_t vbucket, std::size_t index) const;
+  auto server_by_vbucket(std::uint16_t vbucket,
+                         std::size_t index) const -> std::optional<std::size_t>;
 };
 
 using endpoint = std::pair<std::string, std::string>;
 
-configuration
+auto
 make_blank_configuration(const std::string& hostname,
                          std::uint16_t plain_port,
-                         std::uint16_t tls_port);
+                         std::uint16_t tls_port) -> configuration;
 
-configuration
-make_blank_configuration(const std::vector<endpoint>& endpoints, bool use_tls, bool force = false);
+auto
+make_blank_configuration(const std::vector<endpoint>& endpoints,
+                         bool use_tls,
+                         bool force = false) -> configuration;
 } // namespace couchbase::core::topology

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -28,7 +28,8 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::topology::configuration> {
   template<template<typename...> class Traits>
-  static couchbase::core::topology::configuration as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v)
+    -> couchbase::core::topology::configuration
   {
     couchbase::core::topology::configuration result;
     result.id = couchbase::core::uuid::random();

--- a/core/topology/error_map_json.hxx
+++ b/core/topology/error_map_json.hxx
@@ -27,7 +27,7 @@ namespace tao::json
 template<>
 struct traits<couchbase::core::error_map> {
   template<template<typename...> class Traits>
-  static couchbase::core::error_map as(const tao::json::basic_value<Traits>& v)
+  static auto as(const tao::json::basic_value<Traits>& v) -> couchbase::core::error_map
   {
     couchbase::core::error_map result;
     result.id = couchbase::core::uuid::random();

--- a/core/tracing/noop_tracer.hxx
+++ b/core/tracing/noop_tracer.hxx
@@ -39,7 +39,7 @@ class noop_span : public couchbase::tracing::request_span
     /* do nothing */
   }
 
-  bool uses_tags() const override
+  auto uses_tags() const -> bool override
   {
     return false;
   }
@@ -51,9 +51,9 @@ private:
   std::shared_ptr<noop_span> instance_{ std::make_shared<noop_span>() };
 
 public:
-  std::shared_ptr<couchbase::tracing::request_span> start_span(
-    std::string /* name */,
-    std::shared_ptr<couchbase::tracing::request_span> /* parent */) override
+  auto start_span(std::string /* name */,
+                  std::shared_ptr<couchbase::tracing::request_span> /* parent */)
+    -> std::shared_ptr<couchbase::tracing::request_span> override
   {
     return instance_;
   }

--- a/core/tracing/threshold_logging_options.hxx
+++ b/core/tracing/threshold_logging_options.hxx
@@ -37,7 +37,7 @@ struct threshold_logging_options {
   std::chrono::milliseconds management_threshold{ 1'000 };
   std::chrono::milliseconds eventing_threshold{ 1'000 };
 
-  [[nodiscard]] std::chrono::milliseconds threshold_for_service(service_type service) const
+  [[nodiscard]] auto threshold_for_service(service_type service) const -> std::chrono::milliseconds
   {
     switch (service) {
       case service_type::key_value:

--- a/core/tracing/threshold_logging_tracer.cxx
+++ b/core/tracing/threshold_logging_tracer.cxx
@@ -39,7 +39,7 @@ struct reported_span {
   std::chrono::microseconds duration;
   tao::json::value payload;
 
-  bool operator<(const reported_span& other) const
+  auto operator<(const reported_span& other) const -> bool
   {
     return duration < other.duration;
   }
@@ -89,32 +89,32 @@ public:
 
   void end() override;
 
-  [[nodiscard]] const auto& string_tags() const
+  [[nodiscard]] auto string_tags() const -> const auto&
   {
     return string_tags_;
   }
 
-  [[nodiscard]] std::chrono::microseconds duration() const
+  [[nodiscard]] auto duration() const -> std::chrono::microseconds
   {
     return duration_;
   }
 
-  [[nodiscard]] std::uint64_t last_server_duration_us() const
+  [[nodiscard]] auto last_server_duration_us() const -> std::uint64_t
   {
     return last_server_duration_us_;
   }
 
-  [[nodiscard]] std::uint64_t total_server_duration_us() const
+  [[nodiscard]] auto total_server_duration_us() const -> std::uint64_t
   {
     return total_server_duration_us_;
   }
 
-  [[nodiscard]] bool orphan() const
+  [[nodiscard]] auto orphan() const -> bool
   {
     return string_tags_.find(tracing::attributes::orphan) != string_tags_.end();
   }
 
-  [[nodiscard]] bool is_key_value() const
+  [[nodiscard]] auto is_key_value() const -> bool
   {
     auto service_tag = string_tags_.find(tracing::attributes::service);
     if (service_tag == string_tags_.end()) {
@@ -123,7 +123,7 @@ public:
     return service_tag->second == tracing::service::key_value;
   }
 
-  [[nodiscard]] std::optional<service_type> service() const
+  [[nodiscard]] auto service() const -> std::optional<service_type>
   {
     auto service_tag = string_tags_.find(tracing::attributes::service);
     if (service_tag == string_tags_.end()) {
@@ -190,13 +190,13 @@ public:
     data_.pop();
   }
 
-  size_type size()
+  auto size() -> size_type
   {
     std::unique_lock<std::mutex> lock(mutex_);
     return data_.size();
   }
 
-  bool empty()
+  auto empty() -> bool
   {
     std::unique_lock<std::mutex> lock(mutex_);
     return data_.empty();
@@ -211,7 +211,7 @@ public:
     }
   }
 
-  std::priority_queue<T> steal_data()
+  auto steal_data() -> std::priority_queue<T>
   {
     std::priority_queue<T> data;
     std::unique_lock<std::mutex> lock(mutex_);
@@ -222,8 +222,8 @@ public:
 
 using fixed_span_queue = concurrent_fixed_queue<reported_span>;
 
-reported_span
-convert(std::shared_ptr<threshold_logging_span> span)
+auto
+convert(std::shared_ptr<threshold_logging_span> span) -> reported_span
 {
   tao::json::value entry{
     { "operation_name", span->name() },
@@ -400,9 +400,10 @@ private:
   std::map<service_type, fixed_span_queue> threshold_queues_{};
 };
 
-std::shared_ptr<couchbase::tracing::request_span>
+auto
 threshold_logging_tracer::start_span(std::string name,
                                      std::shared_ptr<couchbase::tracing::request_span> parent)
+  -> std::shared_ptr<couchbase::tracing::request_span>
 {
   return std::make_shared<threshold_logging_span>(std::move(name), shared_from_this(), parent);
 }

--- a/core/tracing/threshold_logging_tracer.hxx
+++ b/core/tracing/threshold_logging_tracer.hxx
@@ -38,9 +38,8 @@ class threshold_logging_tracer
 public:
   threshold_logging_tracer(asio::io_context& ctx, threshold_logging_options options);
 
-  std::shared_ptr<couchbase::tracing::request_span> start_span(
-    std::string name,
-    std::shared_ptr<couchbase::tracing::request_span> parent) override;
+  auto start_span(std::string name, std::shared_ptr<couchbase::tracing::request_span> parent)
+    -> std::shared_ptr<couchbase::tracing::request_span> override;
   void report(std::shared_ptr<threshold_logging_span> span);
   void start() override;
   void stop() override;

--- a/core/transactions/active_transaction_record.cxx
+++ b/core/transactions/active_transaction_record.cxx
@@ -19,8 +19,9 @@
 
 namespace couchbase::core::transactions
 {
-active_transaction_record
+auto
 active_transaction_record::map_to_atr(const operations::lookup_in_response& resp)
+  -> active_transaction_record
 {
   std::vector<atr_entry> entries;
   if (resp.fields[0].status == key_value_status_code::success) {

--- a/core/transactions/active_transaction_record.hxx
+++ b/core/transactions/active_transaction_record.hxx
@@ -69,8 +69,8 @@ public:
       });
   }
 
-  static std::optional<active_transaction_record> get_atr(const core::cluster& cluster,
-                                                          const core::document_id& atr_id)
+  static auto get_atr(const core::cluster& cluster,
+                      const core::document_id& atr_id) -> std::optional<active_transaction_record>
   {
     auto barrier = std::promise<std::optional<active_transaction_record>>();
     auto f = barrier.get_future();
@@ -89,7 +89,7 @@ public:
   {
   }
 
-  [[nodiscard]] const std::vector<atr_entry>& entries() const
+  [[nodiscard]] auto entries() const -> const std::vector<atr_entry>&
   {
     return entries_;
   }
@@ -111,7 +111,7 @@ private:
    *
    * returns epoch time in ms
    */
-  static inline uint64_t parse_mutation_cas(const std::string& cas)
+  static inline auto parse_mutation_cas(const std::string& cas) -> uint64_t
   {
     if (cas.empty()) {
       return 0;
@@ -129,9 +129,8 @@ private:
     return ret / 1000000;
   }
 
-  static inline std::optional<std::vector<doc_record>> process_document_ids(
-    const tao::json::value& entry,
-    const std::string& key)
+  static inline auto process_document_ids(const tao::json::value& entry, const std::string& key)
+    -> std::optional<std::vector<doc_record>>
   {
     const auto* items = entry.find(key);
     if (items == nullptr || !items->is_array()) {
@@ -145,7 +144,8 @@ private:
     return records;
   }
 
-  static active_transaction_record map_to_atr(const core::operations::lookup_in_response& resp);
+  static auto map_to_atr(const core::operations::lookup_in_response& resp)
+    -> active_transaction_record;
 };
 
 } // namespace couchbase::core::transactions

--- a/core/transactions/atr_cleanup_entry.cxx
+++ b/core/transactions/atr_cleanup_entry.cxx
@@ -37,8 +37,8 @@ namespace couchbase::core::transactions
 
 // NOTE: priority queue outputs largest to smallest - since we want the least
 // recent statr time first, this returns true if lhs > rhs
-bool
-compare_atr_entries::operator()(atr_cleanup_entry& lhs, atr_cleanup_entry& rhs)
+auto
+compare_atr_entries::operator()(atr_cleanup_entry& lhs, atr_cleanup_entry& rhs) -> bool
 {
   return lhs.min_start_time_ > rhs.min_start_time_;
 }
@@ -454,14 +454,14 @@ atr_cleanup_entry::cleanup_entry(durability_level dl)
   }
 }
 
-bool
-atr_cleanup_entry::ready() const
+auto
+atr_cleanup_entry::ready() const -> bool
 {
   return std::chrono::steady_clock::now() > min_start_time_;
 }
 
-std::optional<atr_cleanup_entry>
-atr_cleanup_queue::pop(bool check_time)
+auto
+atr_cleanup_queue::pop(bool check_time) -> std::optional<atr_cleanup_entry>
 {
   std::unique_lock<std::mutex> lock(mutex_);
   if (!queue_.empty()) {
@@ -476,8 +476,8 @@ atr_cleanup_queue::pop(bool check_time)
   return {};
 }
 
-std::size_t
-atr_cleanup_queue::size() const
+auto
+atr_cleanup_queue::size() const -> std::size_t
 {
   std::unique_lock<std::mutex> lock(mutex_);
   return queue_.size();

--- a/core/transactions/atr_ids.cxx
+++ b/core/transactions/atr_ids.cxx
@@ -284,14 +284,14 @@ const std::vector<std::string> ATR_IDS({
   "_txn:atr-1020-#249", "_txn:atr-1021-#159",  "_txn:atr-1022-#cb",  "_txn:atr-1023-#10c2",
 });
 
-const std::vector<std::string>&
-atr_ids::all()
+auto
+atr_ids::all() -> const std::vector<std::string>&
 {
   return ATR_IDS;
 }
 
-const std::string&
-atr_ids::atr_id_for_vbucket(std::size_t vbucket_id)
+auto
+atr_ids::atr_id_for_vbucket(std::size_t vbucket_id) -> const std::string&
 {
   if (vbucket_id > ATR_IDS.size()) {
     throw std::invalid_argument(std::string("invalid vbucket_id: ") + std::to_string(vbucket_id));
@@ -299,8 +299,8 @@ atr_ids::atr_id_for_vbucket(std::size_t vbucket_id)
   return ATR_IDS[vbucket_id];
 }
 
-std::size_t
-atr_ids::vbucket_for_key(const std::string& key)
+auto
+atr_ids::vbucket_for_key(const std::string& key) -> std::size_t
 {
   static const int num_vbuckets = 1024;
   std::uint32_t digest = core::utils::hash_crc32(key.data(), key.size());

--- a/core/transactions/atr_ids.hxx
+++ b/core/transactions/atr_ids.hxx
@@ -24,9 +24,9 @@ namespace couchbase::core::transactions
 class atr_ids
 {
 public:
-  static const std::string& atr_id_for_vbucket(std::size_t vbucket_id);
-  static std::size_t vbucket_for_key(const std::string& key);
-  static const std::vector<std::string>& all();
+  static auto atr_id_for_vbucket(std::size_t vbucket_id) -> const std::string&;
+  static auto vbucket_for_key(const std::string& key) -> std::size_t;
+  static auto all() -> const std::vector<std::string>&;
 };
 
 } // namespace couchbase::core::transactions

--- a/core/transactions/attempt_context.cxx
+++ b/core/transactions/attempt_context.cxx
@@ -22,16 +22,18 @@
 
 namespace couchbase::transactions
 {
-std::pair<error, transaction_query_result>
+auto
 attempt_context::query(const scope& scope,
                        const std::string& statement,
                        const transaction_query_options& opts)
+  -> std::pair<error, transaction_query_result>
 {
   return do_public_query(statement, opts, fmt::format("{}.{}", scope.bucket_name(), scope.name()));
 }
 
-std::pair<error, transaction_query_result>
+auto
 attempt_context::query(const std::string& statement, const transaction_query_options& options)
+  -> std::pair<error, transaction_query_result>
 {
   return do_public_query(statement, options, {});
 }

--- a/core/transactions/attempt_context.hxx
+++ b/core/transactions/attempt_context.hxx
@@ -47,7 +47,7 @@ public:
    * @throws transaction_operation_failed which either should not be caught by the lambda, or
    *         rethrown if it is caught.
    */
-  virtual transaction_get_result get(const core::document_id& id) = 0;
+  virtual auto get(const core::document_id& id) -> transaction_get_result = 0;
 
   /**
    * Gets a document from the specified Couchbase collection matching the specified id.
@@ -61,7 +61,8 @@ public:
    * @throws transaction_operation_failed which either should not be caught by the lambda, or
    *         rethrown if it is caught.
    */
-  virtual std::optional<transaction_get_result> get_optional(const core::document_id& id) = 0;
+  virtual auto get_optional(const core::document_id& id)
+    -> std::optional<transaction_get_result> = 0;
 
   /**
    * Mutates the specified document with new content, using the document's last
@@ -83,7 +84,8 @@ public:
    *         rethrown if it is caught.
    */
   template<typename Content>
-  transaction_get_result replace(const transaction_get_result& document, const Content& content)
+  auto replace(const transaction_get_result& document,
+               const Content& content) -> transaction_get_result
   {
     if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
       return replace_raw(document, content);
@@ -110,7 +112,7 @@ public:
    *         rethrown if it is caught.
    */
   template<typename Content>
-  transaction_get_result insert(const core::document_id& id, const Content& content)
+  auto insert(const core::document_id& id, const Content& content) -> transaction_get_result
   {
     if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
       return insert_raw(id, content);
@@ -143,10 +145,9 @@ public:
    * @param query_context query context, if any.
    * @returns result of the query.
    */
-  core::operations::query_response query(
-    const std::string& statement,
-    const couchbase::transactions::transaction_query_options& opts,
-    std::optional<std::string> query_context = {})
+  auto query(const std::string& statement,
+             const couchbase::transactions::transaction_query_options& opts,
+             std::optional<std::string> query_context = {}) -> core::operations::query_response
   {
     return do_core_query(statement, opts, query_context);
   };
@@ -156,7 +157,7 @@ public:
    * @param statement query statement to execute.
    * @return result of the query
    */
-  core::operations::query_response query(const std::string& statement)
+  auto query(const std::string& statement) -> core::operations::query_response
   {
     couchbase::transactions::transaction_query_options opts;
     return query(statement, opts);
@@ -188,17 +189,17 @@ public:
 
 protected:
   /** @internal */
-  virtual transaction_get_result insert_raw(const core::document_id& id,
-                                            const std::vector<std::byte>& content) = 0;
+  virtual auto insert_raw(const core::document_id& id,
+                          const std::vector<std::byte>& content) -> transaction_get_result = 0;
 
   /** @internal */
-  virtual transaction_get_result replace_raw(const transaction_get_result& document,
-                                             const std::vector<std::byte>& content) = 0;
+  virtual auto replace_raw(const transaction_get_result& document,
+                           const std::vector<std::byte>& content) -> transaction_get_result = 0;
 
-  virtual core::operations::query_response do_core_query(
-    const std::string&,
-    const couchbase::transactions::transaction_query_options& opts,
-    std::optional<std::string> query_context) = 0;
+  virtual auto do_core_query(const std::string&,
+                             const couchbase::transactions::transaction_query_options& opts,
+                             std::optional<std::string> query_context)
+    -> core::operations::query_response = 0;
 };
 
 } // namespace couchbase::core::transactions

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -45,12 +45,14 @@
 namespace couchbase::core::impl
 {
 
-std::pair<couchbase::transaction_op_error_context,
-          couchbase::transactions::transaction_query_result>
-build_transaction_query_result(operations::query_response resp, std::error_code ec = {});
+auto
+build_transaction_query_result(operations::query_response resp, std::error_code ec = {})
+  -> std::pair<couchbase::transaction_op_error_context,
+               couchbase::transactions::transaction_query_result>;
 
-core::operations::query_request
-build_transaction_query_request(couchbase::query_options::built opts);
+auto
+build_transaction_query_request(couchbase::query_options::built opts)
+  -> core::operations::query_request;
 
 } // namespace couchbase::core::impl
 
@@ -89,18 +91,18 @@ private:
   // transaction_context needs access to the two functions below
   friend class transaction_context;
 
-  std::pair<couchbase::error, couchbase::transactions::transaction_get_result> insert_raw(
-    const couchbase::collection& coll,
-    const std::string& id,
-    std::vector<std::byte> content) override
+  auto insert_raw(const couchbase::collection& coll,
+                  const std::string& id,
+                  std::vector<std::byte> content)
+    -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result> override
   {
     return wrap_call_for_public_api([this, coll, &id, &content]() -> transaction_get_result {
       return insert_raw({ coll.bucket_name(), coll.scope_name(), coll.name(), id }, content);
     });
   }
 
-  transaction_get_result insert_raw(const core::document_id& id,
-                                    const std::vector<std::byte>& content) override;
+  auto insert_raw(const core::document_id& id,
+                  const std::vector<std::byte>& content) -> transaction_get_result override;
   void insert_raw(const collection& coll,
                   std::string id,
                   std::vector<std::byte> content,
@@ -117,12 +119,12 @@ private:
                   const std::vector<std::byte>& content,
                   Callback&& cb) override;
 
-  transaction_get_result replace_raw(const transaction_get_result& document,
-                                     const std::vector<std::byte>& content) override;
+  auto replace_raw(const transaction_get_result& document,
+                   const std::vector<std::byte>& content) -> transaction_get_result override;
 
-  std::pair<couchbase::error, couchbase::transactions::transaction_get_result> replace_raw(
-    const couchbase::transactions::transaction_get_result& doc,
-    std::vector<std::byte> content) override
+  auto replace_raw(const couchbase::transactions::transaction_get_result& doc,
+                   std::vector<std::byte> content)
+    -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result> override
   {
     return wrap_call_for_public_api([this, doc, &content]() -> transaction_get_result {
       return replace_raw(transaction_get_result(doc), content);
@@ -165,7 +167,7 @@ private:
                 const couchbase::transactions::transaction_query_options& opts,
                 std::optional<std::string> query_context,
                 QueryCallback&& cb);
-  std::exception_ptr handle_query_error(const core::operations::query_response& resp);
+  auto handle_query_error(const core::operations::query_response& resp) -> std::exception_ptr;
   void wrap_query(const std::string& statement,
                   const couchbase::transactions::transaction_query_options& opts,
                   const std::vector<core::json_string>& params,
@@ -360,16 +362,15 @@ private:
     }
   }
 
-  const core::cluster& cluster_ref() const;
+  auto cluster_ref() const -> const core::cluster&;
 
 public:
   explicit attempt_context_impl(transaction_context& transaction_ctx);
   ~attempt_context_impl() override;
 
-  transaction_get_result get(const core::document_id& id) override;
-  std::pair<couchbase::error, couchbase::transactions::transaction_get_result> get(
-    const couchbase::collection& coll,
-    const std::string& id) override
+  auto get(const core::document_id& id) -> transaction_get_result override;
+  auto get(const couchbase::collection& coll, const std::string& id)
+    -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result> override
   {
     auto [ctx, res] =
       wrap_call_for_public_api([this, coll, id]() mutable -> transaction_get_result {
@@ -399,11 +400,12 @@ public:
   }
   void get(const core::document_id& id, Callback&& cb) override;
 
-  std::optional<transaction_get_result> get_optional(const core::document_id& id) override;
+  auto get_optional(const core::document_id& id) -> std::optional<transaction_get_result> override;
   void get_optional(const core::document_id& id, Callback&& cb) override;
 
   void remove(const transaction_get_result& document) override;
-  couchbase::error remove(const couchbase::transactions::transaction_get_result& doc) override
+  auto remove(const couchbase::transactions::transaction_get_result& doc)
+    -> couchbase::error override
   {
     return wrap_void_call_for_public_api([this, doc]() {
       remove(transaction_get_result(doc));
@@ -419,15 +421,15 @@ public:
            });
   };
 
-  core::operations::query_response do_core_query(
-    const std::string& statement,
-    const couchbase::transactions::transaction_query_options& options,
-    std::optional<std::string> query_context) override;
+  auto do_core_query(const std::string& statement,
+                     const couchbase::transactions::transaction_query_options& options,
+                     std::optional<std::string> query_context)
+    -> core::operations::query_response override;
 
-  std::pair<couchbase::error, couchbase::transactions::transaction_query_result> do_public_query(
-    const std::string& statement,
-    const couchbase::transactions::transaction_query_options& opts,
-    std::optional<std::string> query_context) override;
+  auto do_public_query(const std::string& statement,
+                       const couchbase::transactions::transaction_query_options& opts,
+                       std::optional<std::string> query_context)
+    -> std::pair<couchbase::error, couchbase::transactions::transaction_query_result> override;
 
   void query(const std::string& statement,
              const couchbase::transactions::transaction_query_options& options,
@@ -474,27 +476,27 @@ public:
     }
   }
 
-  [[nodiscard]] bool is_done()
+  [[nodiscard]] auto is_done() -> bool
   {
     return is_done_;
   }
 
-  [[nodiscard]] transaction_context& overall()
+  [[nodiscard]] auto overall() -> transaction_context&
   {
     return overall_;
   }
 
-  [[nodiscard]] const std::string& transaction_id()
+  [[nodiscard]] auto transaction_id() -> const std::string&
   {
     return overall_.transaction_id();
   }
 
-  [[nodiscard]] const std::string& id()
+  [[nodiscard]] auto id() -> const std::string&
   {
     return overall_.current_attempt().id;
   }
 
-  [[nodiscard]] attempt_state state()
+  [[nodiscard]] auto state() -> attempt_state
   {
     return overall_.current_attempt().state;
   }
@@ -504,7 +506,7 @@ public:
     overall_.current_attempt_state(s);
   }
 
-  [[nodiscard]] const std::string atr_id()
+  [[nodiscard]] auto atr_id() -> const std::string
   {
     return overall_.atr_id();
   }
@@ -514,7 +516,7 @@ public:
     overall_.atr_id(atr_id);
   }
 
-  [[nodiscard]] const std::string atr_collection()
+  [[nodiscard]] auto atr_collection() -> const std::string
   {
     return overall_.atr_collection();
   }
@@ -524,12 +526,12 @@ public:
     overall_.atr_collection(coll);
   }
 
-  bool has_expired_client_side(std::string place, std::optional<const std::string> doc_id);
+  auto has_expired_client_side(std::string place, std::optional<const std::string> doc_id) -> bool;
 
 private:
   std::atomic<bool> expiry_overtime_mode_{ false };
 
-  bool check_expiry_pre_commit(std::string stage, std::optional<const std::string> doc_id);
+  auto check_expiry_pre_commit(std::string stage, std::optional<const std::string> doc_id) -> bool;
 
   void check_expiry_during_commit_or_rollback(const std::string& stage,
                                               std::optional<const std::string> doc_id);
@@ -539,11 +541,11 @@ private:
                               std::unique_lock<std::mutex>&& lock,
                               Handler&& cb);
 
-  std::optional<error_class> error_if_expired_and_not_in_overtime(
-    const std::string& stage,
-    std::optional<const std::string> doc_id);
+  auto error_if_expired_and_not_in_overtime(const std::string& stage,
+                                            std::optional<const std::string> doc_id)
+    -> std::optional<error_class>;
 
-  staged_mutation* check_for_own_write(const core::document_id& id);
+  auto check_for_own_write(const core::document_id& id) -> staged_mutation*;
 
   template<typename Handler>
   void check_and_handle_blocking_transactions(const transaction_get_result& doc,
@@ -582,12 +584,12 @@ private:
                                   std::optional<std::string>,
                                   std::optional<transaction_get_result>)>&& cb);
 
-  core::operations::mutate_in_request create_staging_request(
-    const core::document_id& in,
-    const transaction_get_result* document,
-    const std::string type,
-    const std::string op_id,
-    std::optional<std::vector<std::byte>> content = std::nullopt);
+  auto create_staging_request(const core::document_id& in,
+                              const transaction_get_result* document,
+                              const std::string type,
+                              const std::string op_id,
+                              std::optional<std::vector<std::byte>> content = std::nullopt)
+    -> core::operations::mutate_in_request;
 
   template<typename Handler, typename Delay>
   void create_staged_insert(const core::document_id& id,
@@ -613,8 +615,8 @@ private:
                                           error_class ec,
                                           const std::string& message);
 
-  std::pair<couchbase::error, couchbase::transactions::transaction_get_result>
-  wrap_call_for_public_api(std::function<transaction_get_result()>&& handler)
+  auto wrap_call_for_public_api(std::function<transaction_get_result()>&& handler)
+    -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result>
   {
     try {
       return { {}, handler().to_public_result() };
@@ -628,7 +630,7 @@ private:
     }
   }
 
-  couchbase::error wrap_void_call_for_public_api(std::function<void()>&& handler)
+  auto wrap_void_call_for_public_api(std::function<void()>&& handler) -> couchbase::error
   {
     try {
       handler();

--- a/core/transactions/attempt_context_testing_hooks.cxx
+++ b/core/transactions/attempt_context_testing_hooks.cxx
@@ -35,14 +35,14 @@ noop2(attempt_context*,
   return handler({});
 }
 
-inline std::optional<const std::string>
-noop3(attempt_context*)
+inline auto
+noop3(attempt_context*) -> std::optional<const std::string>
 {
   return {};
 }
 
-inline bool
-noop4(attempt_context*, const std::string&, std::optional<const std::string>)
+inline auto
+noop4(attempt_context*, const std::string&, std::optional<const std::string>) -> bool
 {
   return false;
 }

--- a/core/transactions/attempt_state.hxx
+++ b/core/transactions/attempt_state.hxx
@@ -63,8 +63,8 @@ enum class attempt_state {
   UNKNOWN
 };
 
-inline const char*
-attempt_state_name(attempt_state state)
+inline auto
+attempt_state_name(attempt_state state) -> const char*
 {
   switch (state) {
     case attempt_state::NOT_STARTED:
@@ -86,8 +86,8 @@ attempt_state_name(attempt_state state)
   }
 }
 
-inline attempt_state
-attempt_state_value(const std::string& str)
+inline auto
+attempt_state_value(const std::string& str) -> attempt_state
 {
   if (str == "NOT_STARTED") {
     return attempt_state::NOT_STARTED;

--- a/core/transactions/binary.cxx
+++ b/core/transactions/binary.cxx
@@ -18,8 +18,8 @@
 
 namespace couchbase::core::transactions
 {
-std::string
-to_string(const std::vector<std::byte>& input)
+auto
+to_string(const std::vector<std::byte>& input) -> std::string
 {
   return std::string(reinterpret_cast<const char*>(input.data()), input.size());
 }

--- a/core/transactions/document_metadata.hxx
+++ b/core/transactions/document_metadata.hxx
@@ -61,7 +61,7 @@ public:
    *
    * @return the CAS of the document, as a string.
    */
-  [[nodiscard]] std::optional<std::string> cas() const
+  [[nodiscard]] auto cas() const -> std::optional<std::string>
   {
     return cas_;
   }
@@ -71,7 +71,7 @@ public:
    *
    * @return the revid of the document, as a string.
    */
-  [[nodiscard]] std::optional<std::string> revid() const
+  [[nodiscard]] auto revid() const -> std::optional<std::string>
   {
     return revid_;
   }
@@ -82,7 +82,7 @@ public:
    * @return the expiry of the document, if one was set, and the request
    *         specified it.
    */
-  [[nodiscard]] std::optional<std::uint32_t> exptime() const
+  [[nodiscard]] auto exptime() const -> std::optional<std::uint32_t>
   {
     return exptime_;
   }
@@ -92,7 +92,7 @@ public:
    *
    * @return the crc-32 for the document, as a string
    */
-  [[nodiscard]] std::optional<std::string> crc32() const
+  [[nodiscard]] auto crc32() const -> std::optional<std::string>
   {
     return crc32_;
   }

--- a/core/transactions/durability_level.hxx
+++ b/core/transactions/durability_level.hxx
@@ -21,8 +21,8 @@
 
 namespace couchbase::core::transactions
 {
-constexpr std::string_view
-durability_level_to_string(durability_level level)
+constexpr auto
+durability_level_to_string(durability_level level) -> std::string_view
 {
   switch (level) {
     case durability_level::none:
@@ -37,8 +37,8 @@ durability_level_to_string(durability_level level)
   return "MAJORITY";
 }
 
-constexpr std::string_view
-durability_level_to_string_for_query(durability_level level)
+constexpr auto
+durability_level_to_string_for_query(durability_level level) -> std::string_view
 {
   switch (level) {
     case durability_level::none:
@@ -53,8 +53,8 @@ durability_level_to_string_for_query(durability_level level)
   return "majority";
 }
 
-constexpr std::string_view
-store_durability_level_to_string(durability_level level)
+constexpr auto
+store_durability_level_to_string(durability_level level) -> std::string_view
 {
   switch (level) {
     case durability_level::none:

--- a/core/transactions/error_list.hxx
+++ b/core/transactions/error_list.hxx
@@ -33,7 +33,7 @@ private:
   std::atomic<std::size_t> size_{ 0 };
 
 public:
-  bool empty()
+  auto empty() -> bool
   {
     return size_.load() == 0;
   }

--- a/core/transactions/exceptions.cxx
+++ b/core/transactions/exceptions.cxx
@@ -20,8 +20,8 @@
 
 namespace couchbase::core::transactions
 {
-external_exception
-external_exception_from_error_class(error_class ec)
+auto
+external_exception_from_error_class(error_class ec) -> external_exception
 {
   switch (ec) {
     case FAIL_DOC_NOT_FOUND:
@@ -33,8 +33,9 @@ external_exception_from_error_class(error_class ec)
   }
 }
 
-couchbase::core::transactions::error_class
+auto
 error_class_from_external_exception(external_exception e)
+  -> couchbase::core::transactions::error_class
 {
   switch (e) {
     case DOCUMENT_NOT_FOUND_EXCEPTION:
@@ -46,8 +47,8 @@ error_class_from_external_exception(external_exception e)
   }
 }
 
-error_class
-error_class_from_result(const result& res)
+auto
+error_class_from_result(const result& res) -> error_class
 {
   subdoc_result::status_type subdoc_status = res.subdoc_status();
   assert(res.ec ||
@@ -110,8 +111,8 @@ transaction_exception::transaction_exception(const std::runtime_error& cause,
   }
 }
 
-errc::transaction_op
-transaction_op_errc_from_external_exception(external_exception e)
+auto
+transaction_op_errc_from_external_exception(external_exception e) -> errc::transaction_op
 {
   switch (e) {
     case external_exception::UNKNOWN:

--- a/core/transactions/exceptions.hxx
+++ b/core/transactions/exceptions.hxx
@@ -62,11 +62,13 @@ enum external_exception {
   TRANSACTION_ALREADY_COMMITTED,
 };
 
-couchbase::errc::transaction_op
-transaction_op_errc_from_external_exception(external_exception e);
+auto
+transaction_op_errc_from_external_exception(external_exception e)
+  -> couchbase::errc::transaction_op;
 
-couchbase::core::transactions::error_class
-error_class_from_external_exception(external_exception e);
+auto
+error_class_from_external_exception(external_exception e)
+  -> couchbase::core::transactions::error_class;
 
 /**
  * @brief Base class for all exceptions expected to be raised from a transaction.
@@ -97,8 +99,8 @@ public:
    *
    * @returns Internal state of transaction.
    */
-  std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result>
-  get_transaction_result() const
+  auto get_transaction_result() const
+    -> std::pair<couchbase::transaction_error_context, couchbase::transactions::transaction_result>
   {
     return { error_context(), { result_.transaction_id, result_.unstaging_complete } };
   }
@@ -108,7 +110,7 @@ public:
    *
    * @returns The underlying cause for this exception.
    */
-  external_exception cause() const
+  auto cause() const -> external_exception
   {
     return cause_;
   }
@@ -116,12 +118,12 @@ public:
    * @brief The type of the exception - see @ref failure_type
    * @return The failure type.
    */
-  failure_type type() const
+  auto type() const -> failure_type
   {
     return type_;
   }
 
-  [[nodiscard]] transaction_error_context error_context() const
+  [[nodiscard]] auto error_context() const -> transaction_error_context
   {
     std::error_code ec{};
     switch (type_) {
@@ -153,12 +155,12 @@ public:
   {
   }
 
-  [[nodiscard]] external_exception cause() const
+  [[nodiscard]] auto cause() const -> external_exception
   {
     return cause_;
   }
 
-  [[nodiscard]] const transaction_op_error_context& ctx() const
+  [[nodiscard]] auto ctx() const -> const transaction_op_error_context&
   {
     return ctx_;
   }

--- a/core/transactions/forward_compat.hxx
+++ b/core/transactions/forward_compat.hxx
@@ -39,8 +39,8 @@ enum class forward_compat_stage {
   CLEANUP_ENTRY
 };
 
-static forward_compat_stage
-create_forward_compat_stage(const std::string& str)
+static auto
+create_forward_compat_stage(const std::string& str) -> forward_compat_stage
 {
   if (str == "WW_R") {
     return forward_compat_stage::WWC_READING_ATR;
@@ -68,8 +68,8 @@ enum class forward_compat_behavior {
   FAIL_FAST_TXN
 };
 
-inline forward_compat_behavior
-create_forward_compat_behavior(const std::string& str)
+inline auto
+create_forward_compat_behavior(const std::string& str) -> forward_compat_behavior
 {
   if (str == "r") {
     return forward_compat_behavior::RETRY_TXN;
@@ -78,8 +78,8 @@ create_forward_compat_behavior(const std::string& str)
 }
 
 // used only for logging
-inline const char*
-forward_compat_behavior_name(forward_compat_behavior b)
+inline auto
+forward_compat_behavior_name(forward_compat_behavior b) -> const char*
 {
   switch (b) {
     case forward_compat_behavior::CONTINUE:
@@ -113,7 +113,7 @@ struct forward_compat_behavior_full {
   }
 
   template<typename OStream>
-  friend OStream& operator<<(OStream& os, const forward_compat_behavior_full& b)
+  friend auto operator<<(OStream& os, const forward_compat_behavior_full& b) -> OStream&
   {
     os << "forward_compat_behavior_full:{";
     os << "behavior: " << forward_compat_behavior_name(b.behavior);
@@ -140,7 +140,7 @@ struct forward_compat_requirement {
   {
   }
 
-  virtual forward_compat_behavior_full check(forward_compat_supported supported) = 0;
+  virtual auto check(forward_compat_supported supported) -> forward_compat_behavior_full = 0;
   virtual ~forward_compat_requirement() = default;
 };
 
@@ -157,7 +157,7 @@ struct forward_compat_protocol_requirement : public forward_compat_requirement {
   {
   }
 
-  virtual forward_compat_behavior_full check(forward_compat_supported supported)
+  virtual auto check(forward_compat_supported supported) -> forward_compat_behavior_full
   {
     if ((min_protocol_major > supported.protocol_major) ||
         (min_protocol_minor > supported.protocol_minor)) {
@@ -176,7 +176,7 @@ struct forward_compat_extension_requirement : public forward_compat_requirement 
   {
   }
 
-  virtual forward_compat_behavior_full check(forward_compat_supported supported)
+  virtual auto check(forward_compat_supported supported) -> forward_compat_behavior_full
   {
     auto it = std::find(supported.extensions.begin(), supported.extensions.end(), extension_id);
     if (it == supported.extensions.end()) {
@@ -192,8 +192,8 @@ private:
   std::map<forward_compat_stage, std::list<forward_compat_requirement*>> compat_map_;
   tao::json::value json_;
 
-  std::optional<transaction_operation_failed> check_internal(forward_compat_stage stage,
-                                                             forward_compat_supported supported)
+  auto check_internal(forward_compat_stage stage, forward_compat_supported supported)
+    -> std::optional<transaction_operation_failed>
   {
     if (auto it = compat_map_.find(stage); it != compat_map_.end()) {
       transaction_operation_failed ex(FAIL_OTHER, "Forward Compatibililty failure");
@@ -248,8 +248,8 @@ private:
   }
 
 public:
-  static std::optional<transaction_operation_failed> check(forward_compat_stage stage,
-                                                           std::optional<tao::json::value> json)
+  static auto check(forward_compat_stage stage, std::optional<tao::json::value> json)
+    -> std::optional<transaction_operation_failed>
   {
     if (json) {
       forward_compat_supported supported;

--- a/core/transactions/result.cxx
+++ b/core/transactions/result.cxx
@@ -21,8 +21,8 @@
 
 namespace couchbase::core::transactions
 {
-std::string
-result::strerror() const
+auto
+result::strerror() const -> std::string
 {
   static std::string success("success");
   if (ec) {
@@ -31,14 +31,14 @@ result::strerror() const
   return success;
 }
 
-bool
-result::is_success() const
+auto
+result::is_success() const -> bool
 {
   return !ec;
 }
 
-subdoc_result::status_type
-result::subdoc_status() const
+auto
+result::subdoc_status() const -> subdoc_result::status_type
 {
   auto it = std::find_if(values.begin(), values.end(), [](const subdoc_result& res) {
     return res.status != subdoc_result::status_type::success;
@@ -49,8 +49,8 @@ result::subdoc_status() const
   return subdoc_result::status_type::success;
 }
 
-result
-result::create_from_subdoc_response(const core::operations::lookup_in_response& resp)
+auto
+result::create_from_subdoc_response(const core::operations::lookup_in_response& resp) -> result
 {
   result res{};
   res.ec = resp.ctx.ec();
@@ -64,8 +64,8 @@ result::create_from_subdoc_response(const core::operations::lookup_in_response& 
   return res;
 }
 
-result
-result::create_from_subdoc_response(const core::operations::mutate_in_response& resp)
+auto
+result::create_from_subdoc_response(const core::operations::mutate_in_response& resp) -> result
 {
   result res{};
   res.ec = resp.ctx.ec();

--- a/core/transactions/result.hxx
+++ b/core/transactions/result.hxx
@@ -51,7 +51,7 @@ struct result_base {
   {
   }
 
-  bool has_value() const
+  auto has_value() const -> bool
   {
     return !raw_value.empty();
   }
@@ -108,7 +108,7 @@ struct subdoc_result : result_base {
   }
 
   template<typename T>
-  T content_as() const
+  auto content_as() const -> T
   {
     // this will always be a json string.  To not have extraneous
     // "" when asked to return as a string, we parse it first.
@@ -116,7 +116,7 @@ struct subdoc_result : result_base {
     return codec::tao_json_serializer::deserialize<T>(raw_value);
   }
 
-  [[nodiscard]] tao::json::value content_as() const
+  [[nodiscard]] auto content_as() const -> tao::json::value
   {
     return core::utils::json::parse_binary(raw_value);
   }
@@ -196,7 +196,7 @@ struct result : result_base {
   bool ignore_subdoc_errors{ false };
 
   template<typename Resp>
-  static result create_from_mutation_response(const Resp& resp)
+  static auto create_from_mutation_response(const Resp& resp) -> result
   {
     result res{};
     res.ec = resp.ctx.ec();
@@ -206,7 +206,7 @@ struct result : result_base {
   }
 
   template<typename Resp>
-  static result create_from_response(const Resp& resp)
+  static auto create_from_response(const Resp& resp) -> result
   {
     result res{};
     res.ec = resp.ctx.ec();
@@ -217,9 +217,11 @@ struct result : result_base {
     return res;
   }
 
-  static result create_from_subdoc_response(const core::operations::lookup_in_response& resp);
+  static auto create_from_subdoc_response(const core::operations::lookup_in_response& resp)
+    -> result;
 
-  static result create_from_subdoc_response(const core::operations::mutate_in_response& resp);
+  static auto create_from_subdoc_response(const core::operations::mutate_in_response& resp)
+    -> result;
 
   result() = default;
 
@@ -228,16 +230,16 @@ struct result : result_base {
    *
    * @return String describing the error code.
    */
-  [[nodiscard]] std::string strerror() const;
+  [[nodiscard]] auto strerror() const -> std::string;
 
-  [[nodiscard]] bool is_success() const;
+  [[nodiscard]] auto is_success() const -> bool;
   /**
    *  Get error code.  This is either the rc_, or if that is LCB_SUCCESS,
    *  then the first error in the values (if any) see @ref subdoc_results
    */
   // [[nodiscard]]std::uint32_t error() const;
   template<typename OStream>
-  friend OStream& operator<<(OStream& os, const result& res)
+  friend auto operator<<(OStream& os, const result& res) -> OStream&
   {
     os << "result{";
     os << "rc:" << res.rc << ",";
@@ -259,12 +261,12 @@ struct result : result_base {
   }
 
   template<typename T>
-  T content_as() const
+  auto content_as() const -> T
   {
     return codec::tao_json_serializer::deserialize<T>(raw_value);
   }
 
-  [[nodiscard]] subdoc_result::status_type subdoc_status() const;
+  [[nodiscard]] auto subdoc_status() const -> subdoc_result::status_type;
 };
 } // namespace transactions
 } // namespace couchbase::core

--- a/core/transactions/staged_mutation.cxx
+++ b/core/transactions/staged_mutation.cxx
@@ -31,8 +31,8 @@
 namespace couchbase::core::transactions
 {
 
-bool
-unstaging_state::wait_until_unstage_possible()
+auto
+unstaging_state::wait_until_unstage_possible() -> bool
 {
   std::unique_lock lock(mutex_);
   auto success = cv_.wait_for(lock, ctx_->overall().remaining(), [this] {
@@ -65,8 +65,8 @@ unstaging_state::notify_unstage_error()
   cv_.notify_all();
 }
 
-bool
-staged_mutation_queue::empty()
+auto
+staged_mutation_queue::empty() -> bool
 {
   std::lock_guard<std::mutex> lock(mutex_);
   return queue_.empty();
@@ -141,8 +141,8 @@ staged_mutation_queue::remove_any(const core::document_id& id)
   queue_.erase(new_end, queue_.end());
 }
 
-staged_mutation*
-staged_mutation_queue::find_any(const core::document_id& id)
+auto
+staged_mutation_queue::find_any(const core::document_id& id) -> staged_mutation*
 {
   const std::lock_guard<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
@@ -153,8 +153,8 @@ staged_mutation_queue::find_any(const core::document_id& id)
   return nullptr;
 }
 
-staged_mutation*
-staged_mutation_queue::find_replace(const core::document_id& id)
+auto
+staged_mutation_queue::find_replace(const core::document_id& id) -> staged_mutation*
 {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
@@ -165,8 +165,8 @@ staged_mutation_queue::find_replace(const core::document_id& id)
   return nullptr;
 }
 
-staged_mutation*
-staged_mutation_queue::find_insert(const core::document_id& id)
+auto
+staged_mutation_queue::find_insert(const core::document_id& id) -> staged_mutation*
 {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
@@ -177,8 +177,8 @@ staged_mutation_queue::find_insert(const core::document_id& id)
   return nullptr;
 }
 
-staged_mutation*
-staged_mutation_queue::find_remove(const core::document_id& id)
+auto
+staged_mutation_queue::find_remove(const core::document_id& id) -> staged_mutation*
 {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& item : queue_) {

--- a/core/transactions/staged_mutation.hxx
+++ b/core/transactions/staged_mutation.hxx
@@ -56,25 +56,25 @@ public:
 
   staged_mutation(const staged_mutation& o) = default;
   staged_mutation(staged_mutation&& o) = default;
-  staged_mutation& operator=(const staged_mutation& o) = default;
-  staged_mutation& operator=(staged_mutation&& o) = default;
+  auto operator=(const staged_mutation& o) -> staged_mutation& = default;
+  auto operator=(staged_mutation&& o) -> staged_mutation& = default;
 
-  const core::document_id& id() const
+  auto id() const -> const core::document_id&
   {
     return doc_.id();
   }
 
-  [[nodiscard]] const transaction_get_result& doc() const
+  [[nodiscard]] auto doc() const -> const transaction_get_result&
   {
     return doc_;
   }
 
-  [[nodiscard]] transaction_get_result& doc()
+  [[nodiscard]] auto doc() -> transaction_get_result&
   {
     return doc_;
   }
 
-  [[nodiscard]] const staged_mutation_type& type() const
+  [[nodiscard]] auto type() const -> const staged_mutation_type&
   {
     return type_;
   }
@@ -84,7 +84,7 @@ public:
     type_ = type;
   }
 
-  [[nodiscard]] const std::vector<std::byte>& content() const
+  [[nodiscard]] auto content() const -> const std::vector<std::byte>&
   {
     return content_;
   }
@@ -94,7 +94,7 @@ public:
     content_ = content;
   }
 
-  [[nodiscard]] std::string type_as_string() const
+  [[nodiscard]] auto type_as_string() const -> std::string
   {
     switch (type_) {
       case staged_mutation_type::INSERT:
@@ -107,7 +107,7 @@ public:
     throw std::runtime_error("unknown type of staged mutation");
   }
 
-  [[nodiscard]] const std::string& operation_id() const
+  [[nodiscard]] auto operation_id() const -> const std::string&
   {
     return operation_id_;
   }
@@ -122,7 +122,7 @@ struct unstaging_state {
   std::atomic_size_t in_flight_count_{ 0 };
   bool abort_{ false };
 
-  bool wait_until_unstage_possible();
+  auto wait_until_unstage_possible() -> bool;
   void notify_unstage_complete();
   void notify_unstage_error();
 };
@@ -196,7 +196,7 @@ private:
                                   utils::movable_function<void(std::exception_ptr)> callback);
 
 public:
-  bool empty();
+  auto empty() -> bool;
   void add(const staged_mutation& mutation);
   void extract_to(const std::string& prefix, core::operations::mutate_in_request& req);
   void commit(attempt_context_impl* ctx);
@@ -204,9 +204,9 @@ public:
   void iterate(std::function<void(staged_mutation&)>);
   void remove_any(const core::document_id&);
 
-  staged_mutation* find_any(const core::document_id& id);
-  staged_mutation* find_replace(const core::document_id& id);
-  staged_mutation* find_insert(const core::document_id& id);
-  staged_mutation* find_remove(const core::document_id& id);
+  auto find_any(const core::document_id& id) -> staged_mutation*;
+  auto find_replace(const core::document_id& id) -> staged_mutation*;
+  auto find_insert(const core::document_id& id) -> staged_mutation*;
+  auto find_remove(const core::document_id& id) -> staged_mutation*;
 };
 } // namespace couchbase::core::transactions

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -53,8 +53,8 @@ transaction_context::add_attempt()
   attempts_.push_back(attempt);
 }
 
-[[nodiscard]] std::chrono::nanoseconds
-transaction_context::remaining() const
+[[nodiscard]] auto
+transaction_context::remaining() const -> std::chrono::nanoseconds
 {
   const auto& now = std::chrono::steady_clock::now();
   auto expired_nanos =
@@ -63,8 +63,8 @@ transaction_context::remaining() const
   return config_.timeout - expired_nanos;
 }
 
-[[nodiscard]] bool
-transaction_context::has_expired_client_side()
+[[nodiscard]] auto
+transaction_context::has_expired_client_side() -> bool
 {
   // repeat code above - nice for logging.  Ponder changing this.
   const auto& now = std::chrono::steady_clock::now();
@@ -120,8 +120,8 @@ transaction_context::new_attempt_context(async_attempt_context::VoidCallback&& c
   });
 }
 
-std::shared_ptr<attempt_context_impl>
-transaction_context::current_attempt_context()
+auto
+transaction_context::current_attempt_context() -> std::shared_ptr<attempt_context_impl>
 {
   return current_attempt_context_;
 }

--- a/core/transactions/transaction_get_result.cxx
+++ b/core/transactions/transaction_get_result.cxx
@@ -19,8 +19,9 @@
 
 namespace couchbase::core::transactions
 {
-transaction_get_result
+auto
 transaction_get_result::create_from(const core::operations::lookup_in_response& resp)
+  -> transaction_get_result
 {
   std::optional<std::string> atr_id;
   std::optional<std::string> transaction_id;
@@ -126,8 +127,9 @@ transaction_get_result::create_from(const core::operations::lookup_in_response& 
            std::make_optional(md) };
 }
 
-transaction_get_result
-transaction_get_result::create_from(const core::document_id& id, const result& res)
+auto
+transaction_get_result::create_from(const core::document_id& id,
+                                    const result& res) -> transaction_get_result
 {
   std::optional<std::string> atr_id;
   std::optional<std::string> transaction_id;

--- a/core/transactions/transaction_get_result.hxx
+++ b/core/transactions/transaction_get_result.hxx
@@ -87,7 +87,7 @@ public:
   {
   }
 
-  couchbase::transactions::transaction_get_result to_public_result()
+  auto to_public_result() -> couchbase::transactions::transaction_get_result
   {
     return couchbase::transactions::transaction_get_result(std::make_shared<transaction_get_result>(
       document_id_, std::move(content_), cas_.value(), links_, metadata_));
@@ -110,7 +110,7 @@ public:
     }
   }
 
-  transaction_get_result& operator=(const transaction_get_result& o)
+  auto operator=(const transaction_get_result& o) -> transaction_get_result&
   {
     if (this != &o) {
       document_id_ = o.document_id_;
@@ -123,7 +123,8 @@ public:
 
   /** @internal */
   template<typename Content>
-  static transaction_get_result create_from(const transaction_get_result& document, Content content)
+  static auto create_from(const transaction_get_result& document,
+                          Content content) -> transaction_get_result
   {
     transaction_links links(document.links().atr_id(),
                             document.links().atr_bucket_name(),
@@ -145,14 +146,15 @@ public:
   }
 
   /** @internal */
-  static transaction_get_result create_from(const core::document_id& id, const result& res);
+  static auto create_from(const core::document_id& id, const result& res) -> transaction_get_result;
 
   /** @internal */
-  static transaction_get_result create_from(const core::operations::lookup_in_response& resp);
+  static auto create_from(const core::operations::lookup_in_response& resp)
+    -> transaction_get_result;
 
   /** @internal */
   template<typename Content>
-  transaction_get_result& operator=(const transaction_get_result& other)
+  auto operator=(const transaction_get_result& other) -> transaction_get_result&
   {
     if (this != &other) {
       document_id_ = other.document_id_;
@@ -168,33 +170,33 @@ public:
    *
    * @return the id of this document.
    */
-  [[nodiscard]] const core::document_id& id() const
+  [[nodiscard]] auto id() const -> const core::document_id&
   {
     return document_id_;
   }
 
-  [[nodiscard]] const std::string& bucket() const
+  [[nodiscard]] auto bucket() const -> const std::string&
   {
     return document_id_.bucket();
   }
 
-  [[nodiscard]] const std::string& key() const
+  [[nodiscard]] auto key() const -> const std::string&
   {
     return document_id_.key();
   }
 
-  [[nodiscard]] const std::string& scope() const
+  [[nodiscard]] auto scope() const -> const std::string&
   {
     return document_id_.scope();
   }
 
-  [[nodiscard]] const std::string& collection() const
+  [[nodiscard]] auto collection() const -> const std::string&
   {
     return document_id_.collection();
   }
 
   /** @internal */
-  [[nodiscard]] transaction_links links() const
+  [[nodiscard]] auto links() const -> transaction_links
   {
     return links_;
   }
@@ -214,7 +216,7 @@ public:
    *
    * @return metadata for this document.
    */
-  [[nodiscard]] const std::optional<document_metadata>& metadata() const
+  [[nodiscard]] auto metadata() const -> const std::optional<document_metadata>&
   {
     return metadata_;
   }
@@ -224,14 +226,14 @@ public:
    *
    * @return the CAS for this document.
    */
-  [[nodiscard]] couchbase::cas cas() const
+  [[nodiscard]] auto cas() const -> couchbase::cas
   {
     return cas_;
   }
 
   /** @internal */
   template<typename OStream>
-  friend OStream& operator<<(OStream& os, const transaction_get_result document)
+  friend auto operator<<(OStream& os, const transaction_get_result document) -> OStream&
   {
     os << "transaction_get_result{id: " << document.id().key() << ", cas: " << document.cas_.value()
        << ", links_: " << document.links_ << "}";
@@ -244,7 +246,7 @@ public:
    * @return content of the document.
    */
   template<typename Content>
-  [[nodiscard]] Content content() const
+  [[nodiscard]] auto content() const -> Content
   {
     return codec::tao_json_serializer::deserialize<Content>(content_);
   }
@@ -254,7 +256,7 @@ public:
    *
    * @return content
    */
-  [[nodiscard]] const std::vector<std::byte>& content() const
+  [[nodiscard]] auto content() const -> const std::vector<std::byte>&
   {
     return content_;
   }

--- a/core/transactions/transaction_keyspace.cxx
+++ b/core/transactions/transaction_keyspace.cxx
@@ -44,8 +44,8 @@ transaction_keyspace::transaction_keyspace(const std::string& bucket_name)
 {
 }
 
-bool
-transaction_keyspace::valid()
+auto
+transaction_keyspace::valid() -> bool
 {
   return !bucket.empty() && !scope.empty() && !collection.empty();
 }

--- a/core/transactions/transaction_links.cxx
+++ b/core/transactions/transaction_links.cxx
@@ -16,8 +16,9 @@
 
 #include "transaction_links.hxx"
 
-std::ostream&
-couchbase::core::transactions::operator<<(std::ostream& os, const transaction_links& links)
+auto
+couchbase::core::transactions::operator<<(std::ostream& os,
+                                          const transaction_links& links) -> std::ostream&
 {
   os << "transaction_links{atr: " << links.atr_id_.value_or("none")
      << ", atr_bkt: " << links.atr_bucket_name_.value_or("none")

--- a/core/transactions/transaction_links.hxx
+++ b/core/transactions/transaction_links.hxx
@@ -135,109 +135,109 @@ public:
    * Note this doesn't guarantee an active transaction, as it may have expired and need rolling
    * back.
    */
-  [[nodiscard]] bool is_document_in_transaction() const
+  [[nodiscard]] auto is_document_in_transaction() const -> bool
   {
     return !!(atr_id_);
   }
-  [[nodiscard]] bool has_staged_content() const
+  [[nodiscard]] auto has_staged_content() const -> bool
   {
     return !!(staged_content_);
   }
-  [[nodiscard]] bool is_document_being_removed() const
+  [[nodiscard]] auto is_document_being_removed() const -> bool
   {
     return (!!op_ && *op_ == "remove");
   }
 
-  [[nodiscard]] bool is_document_being_inserted() const
+  [[nodiscard]] auto is_document_being_inserted() const -> bool
   {
     return (!!op_ && *op_ == "insert");
   }
 
-  [[nodiscard]] bool has_staged_write() const
+  [[nodiscard]] auto has_staged_write() const -> bool
   {
     return !!(staged_attempt_id_);
   }
 
-  [[nodiscard]] std::optional<std::string> atr_id() const
+  [[nodiscard]] auto atr_id() const -> std::optional<std::string>
   {
     return atr_id_;
   }
 
-  [[nodiscard]] std::optional<std::string> atr_bucket_name() const
+  [[nodiscard]] auto atr_bucket_name() const -> std::optional<std::string>
   {
     return atr_bucket_name_;
   }
 
-  [[nodiscard]] std::optional<std::string> atr_scope_name() const
+  [[nodiscard]] auto atr_scope_name() const -> std::optional<std::string>
   {
     return atr_scope_name_;
   }
 
-  [[nodiscard]] std::optional<std::string> atr_collection_name() const
+  [[nodiscard]] auto atr_collection_name() const -> std::optional<std::string>
   {
     return atr_collection_name_;
   }
 
-  [[nodiscard]] std::optional<std::string> staged_transaction_id() const
+  [[nodiscard]] auto staged_transaction_id() const -> std::optional<std::string>
   {
     return staged_transaction_id_;
   }
 
-  [[nodiscard]] std::optional<std::string> staged_attempt_id() const
+  [[nodiscard]] auto staged_attempt_id() const -> std::optional<std::string>
   {
     return staged_attempt_id_;
   }
 
-  [[nodiscard]] std::optional<std::string> staged_operation_id() const
+  [[nodiscard]] auto staged_operation_id() const -> std::optional<std::string>
   {
     return staged_operation_id_;
   }
 
-  [[nodiscard]] std::optional<std::string> cas_pre_txn() const
+  [[nodiscard]] auto cas_pre_txn() const -> std::optional<std::string>
   {
     return cas_pre_txn_;
   }
 
-  [[nodiscard]] std::optional<std::string> revid_pre_txn() const
+  [[nodiscard]] auto revid_pre_txn() const -> std::optional<std::string>
   {
     return revid_pre_txn_;
   }
 
-  [[nodiscard]] std::optional<std::uint32_t> exptime_pre_txn() const
+  [[nodiscard]] auto exptime_pre_txn() const -> std::optional<std::uint32_t>
   {
     return exptime_pre_txn_;
   }
 
-  [[nodiscard]] std::optional<std::string> op() const
+  [[nodiscard]] auto op() const -> std::optional<std::string>
   {
     return op_;
   }
 
-  [[nodiscard]] std::optional<std::string> crc32_of_staging() const
+  [[nodiscard]] auto crc32_of_staging() const -> std::optional<std::string>
   {
     return crc32_of_staging_;
   }
 
-  [[nodiscard]] std::vector<std::byte> staged_content() const
+  [[nodiscard]] auto staged_content() const -> std::vector<std::byte>
   {
     return staged_content_.value_or(std::vector<std::byte>{});
   }
 
-  [[nodiscard]] std::optional<tao::json::value> forward_compat() const
+  [[nodiscard]] auto forward_compat() const -> std::optional<tao::json::value>
   {
     return forward_compat_;
   }
 
-  [[nodiscard]] bool is_deleted() const
+  [[nodiscard]] auto is_deleted() const -> bool
   {
     return is_deleted_;
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const transaction_links& links);
+  friend auto operator<<(std::ostream& os, const transaction_links& links) -> std::ostream&;
 };
 
-std::ostream&
-operator<<(std::ostream& os, const transaction_links& links);
+auto
+operator<<(std::ostream& os, const transaction_links& links) -> std::ostream&;
 } // namespace couchbase::core::transactions
 
 template<>

--- a/core/transactions/transaction_options.cxx
+++ b/core/transactions/transaction_options.cxx
@@ -22,8 +22,9 @@
 
 namespace couchbase::transactions
 {
-transactions_config::built
+auto
 transaction_options::apply(const transactions_config::built& conf) const
+  -> transactions_config::built
 {
   auto query_config = conf.query_config;
   if (scan_consistency_) {
@@ -38,56 +39,57 @@ transaction_options::apply(const transactions_config::built& conf) const
            conf.cleanup_config };
 }
 
-transaction_options&
+auto
 transaction_options::test_factories(
   std::shared_ptr<core::transactions::attempt_context_testing_hooks> hooks,
-  std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks)
+  std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks) -> transaction_options&
 {
   attempt_context_hooks_ = hooks;
   cleanup_hooks_ = cleanup_hooks;
   return *this;
 }
 
-std::optional<transaction_keyspace>
-transaction_options::metadata_collection() const
+auto
+transaction_options::metadata_collection() const -> std::optional<transaction_keyspace>
 {
   return metadata_collection_;
 }
 
-transaction_options&
-transaction_options::durability_level(couchbase::durability_level level)
+auto
+transaction_options::durability_level(couchbase::durability_level level) -> transaction_options&
 {
   durability_ = level;
   return *this;
 }
 
-std::optional<couchbase::durability_level>
-transaction_options::durability_level() const
+auto
+transaction_options::durability_level() const -> std::optional<couchbase::durability_level>
 {
   return durability_;
 }
 
-transaction_options&
+auto
 transaction_options::scan_consistency(query_scan_consistency scan_consistency)
+  -> transaction_options&
 {
   scan_consistency_ = scan_consistency;
   return *this;
 }
 
-std::optional<query_scan_consistency>
-transaction_options::scan_consistency() const
+auto
+transaction_options::scan_consistency() const -> std::optional<query_scan_consistency>
 {
   return scan_consistency_;
 }
 
-std::optional<std::chrono::nanoseconds>
-transaction_options::timeout()
+auto
+transaction_options::timeout() -> std::optional<std::chrono::nanoseconds>
 {
   return timeout_;
 }
 
-transaction_options&
-transaction_options::metadata_collection(const couchbase::collection& coll)
+auto
+transaction_options::metadata_collection(const couchbase::collection& coll) -> transaction_options&
 {
   metadata_collection_.emplace(coll.bucket_name(), coll.scope_name(), coll.name());
   return *this;

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -91,9 +91,10 @@ transactions::create(
   return create(std::move(cluster), config.build(), std::move(cb));
 }
 
-std::future<std::pair<std::error_code, std::shared_ptr<transactions>>>
+auto
 transactions::create(core::cluster cluster,
                      const couchbase::transactions::transactions_config::built& config)
+  -> std::future<std::pair<std::error_code, std::shared_ptr<transactions>>>
 {
   auto barrier =
     std::make_shared<std::promise<std::pair<std::error_code, std::shared_ptr<transactions>>>>();
@@ -103,19 +104,20 @@ transactions::create(core::cluster cluster,
   return barrier->get_future();
 }
 
-std::future<std::pair<std::error_code, std::shared_ptr<transactions>>>
+auto
 transactions::create(core::cluster cluster,
                      const couchbase::transactions::transactions_config& config)
+  -> std::future<std::pair<std::error_code, std::shared_ptr<transactions>>>
 {
   return create(std::move(cluster), config.build());
 }
 
 template<typename Handler>
-::couchbase::transactions::transaction_result
+auto
 wrap_run(transactions& txns,
          const couchbase::transactions::transaction_options& config,
          std::size_t max_attempts,
-         Handler&& fn)
+         Handler&& fn) -> ::couchbase::transactions::transaction_result
 {
   transaction_context overall(txns, config);
   std::size_t attempts{ 0 };
@@ -163,22 +165,24 @@ wrap_run(transactions& txns,
   return overall.get_transaction_result();
 }
 
-::couchbase::transactions::transaction_result
-transactions::run(logic&& code)
+auto
+transactions::run(logic&& code) -> ::couchbase::transactions::transaction_result
 {
   couchbase::transactions::transaction_options config;
   return wrap_run(*this, config, max_attempts_, std::move(code));
 }
 
-::couchbase::transactions::transaction_result
-transactions::run(const couchbase::transactions::transaction_options& config, logic&& code)
+auto
+transactions::run(const couchbase::transactions::transaction_options& config,
+                  logic&& code) -> ::couchbase::transactions::transaction_result
 {
   return wrap_run(*this, config, max_attempts_, std::move(code));
 }
 
-std::pair<error, couchbase::transactions::transaction_result>
+auto
 transactions::run(couchbase::transactions::txn_logic&& code,
                   const couchbase::transactions::transaction_options& config)
+  -> std::pair<error, couchbase::transactions::transaction_result>
 {
   try {
     return { {}, wrap_run(*this, config, max_attempts_, std::move(code)) };

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -51,8 +51,8 @@ transactions_cleanup::transactions_cleanup(
   start();
 }
 
-static std::uint64_t
-byteswap64(std::uint64_t val)
+static auto
+byteswap64(std::uint64_t val) -> std::uint64_t
 {
   std::uint64_t ret = 0;
   for (std::size_t ii = 0; ii < sizeof(std::uint64_t); ii++) {
@@ -76,8 +76,8 @@ byteswap64(std::uint64_t val)
  * Want:        0x155CD21DA7580000   (1539336197457313792 in base10, an epoch
  * time in millionths of a second)
  */
-static std::uint64_t
-parse_mutation_cas(const std::string& cas)
+static auto
+parse_mutation_cas(const std::string& cas) -> std::uint64_t
 {
   if (cas.empty()) {
     return 0;
@@ -99,8 +99,8 @@ static const std::string FIELD_NUM_ATRS = "num_atrs";
 #define SAFETY_MARGIN_EXPIRY_MS 2000
 
 template<class R, class P>
-bool
-transactions_cleanup::interruptable_wait(std::chrono::duration<R, P> delay)
+auto
+transactions_cleanup::interruptable_wait(std::chrono::duration<R, P> delay) -> bool
 {
   // wait for specified time, _or_ until the condition variable changes
   std::unique_lock<std::mutex> lock(mutex_);
@@ -204,9 +204,10 @@ transactions_cleanup::clean_collection(
   }
 }
 
-const atr_cleanup_stats
+auto
 transactions_cleanup::handle_atr_cleanup(const core::document_id& atr_id,
                                          std::vector<transactions_cleanup_attempt>* results)
+  -> const atr_cleanup_stats
 {
   atr_cleanup_stats stats;
   auto atr = active_transaction_record::get_atr(cluster_, atr_id);
@@ -286,10 +287,10 @@ transactions_cleanup::create_client_record(
   }
 }
 
-const client_record_details
+auto
 transactions_cleanup::get_active_clients(
   const couchbase::transactions::transaction_keyspace& keyspace,
-  const std::string& uuid)
+  const std::string& uuid) -> const client_record_details
 {
   client_record_details details;
   // Write our client record, return details.
@@ -492,9 +493,10 @@ transactions_cleanup::remove_client_record_from_all_buckets(const std::string& u
   }
 }
 
-const atr_cleanup_stats
+auto
 transactions_cleanup::force_cleanup_atr(const core::document_id& atr_id,
                                         std::vector<transactions_cleanup_attempt>& results)
+  -> const atr_cleanup_stats
 {
   CB_LOST_ATTEMPT_CLEANUP_LOG_TRACE("starting force_cleanup_atr: atr_id {}", atr_id);
   return handle_atr_cleanup(atr_id, &results);

--- a/core/transactions/transactions_config.cxx
+++ b/core/transactions/transactions_config.cxx
@@ -58,8 +58,8 @@ transactions_config::transactions_config(const transactions_config& config)
 {
 }
 
-transactions_config&
-transactions_config::operator=(const transactions_config& c)
+auto
+transactions_config::operator=(const transactions_config& c) -> transactions_config&
 {
   if (this != &c) {
     level_ = c.level_;
@@ -73,8 +73,8 @@ transactions_config::operator=(const transactions_config& c)
   return *this;
 }
 
-transactions_config::built
-transactions_config::build() const
+auto
+transactions_config::build() const -> transactions_config::built
 {
   return { level_,
            timeout_,

--- a/core/transactions/uid_generator.cxx
+++ b/core/transactions/uid_generator.cxx
@@ -20,8 +20,8 @@
 
 // TODO: Remove this, and just use client directly
 
-std::string
-couchbase::core::transactions::uid_generator::next()
+auto
+couchbase::core::transactions::uid_generator::next() -> std::string
 {
   return core::uuid::to_string(core::uuid::random());
 }

--- a/core/transactions/uid_generator.hxx
+++ b/core/transactions/uid_generator.hxx
@@ -24,6 +24,6 @@ namespace couchbase::core::transactions
 class uid_generator
 {
 public:
-  static std::string next();
+  static auto next() -> std::string;
 };
 } // namespace couchbase::core::transactions

--- a/core/transactions/utils.cxx
+++ b/core/transactions/utils.cxx
@@ -21,28 +21,28 @@
 
 namespace couchbase::core::transactions
 {
-std::string
-collection_spec_from_id(const core::document_id& id)
+auto
+collection_spec_from_id(const core::document_id& id) -> std::string
 {
   std::string retval = id.scope();
   return retval.append(".").append(id.collection());
 }
 
-bool
-document_ids_equal(const core::document_id& id1, const core::document_id& id2)
+auto
+document_ids_equal(const core::document_id& id1, const core::document_id& id2) -> bool
 {
   return id1.key() == id2.key() && id1.bucket() == id2.bucket() && id1.scope() == id2.scope() &&
          id1.collection() == id2.collection();
 }
 
-std::string
-jsonify(const tao::json::value& obj)
+auto
+jsonify(const tao::json::value& obj) -> std::string
 {
   return core::utils::json::generate(obj);
 }
 
-std::uint64_t
-now_ns_from_vbucket(const tao::json::value& vbucket)
+auto
+now_ns_from_vbucket(const tao::json::value& vbucket) -> std::uint64_t
 {
   std::string now_str = vbucket.at("HLC").at("now").get_string();
   return stoull(now_str, nullptr, 10) * 1000000000;
@@ -85,16 +85,17 @@ validate_operation_result(result& res, bool ignore_subdoc_errors)
   }
 }
 
-result
-wrap_operation_future(std::future<result>& fut, bool ignore_subdoc_errors)
+auto
+wrap_operation_future(std::future<result>& fut, bool ignore_subdoc_errors) -> result
 {
   auto res = fut.get();
   validate_operation_result(res, ignore_subdoc_errors);
   return res;
 }
 
-std::optional<error_class>
+auto
 wait_for_hook(std::function<void(utils::movable_function<void(std::optional<error_class>)>)> hook)
+  -> std::optional<error_class>
 {
   auto hook_barrier = std::make_shared<std::promise<std::optional<error_class>>>();
   auto hook_future = hook_barrier->get_future();
@@ -105,15 +106,16 @@ wait_for_hook(std::function<void(utils::movable_function<void(std::optional<erro
 }
 
 template<>
-bool
-is_error(const core::operations::mutate_in_response& resp)
+auto
+is_error(const core::operations::mutate_in_response& resp) -> bool
 {
   return resp.ctx.ec() || resp.ctx.first_error_index();
 }
 
 template<>
-std::optional<error_class>
+auto
 error_class_from_response_extras(const core::operations::mutate_in_response& resp)
+  -> std::optional<error_class>
 {
   if (!resp.ctx.first_error_index()) {
     return {};
@@ -128,10 +130,10 @@ error_class_from_response_extras(const core::operations::mutate_in_response& res
   return FAIL_OTHER;
 }
 
-core::document_id
+auto
 atr_id_from_bucket_and_key(const couchbase::transactions::transactions_config::built& cfg,
                            const std::string& bucket,
-                           const std::string& key)
+                           const std::string& key) -> core::document_id
 {
   if (cfg.metadata_collection) {
     return { cfg.metadata_collection->bucket,

--- a/core/transactions/waitable_op_list.hxx
+++ b/core/transactions/waitable_op_list.hxx
@@ -45,7 +45,7 @@ struct attempt_mode {
   {
   }
 
-  bool is_query()
+  auto is_query() -> bool
   {
     return mode == modes::QUERY;
   }
@@ -79,7 +79,7 @@ public:
     // we have the lock.  Block all further ops
     allow_ops_ = false;
   }
-  attempt_mode get_mode()
+  auto get_mode() -> attempt_mode
   {
     std::unique_lock<std::mutex> lock(mutex_);
     if (mode_.mode == attempt_mode::modes::KV) {

--- a/core/utils/binary.cxx
+++ b/core/utils/binary.cxx
@@ -19,8 +19,8 @@
 
 namespace couchbase::core::utils
 {
-binary
-to_binary(std::string_view value) noexcept
+auto
+to_binary(std::string_view value) noexcept -> binary
 {
   return to_binary(value.data(), value.size());
 }

--- a/core/utils/binary.hxx
+++ b/core/utils/binary.hxx
@@ -28,8 +28,8 @@ namespace couchbase::core::utils
 using binary = std::vector<std::byte>;
 
 template<typename T>
-[[nodiscard]] binary
-to_binary(const T* data, const std::size_t size) noexcept
+[[nodiscard]] auto
+to_binary(const T* data, const std::size_t size) noexcept -> binary
 {
   static_assert(sizeof(T) == 1);
   binary copy;
@@ -40,12 +40,12 @@ to_binary(const T* data, const std::size_t size) noexcept
   return copy;
 }
 
-[[nodiscard]] binary
-to_binary(std::string_view value) noexcept;
+[[nodiscard]] auto
+to_binary(std::string_view value) noexcept -> binary;
 
 template<typename InputIterator, typename OutputIterator>
-OutputIterator
-to_binary(InputIterator first, InputIterator last, OutputIterator result) noexcept
+auto
+to_binary(InputIterator first, InputIterator last, OutputIterator result) noexcept -> OutputIterator
 {
   return std::transform(first, last, result, [](auto e) {
     return static_cast<std::byte>(e);
@@ -53,8 +53,8 @@ to_binary(InputIterator first, InputIterator last, OutputIterator result) noexce
 }
 
 template<typename Container, typename OutputIterator>
-OutputIterator
-to_binary(Container container, OutputIterator result) noexcept
+auto
+to_binary(Container container, OutputIterator result) noexcept -> OutputIterator
 {
   return to_binary(std::begin(container), std::end(container), result);
 }

--- a/core/utils/byteswap.hxx
+++ b/core/utils/byteswap.hxx
@@ -21,16 +21,16 @@
 
 namespace couchbase::core::utils
 {
-static constexpr std::uint16_t
-byte_swap(std::uint16_t value)
+static constexpr auto
+byte_swap(std::uint16_t value) -> std::uint16_t
 {
   auto hi = static_cast<std::uint16_t>(value << 8U);
   auto lo = static_cast<std::uint16_t>(value >> 8U);
   return hi | lo;
 }
 
-static constexpr std::uint32_t
-byte_swap(std::uint32_t value)
+static constexpr auto
+byte_swap(std::uint32_t value) -> std::uint32_t
 {
   std::uint32_t byte0 = value & 0x000000ffU;
   std::uint32_t byte1 = value & 0x0000ff00U;
@@ -39,8 +39,8 @@ byte_swap(std::uint32_t value)
   return (byte0 << 24) | (byte1 << 8) | (byte2 >> 8) | (byte3 >> 24);
 }
 
-static constexpr std::uint64_t
-byte_swap(std::uint64_t value)
+static constexpr auto
+byte_swap(std::uint64_t value) -> std::uint64_t
 {
   std::uint64_t hi = byte_swap(static_cast<std::uint32_t>(value));
   std::uint32_t lo = byte_swap(static_cast<std::uint32_t>(value >> 32));

--- a/core/utils/connection_string.cxx
+++ b/core/utils/connection_string.cxx
@@ -502,8 +502,8 @@ extract_options(connection_string& connstr)
   }
 }
 
-connection_string
-parse_connection_string(const std::string& input, cluster_options options)
+auto
+parse_connection_string(const std::string& input, cluster_options options) -> connection_string
 {
   connection_string res{};
   res.options = std::move(options);

--- a/core/utils/connection_string.hxx
+++ b/core/utils/connection_string.hxx
@@ -46,12 +46,12 @@ struct connection_string {
     address_type type;
     bootstrap_mode mode{ bootstrap_mode::unspecified };
 
-    bool operator==(const node& rhs) const
+    auto operator==(const node& rhs) const -> bool
     {
       return address == rhs.address && port == rhs.port && type == rhs.type && mode == rhs.mode;
     }
 
-    bool operator!=(const node& rhs) const
+    auto operator!=(const node& rhs) const -> bool
     {
       return !(rhs == *this);
     }
@@ -72,6 +72,7 @@ struct connection_string {
   std::optional<std::string> error{};
 };
 
-connection_string
-parse_connection_string(const std::string& input, cluster_options options = {});
+auto
+parse_connection_string(const std::string& input,
+                        cluster_options options = {}) -> connection_string;
 } // namespace couchbase::core::utils

--- a/core/utils/crc32.hxx
+++ b/core/utils/crc32.hxx
@@ -44,8 +44,8 @@ static const std::uint32_t crc32tab[256] = {
   0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
 };
 
-static inline std::uint32_t
-hash_crc32(const char* key, size_t key_length)
+static inline auto
+hash_crc32(const char* key, std::size_t key_length) -> std::uint32_t
 {
   std::uint32_t crc = UINT32_MAX;
 
@@ -56,8 +56,8 @@ hash_crc32(const char* key, size_t key_length)
   return ((~crc) >> 16) & 0x7fff;
 }
 
-static inline std::uint32_t
-hash_crc32(const std::byte* key, size_t key_length)
+static inline auto
+hash_crc32(const std::byte* key, std::size_t key_length) -> std::uint32_t
 {
   return hash_crc32(reinterpret_cast<const char*>(key), key_length);
 }

--- a/core/utils/duration_parser.cxx
+++ b/core/utils/duration_parser.cxx
@@ -22,8 +22,8 @@ namespace couchbase::core::utils
 /**
  * leading_int consumes the leading [0-9]* from s.
  */
-static bool
-leading_int(std::string& s, std::int64_t& v)
+static auto
+leading_int(std::string& s, std::int64_t& v) -> bool
 {
   v = 0;
   std::size_t i = 0;
@@ -93,8 +93,8 @@ leading_fraction(std::string& s, std::int64_t& x, std::uint32_t& scale)
   s = s.substr(i);
 }
 
-std::chrono::nanoseconds
-parse_duration(const std::string& text)
+auto
+parse_duration(const std::string& text) -> std::chrono::nanoseconds
 {
   // [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
   std::string s = text;

--- a/core/utils/duration_parser.hxx
+++ b/core/utils/duration_parser.hxx
@@ -40,6 +40,6 @@ public:
  *
  * Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
  */
-std::chrono::nanoseconds
-parse_duration(const std::string& text);
+auto
+parse_duration(const std::string& text) -> std::chrono::nanoseconds;
 } // namespace couchbase::core::utils

--- a/core/utils/join_strings.hxx
+++ b/core/utils/join_strings.hxx
@@ -26,8 +26,8 @@ namespace couchbase::core::utils
  * Joins a list of strings together.
  */
 template<typename Range>
-std::string
-join_strings(const Range& values, const std::string& sep)
+auto
+join_strings(const Range& values, const std::string& sep) -> std::string
 {
   std::stringstream stream;
   auto sentinel = std::end(values);
@@ -47,8 +47,8 @@ join_strings(const Range& values, const std::string& sep)
  */
 template<typename Range>
 
-std::string
-join_strings_fmt(const Range& values, const std::string& sep)
+auto
+join_strings_fmt(const Range& values, const std::string& sep) -> std::string
 {
   std::stringstream stream;
   auto sentinel = std::end(values);

--- a/core/utils/json.cxx
+++ b/core/utils/json.cxx
@@ -47,14 +47,14 @@ struct last_key_wins : Consumer {
   }
 };
 
-tao::json::value
-parse(std::string_view input)
+auto
+parse(std::string_view input) -> tao::json::value
 {
   return tao::json::from_string<utils::json::last_key_wins>(input);
 }
 
-tao::json::value
-parse(const json_string& input)
+auto
+parse(const json_string& input) -> tao::json::value
 {
   if (input.is_string()) {
     return parse(input.str());
@@ -64,21 +64,21 @@ parse(const json_string& input)
   return {};
 }
 
-tao::json::value
-parse(const char* input, std::size_t size)
+auto
+parse(const char* input, std::size_t size) -> tao::json::value
 {
   return tao::json::from_string<utils::json::last_key_wins>(input, size);
 }
 
-tao::json::value
-parse_binary(const std::vector<std::byte>& input)
+auto
+parse_binary(const std::vector<std::byte>& input) -> tao::json::value
 {
   return tao::json::from_string<utils::json::last_key_wins>(
     reinterpret_cast<const char*>(input.data()), input.size());
 }
 
-std::string
-generate(const tao::json::value& object)
+auto
+generate(const tao::json::value& object) -> std::string
 {
   return tao::json::to_string(object);
 }
@@ -286,8 +286,8 @@ public:
   }
 };
 
-std::vector<std::byte>
-generate_binary(const tao::json::value& object)
+auto
+generate_binary(const tao::json::value& object) -> std::vector<std::byte>
 {
   std::vector<std::byte> out;
   tao::json::events::transformer<to_byte_vector> consumer(out);

--- a/core/utils/json.hxx
+++ b/core/utils/json.hxx
@@ -23,21 +23,21 @@
 
 namespace couchbase::core::utils::json
 {
-tao::json::value
-parse(std::string_view input);
+auto
+parse(std::string_view input) -> tao::json::value;
 
-tao::json::value
-parse(const json_string& input);
+auto
+parse(const json_string& input) -> tao::json::value;
 
-tao::json::value
-parse(const char* input, std::size_t size);
+auto
+parse(const char* input, std::size_t size) -> tao::json::value;
 
-std::string
-generate(const tao::json::value& object);
+auto
+generate(const tao::json::value& object) -> std::string;
 
-tao::json::value
-parse_binary(const std::vector<std::byte>& input);
+auto
+parse_binary(const std::vector<std::byte>& input) -> tao::json::value;
 
-std::vector<std::byte>
-generate_binary(const tao::json::value& object);
+auto
+generate_binary(const tao::json::value& object) -> std::vector<std::byte>;
 } // namespace couchbase::core::utils::json

--- a/core/utils/json_streaming_lexer.cxx
+++ b/core/utils/json_streaming_lexer.cxx
@@ -34,8 +34,8 @@ noop_on_complete(std::error_code /* ec */,
 { /* do nothing */
 }
 
-static stream_control
-noop_on_row(std::string&& /* row */)
+static auto
+noop_on_row(std::string&& /* row */) -> stream_control
 {
   return stream_control::next_row;
 }
@@ -51,9 +51,9 @@ struct streaming_lexer_impl {
   }
 
   streaming_lexer_impl(streaming_lexer_impl& other) = delete;
-  const streaming_lexer_impl& operator=(const streaming_lexer_impl& other) = delete;
+  auto operator=(const streaming_lexer_impl& other) -> const streaming_lexer_impl& = delete;
   streaming_lexer_impl(streaming_lexer_impl&& other) noexcept = delete;
-  const streaming_lexer_impl& operator=(streaming_lexer_impl&& other) = delete;
+  auto operator=(streaming_lexer_impl&& other) -> const streaming_lexer_impl& = delete;
 
   ~streaming_lexer_impl()
   {
@@ -82,7 +82,8 @@ struct streaming_lexer_impl {
     state->data = STATE_MARKER_ROOT;
   }
 
-  [[nodiscard]] std::string_view get_buffer_region(std::size_t pos, std::size_t desired = 0) const
+  [[nodiscard]] auto get_buffer_region(std::size_t pos,
+                                       std::size_t desired = 0) const -> std::string_view
   {
     if (min_pos_ > pos) {
       /* swallowed */
@@ -140,8 +141,8 @@ struct streaming_lexer_impl {
 };
 } // namespace detail
 
-static std::error_code
-convert_status(jsonsl_error_t error)
+static auto
+convert_status(jsonsl_error_t error) -> std::error_code
 {
   switch (error) {
     case JSONSL_ERROR_SUCCESS:
@@ -231,11 +232,11 @@ convert_status(jsonsl_error_t error)
   return errc::streaming_json_lexer::generic;
 }
 
-static int
+static auto
 error_callback(jsonsl_t lexer,
                jsonsl_error_t error,
                struct jsonsl_state_st* /* state */,
-               jsonsl_char_t* /* at */)
+               jsonsl_char_t* /* at */) -> int
 {
   auto* impl = static_cast<detail::streaming_lexer_impl*>(lexer->data);
 

--- a/core/utils/keyspace.hxx
+++ b/core/utils/keyspace.hxx
@@ -23,8 +23,8 @@
 namespace couchbase::core::utils
 {
 template<typename Request>
-static bool
-check_query_management_request(const Request& req)
+static auto
+check_query_management_request(const Request& req) -> bool
 {
   // if there is a query_context, then bucket and scope will be ignored
   if (req.query_ctx.has_value()) {
@@ -38,8 +38,8 @@ check_query_management_request(const Request& req)
 }
 
 template<typename Request>
-static std::string
-build_keyspace(const Request& req)
+static auto
+build_keyspace(const Request& req) -> std::string
 {
   // keyspace is just the collection if we have a query_context.
   if (req.query_ctx.has_value()) {

--- a/core/utils/movable_function.hxx
+++ b/core/utils/movable_function.hxx
@@ -63,10 +63,10 @@ class movable_function : public std::function<Signature>
     }
 
     wrapper(wrapper&& /* other */) noexcept = default;
-    wrapper& operator=(wrapper&& /* other */) noexcept = default;
+    auto operator=(wrapper&& /* other */) noexcept -> wrapper& = default;
 
     wrapper(const wrapper& other) = default;
-    wrapper& operator=(const wrapper& /* other */) = default;
+    auto operator=(const wrapper& /* other */) -> wrapper& = default;
 
     template<typename... Args>
     auto operator()(Args&&... args)
@@ -96,21 +96,21 @@ public:
     other = nullptr;
   }
 
-  movable_function& operator=(movable_function&& other) noexcept
+  auto operator=(movable_function&& other) noexcept -> movable_function&
   {
     base::operator=(std::move(static_cast<base&&>(other)));
     other = nullptr;
     return *this;
   }
 
-  movable_function& operator=(std::nullptr_t /* other */)
+  auto operator=(std::nullptr_t /* other */) -> movable_function&
   {
     base::operator=(nullptr);
     return *this;
   }
 
   template<typename Functor>
-  movable_function& operator=(Functor&& f)
+  auto operator=(Functor&& f) -> movable_function&
   {
     base::operator=(wrapper<Functor>{ std::forward<Functor>(f) });
     return *this;

--- a/core/utils/name_codec.hxx
+++ b/core/utils/name_codec.hxx
@@ -23,7 +23,7 @@
 namespace couchbase::core::utils
 {
 struct analytics {
-  static std::string uncompound_name(const std::string& name)
+  static auto uncompound_name(const std::string& name) -> std::string
   {
     std::stringstream ss;
     ss << '`';

--- a/core/utils/split_string.cxx
+++ b/core/utils/split_string.cxx
@@ -21,8 +21,8 @@
 
 namespace couchbase::core::utils
 {
-std::vector<std::string>
-split_string(const std::string& input, char delimiter)
+auto
+split_string(const std::string& input, char delimiter) -> std::vector<std::string>
 {
   std::vector<std::string> elements;
   std::stringstream stream(input);

--- a/core/utils/split_string.hxx
+++ b/core/utils/split_string.hxx
@@ -22,6 +22,6 @@
 
 namespace couchbase::core::utils
 {
-std::vector<std::string>
-split_string(const std::string& input, char delimiter);
+auto
+split_string(const std::string& input, char delimiter) -> std::vector<std::string>;
 } // namespace couchbase::core::utils

--- a/core/utils/unsigned_leb128.hxx
+++ b/core/utils/unsigned_leb128.hxx
@@ -49,8 +49,9 @@ struct leb_128_no_throw {
  *          leb128 data.
  */
 template<class T>
-typename std::enable_if_t<std::is_unsigned_v<T>, std::pair<T, gsl::span<std::byte>>>
-decode_unsigned_leb128(gsl::span<std::byte> buf, struct leb_128_no_throw /* unused */)
+auto
+decode_unsigned_leb128(gsl::span<std::byte> buf, struct leb_128_no_throw /* unused */) ->
+  typename std::enable_if_t<std::is_unsigned_v<T>, std::pair<T, gsl::span<std::byte>>>
 {
   T rv = std::to_integer<T>(buf[0] & std::byte{ 0b0111'1111 });
   std::size_t end = 0;
@@ -86,8 +87,9 @@ decode_unsigned_leb128(gsl::span<std::byte> buf, struct leb_128_no_throw /* unus
  *         a stop byte.
  */
 template<class T>
-typename std::enable_if_t<std::is_unsigned_v<T>, std::pair<T, gsl::span<std::byte>>>
-decode_unsigned_leb128(gsl::span<std::byte> buf)
+auto
+decode_unsigned_leb128(gsl::span<std::byte> buf) ->
+  typename std::enable_if_t<std::is_unsigned_v<T>, std::pair<T, gsl::span<std::byte>>>
 {
   if (!buf.empty()) {
     auto rv = decode_unsigned_leb128<T>(buf, leb_128_no_throw{});
@@ -103,8 +105,9 @@ decode_unsigned_leb128(gsl::span<std::byte> buf)
  * @return a buffer to the data after the leb128 prefix
  */
 template<class T>
-typename std::enable_if_t<std::is_unsigned_v<T>, gsl::span<std::byte>>
-skip_unsigned_leb128(gsl::span<std::byte> buf)
+auto
+skip_unsigned_leb128(gsl::span<std::byte> buf) ->
+  typename std::enable_if_t<std::is_unsigned_v<T>, gsl::span<std::byte>>
 {
   return decode_unsigned_leb128<T>(buf).second;
 }
@@ -141,32 +144,32 @@ public:
     }
   }
 
-  [[nodiscard]] std::string get() const
+  [[nodiscard]] auto get() const -> std::string
   {
     return { begin(), end() };
   }
 
-  [[nodiscard]] const std::byte* begin() const
+  [[nodiscard]] auto begin() const -> const std::byte*
   {
     return encoded_data_.data();
   }
 
-  [[nodiscard]] const std::byte* end() const
+  [[nodiscard]] auto end() const -> const std::byte*
   {
     return encoded_data_.data() + encoded_size_;
   }
 
-  [[nodiscard]] const std::byte* data() const
+  [[nodiscard]] auto data() const -> const std::byte*
   {
     return encoded_data_.data();
   }
 
-  [[nodiscard]] std::size_t size() const
+  [[nodiscard]] auto size() const -> std::size_t
   {
     return encoded_size_;
   }
 
-  constexpr static std::size_t get_max_size()
+  constexpr static auto get_max_size() -> std::size_t
   {
     return max_size;
   }

--- a/core/utils/url_codec.cxx
+++ b/core/utils/url_codec.cxx
@@ -28,8 +28,8 @@ namespace couchbase::core::utils::string_codec
 
 namespace priv
 {
-inline bool
-is_legal_uri_char(char c)
+inline auto
+is_legal_uri_char(char c) -> bool
 {
   auto uc = static_cast<unsigned char>(c);
   if ((isalpha(uc) != 0) || (isdigit(uc) != 0)) {
@@ -66,8 +66,8 @@ is_legal_uri_char(char c)
 }
 
 template<typename T>
-inline bool
-is_already_escape(T first, T last)
+inline auto
+is_already_escape(T first, T last) -> bool
 {
   ++first; // ignore '%'
   std::size_t jj = 0;
@@ -81,8 +81,8 @@ is_already_escape(T first, T last)
 } // namespace priv
 
 template<typename Ti, typename To>
-bool
-url_encode(Ti first, Ti last, To& o, bool check_encoded = true)
+auto
+url_encode(Ti first, Ti last, To& o, bool check_encoded = true) -> bool
 {
   // If re-encoding detection is enabled, this flag indicates not to
   // re-encode
@@ -127,14 +127,14 @@ url_encode(Ti first, Ti last, To& o, bool check_encoded = true)
 }
 
 template<typename Tin, typename Tout>
-bool
-url_encode(const Tin& in, Tout& out)
+auto
+url_encode(const Tin& in, Tout& out) -> bool
 {
   return url_encode(in.begin(), in.end(), out);
 }
 
-std::string
-url_encode(const std::string& src)
+auto
+url_encode(const std::string& src) -> std::string
 {
   std::string dst{};
   url_encode(src.begin(), src.end(), dst);
@@ -142,8 +142,8 @@ url_encode(const std::string& src)
 }
 
 template<typename Ti, typename To>
-bool
-url_decode(Ti first, Ti last, To out, std::size_t& nout)
+auto
+url_decode(Ti first, Ti last, To out, std::size_t& nout) -> bool
 {
   for (; first != last && *first != '\0'; ++first) {
     if (*first == '%') {
@@ -178,8 +178,8 @@ url_decode(Ti first, Ti last, To out, std::size_t& nout)
   return true;
 }
 
-std::string
-url_decode(const std::string& src)
+auto
+url_decode(const std::string& src) -> std::string
 {
   std::string dst(src.size(), '\0');
   std::size_t n = 0;
@@ -224,8 +224,8 @@ form_encode(Ti first, Ti last, To& out)
   }
 }
 
-std::string
-form_encode(const std::string& src)
+auto
+form_encode(const std::string& src) -> std::string
 {
   std::string dst;
   form_encode(src.begin(), src.end(), dst);
@@ -234,8 +234,8 @@ form_encode(const std::string& src)
 
 namespace v2
 {
-bool
-should_escape(char c, encoding mode)
+auto
+should_escape(char c, encoding mode) -> bool
 {
   // §2.3 Unreserved characters (alphanum)
   if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')) {
@@ -354,8 +354,8 @@ should_escape(char c, encoding mode)
 
 constexpr auto upper_hex = "0123456789ABCDEF";
 
-std::string
-escape(const std::string& s, encoding mode)
+auto
+escape(const std::string& s, encoding mode) -> std::string
 {
   std::size_t space_count{ 0 };
   std::size_t hex_count{ 0 };

--- a/core/utils/url_codec.hxx
+++ b/core/utils/url_codec.hxx
@@ -6,14 +6,14 @@
 
 namespace couchbase::core::utils::string_codec
 {
-std::string
-url_decode(const std::string& src);
+auto
+url_decode(const std::string& src) -> std::string;
 
-std::string
-url_encode(const std::string& src);
+auto
+url_encode(const std::string& src) -> std::string;
 
-std::string
-form_encode(const std::string& src);
+auto
+form_encode(const std::string& src) -> std::string;
 
 namespace v2
 {
@@ -27,8 +27,8 @@ enum class encoding {
   encode_fragment,
 };
 
-std::string
-escape(const std::string& s, encoding mode);
+auto
+escape(const std::string& s, encoding mode) -> std::string;
 
 /**
  * Escapes the string so it can be safely placed inside a URL query.
@@ -36,8 +36,8 @@ escape(const std::string& s, encoding mode);
  * @param s
  * @return
  */
-inline std::string
-query_escape(const std::string& s)
+inline auto
+query_escape(const std::string& s) -> std::string
 {
   return escape(s, encoding::encode_query_component);
 }
@@ -46,14 +46,14 @@ query_escape(const std::string& s)
  * Escapes the string so it can be safely placed inside a URL path segment, replacing special
  * characters (including /) with %XX sequences as needed.
  */
-inline std::string
-path_escape(const std::string& s)
+inline auto
+path_escape(const std::string& s) -> std::string
 {
   return escape(s, encoding::encode_path_segment);
 }
 
-inline std::string
-form_encode(const std::map<std::string, std::string>& values)
+inline auto
+form_encode(const std::map<std::string, std::string>& values) -> std::string
 {
   std::stringstream ss;
   bool first{ true };

--- a/couchbase/codec/codec_flags.hxx
+++ b/couchbase/codec/codec_flags.hxx
@@ -54,8 +54,8 @@ enum class common_flags : std::uint32_t {
  * @param flags the flags to shift.
  * @return an integer having the common flags set.
  */
-constexpr std::uint32_t
-create_common_flags(common_flags flags)
+constexpr auto
+create_common_flags(common_flags flags) -> std::uint32_t
 {
   return static_cast<std::uint32_t>(flags) << 24U;
 }
@@ -68,8 +68,8 @@ create_common_flags(common_flags flags)
  * @param flags the flags to check.
  * @return only the common flags simple representation (8 bits).
  */
-constexpr common_flags
-extract_common_flags(std::uint32_t flags)
+constexpr auto
+extract_common_flags(std::uint32_t flags) -> common_flags
 {
   switch (auto value = static_cast<common_flags>(flags >> 24U)) {
     case common_flags::client_specific:
@@ -92,8 +92,8 @@ extract_common_flags(std::uint32_t flags)
  * @param flags the flags to check.
  * @return true if set, false otherwise.
  */
-constexpr bool
-has_common_flags(std::uint32_t flags)
+constexpr auto
+has_common_flags(std::uint32_t flags) -> bool
 {
   return extract_common_flags(flags) != common_flags::reserved;
 }
@@ -106,8 +106,8 @@ has_common_flags(std::uint32_t flags)
  * @param expected_common_flag the expected common flags format bits
  * @return true if common flags bits are set and correspond to expected_common_flag format
  */
-constexpr bool
-has_common_flags(std::uint32_t flags, std::uint32_t expected_common_flag)
+constexpr auto
+has_common_flags(std::uint32_t flags, std::uint32_t expected_common_flag) -> bool
 {
   return has_common_flags(flags) && (flags & common_format_mask) == expected_common_flag;
 }
@@ -120,8 +120,8 @@ has_common_flags(std::uint32_t flags, std::uint32_t expected_common_flag)
  * @param expected_common_flag the expected common flags enum value
  * @return true if common flags bits are set and correspond to expected_common_flag format
  */
-constexpr bool
-has_common_flags(std::uint32_t flags, common_flags expected_common_flag)
+constexpr auto
+has_common_flags(std::uint32_t flags, common_flags expected_common_flag) -> bool
 {
   return has_common_flags(flags) &&
          (flags & common_format_mask) == create_common_flags(expected_common_flag);
@@ -136,8 +136,8 @@ has_common_flags(std::uint32_t flags, common_flags expected_common_flag)
  * @param flags the flags to check.
  * @return true if compression set, false otherwise.
  */
-constexpr bool
-has_compression_flags(std::uint32_t flags)
+constexpr auto
+has_compression_flags(std::uint32_t flags) -> bool
 {
   return (flags >> 29U) > 0;
 }

--- a/couchbase/codec/raw_json_transcoder.hxx
+++ b/couchbase/codec/raw_json_transcoder.hxx
@@ -33,8 +33,8 @@ namespace couchbase
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
 namespace core::utils
 {
-std::vector<std::byte>
-to_binary(std::string_view value) noexcept;
+auto
+to_binary(std::string_view value) noexcept -> std::vector<std::byte>;
 } // namespace core::utils
 #endif
 

--- a/couchbase/codec/raw_string_transcoder.hxx
+++ b/couchbase/codec/raw_string_transcoder.hxx
@@ -33,8 +33,8 @@ namespace couchbase
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
 namespace core::utils
 {
-std::vector<std::byte>
-to_binary(std::string_view value) noexcept;
+auto
+to_binary(std::string_view value) noexcept -> std::vector<std::byte>;
 } // namespace core::utils
 #endif
 

--- a/couchbase/codec/tao_json_serializer.hxx
+++ b/couchbase/codec/tao_json_serializer.hxx
@@ -28,11 +28,11 @@ namespace couchbase
 #ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
 namespace core::utils::json
 {
-std::vector<std::byte>
-generate_binary(const tao::json::value& object);
+auto
+generate_binary(const tao::json::value& object) -> std::vector<std::byte>;
 
-tao::json::value
-parse_binary(const std::vector<std::byte>& input);
+auto
+parse_binary(const std::vector<std::byte>& input) -> tao::json::value;
 } // namespace core::utils::json
 #endif
 

--- a/couchbase/management/analytics_link.hxx
+++ b/couchbase/management/analytics_link.hxx
@@ -74,7 +74,7 @@ struct analytics_link {
    *
    * @return the link type
    */
-  [[nodiscard]] virtual analytics_link_type link_type() const = 0;
+  [[nodiscard]] virtual auto link_type() const -> analytics_link_type = 0;
 
   analytics_link() = default;
   analytics_link(std::string name, std::string dataverse_name);
@@ -110,7 +110,7 @@ struct couchbase_remote_analytics_link : analytics_link {
   std::optional<std::string> username{};
   std::optional<std::string> password{};
 
-  [[nodiscard]] analytics_link_type link_type() const override
+  [[nodiscard]] auto link_type() const -> analytics_link_type override
   {
     return analytics_link_type::couchbase_remote;
   }
@@ -156,7 +156,7 @@ struct s3_external_analytics_link : analytics_link {
   std::optional<std::string> session_token{};
   std::optional<std::string> service_endpoint{};
 
-  [[nodiscard]] analytics_link_type link_type() const override
+  [[nodiscard]] auto link_type() const -> analytics_link_type override
   {
     return analytics_link_type::s3_external;
   }
@@ -200,7 +200,7 @@ struct azure_blob_external_analytics_link : analytics_link {
   std::optional<std::string> blob_endpoint{};
   std::optional<std::string> endpoint_suffix{};
 
-  [[nodiscard]] analytics_link_type link_type() const override
+  [[nodiscard]] auto link_type() const -> analytics_link_type override
   {
     return analytics_link_type::azure_external;
   }

--- a/couchbase/metrics/meter.hxx
+++ b/couchbase/metrics/meter.hxx
@@ -29,11 +29,11 @@ public:
   value_recorder() = default;
   value_recorder(const value_recorder& other) = default;
   value_recorder(value_recorder&& other) = default;
-  value_recorder& operator=(const value_recorder& other) = default;
-  value_recorder& operator=(value_recorder&& other) = default;
+  auto operator=(const value_recorder& other) -> value_recorder& = default;
+  auto operator=(value_recorder&& other) -> value_recorder& = default;
   virtual ~value_recorder() = default;
 
-  virtual void record_value(std::int64_t value) = 0;
+  virtual void record_value(int64_t value) = 0;
 };
 
 class meter
@@ -42,8 +42,8 @@ public:
   meter() = default;
   meter(const meter& other) = default;
   meter(meter&& other) = default;
-  meter& operator=(const meter& other) = default;
-  meter& operator=(meter&& other) = default;
+  auto operator=(const meter& other) -> meter& = default;
+  auto operator=(meter&& other) -> meter& = default;
   virtual ~meter() = default;
 
   /**
@@ -63,9 +63,9 @@ public:
     /* do nothing */
   }
 
-  virtual std::shared_ptr<value_recorder> get_value_recorder(
-    const std::string& name,
-    const std::map<std::string, std::string>& tags) = 0;
+  virtual auto get_value_recorder(const std::string& name,
+                                  const std::map<std::string, std::string>& tags)
+    -> std::shared_ptr<value_recorder> = 0;
 };
 
 } // namespace couchbase::metrics

--- a/couchbase/metrics/otel_meter.hxx
+++ b/couchbase/metrics/otel_meter.hxx
@@ -102,9 +102,8 @@ public:
   {
   }
 
-  std::shared_ptr<value_recorder> get_value_recorder(
-    const std::string& name,
-    const std::map<std::string, std::string>& tags) override
+  auto get_value_recorder(const std::string& name, const std::map<std::string, std::string>& tags)
+    -> std::shared_ptr<value_recorder> override
   {
     // first look up the histogram, in case we already have it...
     std::scoped_lock<std::mutex> lock(mutex_);

--- a/couchbase/subdoc/counter.hxx
+++ b/couchbase/subdoc/counter.hxx
@@ -73,7 +73,7 @@ private:
   friend couchbase::mutate_in_specs;
 #endif
 
-  counter(std::string path, std::int64_t value)
+  counter(std::string path, int64_t value)
     : path_(std::move(path))
     , delta_{ value }
   {
@@ -82,7 +82,7 @@ private:
   void encode(core::impl::subdoc::command_bundle& bundle) const;
 
   std::string path_;
-  std::int64_t delta_;
+  int64_t delta_;
   bool xattr_{ false };
   bool create_path_{ false };
 };

--- a/couchbase/tracing/otel_tracer.hxx
+++ b/couchbase/tracing/otel_tracer.hxx
@@ -62,9 +62,8 @@ public:
   {
   }
 
-  std::shared_ptr<couchbase::tracing::request_span> start_span(
-    std::string name,
-    std::shared_ptr<couchbase::tracing::request_span> parent = {}) override
+  auto start_span(std::string name, std::shared_ptr<couchbase::tracing::request_span> parent = {})
+    -> std::shared_ptr<couchbase::tracing::request_span> override
   {
     auto wrapped_parent = std::dynamic_pointer_cast<otel_request_span>(parent);
     if (wrapped_parent) {
@@ -75,8 +74,8 @@ public:
     return std::make_shared<otel_request_span>(tracer_->StartSpan(name));
   }
 
-  std::shared_ptr<couchbase::tracing::otel_request_span> wrap_span(
-    nostd::shared_ptr<opentelemetry::trace::Span> span)
+  auto wrap_span(nostd::shared_ptr<opentelemetry::trace::Span> span)
+    -> std::shared_ptr<couchbase::tracing::otel_request_span>
   {
     return std::make_shared<couchbase::tracing::otel_request_span>(span);
   }

--- a/couchbase/tracing/request_span.hxx
+++ b/couchbase/tracing/request_span.hxx
@@ -29,8 +29,8 @@ public:
   request_span() = default;
   request_span(const request_span& other) = default;
   request_span(request_span&& other) = default;
-  request_span& operator=(const request_span& other) = default;
-  request_span& operator=(request_span&& other) = default;
+  auto operator=(const request_span& other) -> request_span& = default;
+  auto operator=(request_span&& other) -> request_span& = default;
   virtual ~request_span() = default;
 
   explicit request_span(std::string name)
@@ -46,17 +46,17 @@ public:
   virtual void add_tag(const std::string& name, const std::string& value) = 0;
   virtual void end() = 0;
 
-  [[nodiscard]] const std::string& name() const
+  [[nodiscard]] auto name() const -> const std::string&
   {
     return name_;
   }
 
-  [[nodiscard]] std::shared_ptr<request_span> parent() const
+  [[nodiscard]] auto parent() const -> std::shared_ptr<request_span>
   {
     return parent_;
   }
 
-  virtual bool uses_tags() const
+  virtual auto uses_tags() const -> bool
   {
     return true;
   }

--- a/couchbase/tracing/request_tracer.hxx
+++ b/couchbase/tracing/request_tracer.hxx
@@ -30,8 +30,8 @@ public:
   request_tracer() = default;
   request_tracer(const request_tracer& other) = default;
   request_tracer(request_tracer&& other) = default;
-  request_tracer& operator=(const request_tracer& other) = default;
-  request_tracer& operator=(request_tracer&& other) = default;
+  auto operator=(const request_tracer& other) -> request_tracer& = default;
+  auto operator=(request_tracer&& other) -> request_tracer& = default;
   virtual ~request_tracer() = default;
 
   /**
@@ -51,8 +51,8 @@ public:
     /* do nothing */
   }
 
-  virtual std::shared_ptr<request_span> start_span(std::string name,
-                                                   std::shared_ptr<request_span> parent = {}) = 0;
+  virtual auto start_span(std::string name, std::shared_ptr<request_span> parent = {})
+    -> std::shared_ptr<request_span> = 0;
 };
 
 } // namespace couchbase::tracing

--- a/couchbase/transactions/attempt_context.hxx
+++ b/couchbase/transactions/attempt_context.hxx
@@ -47,8 +47,8 @@ public:
    * @param id The unique id of the document.
    * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
    */
-  virtual std::pair<error, transaction_get_result> get(const couchbase::collection& coll,
-                                                       const std::string& id) = 0;
+  virtual auto get(const couchbase::collection& coll,
+                   const std::string& id) -> std::pair<error, transaction_get_result> = 0;
 
   /**
    * Insert a document into a collection.
@@ -64,9 +64,9 @@ public:
    * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
    */
   template<typename Content>
-  std::pair<error, transaction_get_result> insert(const couchbase::collection& coll,
-                                                  const std::string& id,
-                                                  const Content& content)
+  auto insert(const couchbase::collection& coll,
+              const std::string& id,
+              const Content& content) -> std::pair<error, transaction_get_result>
   {
     if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
       return insert_raw(coll, id, content);
@@ -89,8 +89,8 @@ public:
    * @return The result of the operation, which is an @ref error and a @ref transaction_get_result.
    */
   template<typename Content>
-  std::pair<error, transaction_get_result> replace(const transaction_get_result& doc,
-                                                   const Content& content)
+  auto replace(const transaction_get_result& doc,
+               const Content& content) -> std::pair<error, transaction_get_result>
   {
     if constexpr (std::is_same_v<Content, std::vector<std::byte>>) {
       return replace_raw(doc, content);
@@ -108,7 +108,7 @@ public:
    * @param doc The document to remove.
    * @return The result of the operation.
    */
-  virtual error remove(const transaction_get_result& doc) = 0;
+  virtual auto remove(const transaction_get_result& doc) -> error = 0;
 
   /**
    * Perform an unscoped query.
@@ -117,8 +117,8 @@ public:
    * @param options Options for the query.
    * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
    */
-  std::pair<error, transaction_query_result> query(const std::string& statement,
-                                                   const transaction_query_options& options = {});
+  auto query(const std::string& statement, const transaction_query_options& options = {})
+    -> std::pair<error, transaction_query_result>;
 
   /**
    * Perform a scoped query.
@@ -128,25 +128,27 @@ public:
    * @param opts Options for the query.
    * @return The result of the operation, with is an @ref error and a @ref transaction_query_result.
    */
-  std::pair<error, transaction_query_result> query(const scope& scope,
-                                                   const std::string& statement,
-                                                   const transaction_query_options& opts = {});
+  auto query(const scope& scope,
+             const std::string& statement,
+             const transaction_query_options& opts = {})
+    -> std::pair<error, transaction_query_result>;
 
   virtual ~attempt_context() = default;
 
 protected:
   /** @private */
-  virtual std::pair<error, transaction_get_result> replace_raw(const transaction_get_result& doc,
-                                                               std::vector<std::byte> content) = 0;
+  virtual auto replace_raw(const transaction_get_result& doc, std::vector<std::byte> content)
+    -> std::pair<error, transaction_get_result> = 0;
   /** @private */
-  virtual std::pair<error, transaction_get_result> insert_raw(const couchbase::collection& coll,
-                                                              const std::string& id,
-                                                              std::vector<std::byte> content) = 0;
+  virtual auto insert_raw(const couchbase::collection& coll,
+                          const std::string& id,
+                          std::vector<std::byte> content)
+    -> std::pair<error, transaction_get_result> = 0;
   /** @private */
-  virtual std::pair<error, transaction_query_result> do_public_query(
-    const std::string& statement,
-    const transaction_query_options& options,
-    std::optional<std::string> query_context) = 0;
+  virtual auto do_public_query(const std::string& statement,
+                               const transaction_query_options& options,
+                               std::optional<std::string> query_context)
+    -> std::pair<error, transaction_query_result> = 0;
 };
 } // namespace transactions
 } // namespace couchbase

--- a/couchbase/transactions/transaction_get_result.hxx
+++ b/couchbase/transactions/transaction_get_result.hxx
@@ -58,7 +58,7 @@ public:
    * @return content of the document.
    */
   template<typename Content>
-  [[nodiscard]] Content content() const
+  [[nodiscard]] auto content() const -> Content
   {
     return codec::tao_json_serializer::deserialize<Content>(content());
   }
@@ -68,7 +68,7 @@ public:
    *
    * @return content
    */
-  [[nodiscard]] const std::vector<std::byte>& content() const;
+  [[nodiscard]] auto content() const -> const std::vector<std::byte>&;
 
   /**
    * Copy content into document
@@ -88,34 +88,34 @@ public:
    *
    * @return the id of this document.
    */
-  [[nodiscard]] const std::string key() const;
+  [[nodiscard]] auto key() const -> const std::string;
 
   /**
    * Get the name of the bucket this document is in.
    *
    * @return name of the bucket which contains the document.
    */
-  [[nodiscard]] const std::string bucket() const;
+  [[nodiscard]] auto bucket() const -> const std::string;
 
   /**
    * Get the name of the scope this document is in.
    *
    * @return name of the scope which contains the document.
    */
-  [[nodiscard]] const std::string scope() const;
+  [[nodiscard]] auto scope() const -> const std::string;
 
   /**
    * Get the name of the collection this document is in.
    *
    * @return name of the collection which contains the document.
    */
-  [[nodiscard]] const std::string collection() const;
+  [[nodiscard]] auto collection() const -> const std::string;
 
   /**
    * Get the CAS fot this document
    *
    * @return the CAS of the document.
    */
-  [[nodiscard]] const couchbase::cas cas() const;
+  [[nodiscard]] auto cas() const -> const couchbase::cas;
 };
 } // namespace couchbase::transactions

--- a/couchbase/transactions/transaction_keyspace.hxx
+++ b/couchbase/transactions/transaction_keyspace.hxx
@@ -29,7 +29,7 @@ struct transaction_keyspace {
 
   explicit transaction_keyspace(const std::string& bucket_name);
 
-  bool operator==(const transaction_keyspace& keyspace) const
+  auto operator==(const transaction_keyspace& keyspace) const -> bool
   {
     return bucket == keyspace.bucket && scope == keyspace.scope &&
            collection == keyspace.collection;
@@ -44,11 +44,11 @@ struct transaction_keyspace {
    *
    * @return true if valid.
    */
-  bool valid();
+  auto valid() -> bool;
 
   /** @private */
   template<typename OStream>
-  friend OStream& operator<<(OStream& os, const transaction_keyspace& keyspace)
+  friend auto operator<<(OStream& os, const transaction_keyspace& keyspace) -> OStream&
   {
     os << "transaction_keyspace{";
     os << "bucket: " << keyspace.bucket;

--- a/couchbase/transactions/transaction_options.hxx
+++ b/couchbase/transactions/transaction_options.hxx
@@ -46,7 +46,7 @@ public:
    * @param level Durability level for this transaction.
    * @return reference to this object, convenient for chaining operations.
    */
-  transaction_options& durability_level(durability_level level);
+  auto durability_level(durability_level level) -> transaction_options&;
 
   /**
    * Get the durability if it has been set.
@@ -55,7 +55,7 @@ public:
    *
    * @return durability if set.
    */
-  [[nodiscard]] std::optional<couchbase::durability_level> durability_level() const;
+  [[nodiscard]] auto durability_level() const -> std::optional<couchbase::durability_level>;
 
   /**
    * Set the @ref query_scan_consistency for this transaction.
@@ -65,7 +65,7 @@ public:
    * @param scan_consistency The desired @ref query_scan_consistency for this transaction.
    * @return reference to this object, convenient for chaining operations.
    */
-  transaction_options& scan_consistency(query_scan_consistency scan_consistency);
+  auto scan_consistency(query_scan_consistency scan_consistency) -> transaction_options&;
 
   /**
    * Get the scan_consistency if it has been set.
@@ -74,7 +74,7 @@ public:
    *
    * @return The scan_consistency, if set.
    */
-  [[nodiscard]] std::optional<query_scan_consistency> scan_consistency() const;
+  [[nodiscard]] auto scan_consistency() const -> std::optional<query_scan_consistency>;
 
   /**
    * Set the timeout for this transaction.
@@ -84,7 +84,7 @@ public:
    * @return reference to this object, convenient for chaining operations.
    */
   template<typename T>
-  transaction_options& timeout(T timeout)
+  auto timeout(T timeout) -> transaction_options&
   {
     timeout_ = std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
     return *this;
@@ -95,7 +95,7 @@ public:
    *
    * @return the timeout, if set.
    */
-  std::optional<std::chrono::nanoseconds> timeout();
+  auto timeout() -> std::optional<std::chrono::nanoseconds>;
 
   /**
    * Set the metadata collection to use for this transaction
@@ -108,7 +108,7 @@ public:
    * @param coll The desired collection to use.
    * @return reference to this object, convenient for chaining operations.
    */
-  transaction_options& metadata_collection(const couchbase::collection& coll);
+  auto metadata_collection(const couchbase::collection& coll) -> transaction_options&;
 
   /**
    * Set metadata collection to use for this transaction
@@ -116,8 +116,8 @@ public:
    * @param keyspace The desired collection to use
    * @return reference to this object, convenient for chaining operations.
    */
-  transaction_options& metadata_collection(
-    const couchbase::transactions::transaction_keyspace& keyspace)
+  auto metadata_collection(const couchbase::transactions::transaction_keyspace& keyspace)
+    -> transaction_options&
   {
     metadata_collection_.emplace(keyspace);
     return *this;
@@ -127,14 +127,15 @@ public:
    *
    * @return the metadata collection, as a @ref transaction_keyspace, if set.
    */
-  [[nodiscard]] std::optional<transaction_keyspace> metadata_collection() const;
+  [[nodiscard]] auto metadata_collection() const -> std::optional<transaction_keyspace>;
 
   /** @private */
-  transaction_options& test_factories(
-    std::shared_ptr<core::transactions::attempt_context_testing_hooks> hooks,
-    std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks);
+  auto test_factories(std::shared_ptr<core::transactions::attempt_context_testing_hooks> hooks,
+                      std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks)
+    -> transaction_options&;
   /** @private */
-  [[nodiscard]] transactions_config::built apply(const transactions_config::built& conf) const;
+  [[nodiscard]] auto apply(const transactions_config::built& conf) const
+    -> transactions_config::built;
 
 private:
   std::optional<couchbase::durability_level> durability_;

--- a/couchbase/transactions/transaction_query_options.hxx
+++ b/couchbase/transactions/transaction_query_options.hxx
@@ -51,7 +51,7 @@ public:
    * @return reference to this object, convenient for chaining calls.
    */
   template<typename Value>
-  transaction_query_options& raw(const std::string& key, const Value& value)
+  auto raw(const std::string& key, const Value& value) -> transaction_query_options&
   {
     opts_.raw(key, value);
     return *this;
@@ -66,7 +66,7 @@ public:
    * @param value if set to false this query will be turned into a prepared statement query.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& ad_hoc(bool value)
+  auto ad_hoc(bool value) -> transaction_query_options&
   {
     opts_.adhoc(value);
     return *this;
@@ -80,7 +80,7 @@ public:
    * @param scan_consistency Desired scan consistency.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& scan_consistency(query_scan_consistency scan_consistency)
+  auto scan_consistency(query_scan_consistency scan_consistency) -> transaction_query_options&
   {
     opts_.scan_consistency(scan_consistency);
     return *this;
@@ -94,7 +94,7 @@ public:
    * @param mode desired profile mode.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& profile(query_profile mode)
+  auto profile(query_profile mode) -> transaction_query_options&
   {
     opts_.profile(mode);
     return *this;
@@ -108,7 +108,7 @@ public:
    * @param id Desired id
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& client_context_id(const std::string& id)
+  auto client_context_id(const std::string& id) -> transaction_query_options&
   {
     opts_.client_context_id(id);
     return *this;
@@ -122,7 +122,7 @@ public:
    * @param scan_wait Desired time for scan_wait.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& scan_wait(std::chrono::milliseconds scan_wait)
+  auto scan_wait(std::chrono::milliseconds scan_wait) -> transaction_query_options&
   {
     opts_.scan_wait(scan_wait);
     return *this;
@@ -136,7 +136,7 @@ public:
    * @param readonly True if query doesn't mutate documents.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& readonly(bool readonly)
+  auto readonly(bool readonly) -> transaction_query_options&
   {
     opts_.readonly(readonly);
     return *this;
@@ -150,7 +150,7 @@ public:
    * @param cap Desired cap.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& scan_cap(std::uint64_t cap)
+  auto scan_cap(std::uint64_t cap) -> transaction_query_options&
   {
     opts_.scan_cap(cap);
     return *this;
@@ -164,7 +164,7 @@ public:
    * @param batch desired batch size.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& pipeline_batch(std::uint64_t batch)
+  auto pipeline_batch(std::uint64_t batch) -> transaction_query_options&
   {
     opts_.pipeline_batch(batch);
     return *this;
@@ -178,7 +178,7 @@ public:
    * @param cap desired cap.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& pipeline_cap(std::uint64_t cap)
+  auto pipeline_cap(std::uint64_t cap) -> transaction_query_options&
   {
     opts_.pipeline_cap(cap);
     return *this;
@@ -210,7 +210,7 @@ public:
    * @return reference to this object, convenient for chaining calls.
    */
   template<typename... Parameters>
-  transaction_query_options& named_parameters(const Parameters&... parameters)
+  auto named_parameters(const Parameters&... parameters) -> transaction_query_options&
   {
     opts_.named_parameters(parameters...);
     return *this;
@@ -226,7 +226,7 @@ public:
    * @param metrics True if metrics are desired.
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& metrics(bool metrics)
+  auto metrics(bool metrics) -> transaction_query_options&
   {
     opts_.metrics(metrics);
     return *this;
@@ -240,37 +240,38 @@ public:
    * @param max Desired max parallelism
    * @return reference to this object, convenient for chaining calls.
    */
-  transaction_query_options& max_parallelism(std::uint64_t max)
+  auto max_parallelism(std::uint64_t max) -> transaction_query_options&
   {
     opts_.max_parallelism(max);
     return *this;
   }
 
   /** @private */
-  transaction_query_options& encoded_raw_options(
-    std::map<std::string, codec::binary, std::less<>> options)
+  auto encoded_raw_options(std::map<std::string, codec::binary, std::less<>> options)
+    -> transaction_query_options&
   {
     opts_.encoded_raw_options(options);
     return *this;
   }
 
   /** @private */
-  transaction_query_options& encoded_positional_parameters(std::vector<codec::binary> parameters)
+  auto encoded_positional_parameters(std::vector<codec::binary> parameters)
+    -> transaction_query_options&
   {
     opts_.encoded_positional_parameters(parameters);
     return *this;
   }
 
   /** @private */
-  transaction_query_options& encoded_named_parameters(
-    std::map<std::string, codec::binary, std::less<>> parameters)
+  auto encoded_named_parameters(std::map<std::string, codec::binary, std::less<>> parameters)
+    -> transaction_query_options&
   {
     opts_.encoded_named_parameters(parameters);
     return *this;
   }
 
   /** @private */
-  const query_options& get_query_options() const
+  auto get_query_options() const -> const query_options&
   {
     return opts_;
   }

--- a/couchbase/transactions/transactions_cleanup_config.hxx
+++ b/couchbase/transactions/transactions_cleanup_config.hxx
@@ -35,7 +35,7 @@ public:
    * @param value If false, do not start the lost attempts cleanup threads.
    * @return reference to this, so calls can be chained.
    */
-  transactions_cleanup_config& cleanup_lost_attempts(bool value)
+  auto cleanup_lost_attempts(bool value) -> transactions_cleanup_config&
   {
     cleanup_lost_attempts_ = value;
     return *this;
@@ -46,7 +46,7 @@ public:
    *
    * @return If false, no lost attempts cleanup threads will be launched.
    */
-  [[nodiscard]] bool cleanup_lost_attempts() const
+  [[nodiscard]] auto cleanup_lost_attempts() const -> bool
   {
     return cleanup_lost_attempts_;
   }
@@ -58,7 +58,7 @@ public:
    * @param value If true, run the cleanup client attempts loop.
    * @return reference to this, so calls can be chained.
    */
-  transactions_cleanup_config& cleanup_client_attempts(bool value)
+  auto cleanup_client_attempts(bool value) -> transactions_cleanup_config&
   {
     cleanup_client_attempts_ = value;
     return *this;
@@ -72,7 +72,7 @@ public:
    *
    * @return true if the thread is enabled, false if not.
    */
-  [[nodiscard]] bool cleanup_client_attempts() const
+  [[nodiscard]] auto cleanup_client_attempts() const -> bool
   {
     return cleanup_client_attempts_;
   }
@@ -89,7 +89,7 @@ public:
    *
    * @return The cleanup window.
    */
-  [[nodiscard]] std::chrono::milliseconds cleanup_window() const
+  [[nodiscard]] auto cleanup_window() const -> std::chrono::milliseconds
   {
     return cleanup_window_;
   }
@@ -102,7 +102,7 @@ public:
    * @return reference to this, so calls can be chained.
    */
   template<typename T>
-  transactions_cleanup_config& cleanup_window(T duration)
+  auto cleanup_window(T duration) -> transactions_cleanup_config&
   {
     cleanup_window_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
     return *this;
@@ -114,8 +114,8 @@ public:
    * This can be called multiple times, to add several collections, if needed.
    *
    */
-  transactions_cleanup_config& add_collection(
-    const couchbase::transactions::transaction_keyspace& keyspace)
+  auto add_collection(const couchbase::transactions::transaction_keyspace& keyspace)
+    -> transactions_cleanup_config&
   {
     collections_.emplace_back(keyspace);
     return *this;

--- a/couchbase/transactions/transactions_config.hxx
+++ b/couchbase/transactions/transactions_config.hxx
@@ -50,7 +50,7 @@ public:
 
   transactions_config(transactions_config&& c) noexcept;
 
-  transactions_config& operator=(const transactions_config& c);
+  auto operator=(const transactions_config& c) -> transactions_config&;
 
   /**
    * @brief Get the default durability level for all transaction operations
@@ -59,7 +59,7 @@ public:
    *
    * @return The default durability level used for write operations.
    */
-  [[nodiscard]] couchbase::durability_level durability_level() const
+  [[nodiscard]] auto durability_level() const -> couchbase::durability_level
   {
     return level_;
   }
@@ -72,7 +72,7 @@ public:
    * @param level The default durability level desired for write operations.
    * @return reference to this, so calls can be chained.
    */
-  transactions_config& durability_level(enum couchbase::durability_level level)
+  auto durability_level(enum couchbase::durability_level level) -> transactions_config&
   {
     level_ = level;
     return *this;
@@ -87,7 +87,7 @@ public:
    *
    * @return timeout for transactions.
    */
-  [[nodiscard]] std::chrono::nanoseconds timeout() const
+  [[nodiscard]] auto timeout() const -> std::chrono::nanoseconds
   {
     return timeout_;
   }
@@ -98,7 +98,7 @@ public:
    * @return reference to this, so calls can be chained.
    */
   template<typename T>
-  transactions_config& timeout(T duration)
+  auto timeout(T duration) -> transactions_config&
   {
     timeout_ = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
     return *this;
@@ -110,15 +110,15 @@ public:
    * @param keyspace The collection to use for the transaction metadata.
    * @return reference to this, so calls can be chained.
    */
-  transactions_config& metadata_collection(
-    const couchbase::transactions::transaction_keyspace& keyspace)
+  auto metadata_collection(const couchbase::transactions::transaction_keyspace& keyspace)
+    -> transactions_config&
   {
     metadata_collection_ = keyspace;
     return *this;
   }
 
-  [[nodiscard]] std::optional<couchbase::transactions::transaction_keyspace> metadata_collection()
-    const
+  [[nodiscard]] auto metadata_collection() const
+    -> std::optional<couchbase::transactions::transaction_keyspace>
   {
     return metadata_collection_;
   }
@@ -128,7 +128,7 @@ public:
    *
    * @return The query configuration for transactions.
    */
-  [[nodiscard]] const transactions_query_config& query_config() const
+  [[nodiscard]] auto query_config() const -> const transactions_query_config&
   {
     return query_config_;
   }
@@ -138,7 +138,7 @@ public:
    *
    * @return The query configuration for transactions.
    */
-  [[nodiscard]] transactions_query_config& query_config()
+  [[nodiscard]] auto query_config() -> transactions_query_config&
   {
     return query_config_;
   }
@@ -149,7 +149,7 @@ public:
    * @param config The transactions query configuration to use.
    * @return reference to this, so calls can be chained.
    */
-  transactions_config& query_config(const transactions_query_config& config)
+  auto query_config(const transactions_query_config& config) -> transactions_config&
   {
     query_config_ = config;
     return *this;
@@ -160,7 +160,7 @@ public:
    *
    * @return The cleanup configuration.
    */
-  [[nodiscard]] const transactions_cleanup_config& cleanup_config() const
+  [[nodiscard]] auto cleanup_config() const -> const transactions_cleanup_config&
   {
     return cleanup_config_;
   }
@@ -170,7 +170,7 @@ public:
    *
    * @return The cleanup configuration.
    */
-  [[nodiscard]] transactions_cleanup_config& cleanup_config()
+  [[nodiscard]] auto cleanup_config() -> transactions_cleanup_config&
   {
     return cleanup_config_;
   }
@@ -181,16 +181,16 @@ public:
    * @param cleanup_config The cleanup configuration to use.
    * @return reference to this, so calls can be chained.
    */
-  transactions_config& cleanup_config(const transactions_cleanup_config& cleanup_config)
+  auto cleanup_config(const transactions_cleanup_config& cleanup_config) -> transactions_config&
   {
     cleanup_config_ = cleanup_config;
     return *this;
   }
 
   /** @private */
-  transactions_config& test_factories(
-    std::shared_ptr<core::transactions::attempt_context_testing_hooks> hooks,
-    std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks)
+  auto test_factories(std::shared_ptr<core::transactions::attempt_context_testing_hooks> hooks,
+                      std::shared_ptr<core::transactions::cleanup_testing_hooks> cleanup_hooks)
+    -> transactions_config&
   {
     attempt_context_hooks_ = hooks;
     cleanup_hooks_ = cleanup_hooks;
@@ -198,13 +198,14 @@ public:
   }
 
   /** @private */
-  [[nodiscard]] core::transactions::attempt_context_testing_hooks& attempt_context_hooks() const
+  [[nodiscard]] auto attempt_context_hooks() const
+    -> core::transactions::attempt_context_testing_hooks&
   {
     return *attempt_context_hooks_;
   }
 
   /** @private */
-  [[nodiscard]] core::transactions::cleanup_testing_hooks& cleanup_hooks() const
+  [[nodiscard]] auto cleanup_hooks() const -> core::transactions::cleanup_testing_hooks&
   {
     return *cleanup_hooks_;
   }
@@ -221,7 +222,7 @@ public:
   };
 
   /** @internal */
-  [[nodiscard]] built build() const;
+  [[nodiscard]] auto build() const -> built;
 
 private:
   couchbase::durability_level level_{ couchbase::durability_level::majority };

--- a/couchbase/transactions/transactions_query_config.hxx
+++ b/couchbase/transactions/transactions_query_config.hxx
@@ -31,7 +31,7 @@ public:
    * @param consistency the query_scan_consistency to use.
    * @return reference to this, so calls can be chained.
    */
-  transactions_query_config& scan_consistency(query_scan_consistency consistency)
+  auto scan_consistency(query_scan_consistency consistency) -> transactions_query_config&
   {
     scan_consistency_ = consistency;
     return *this;
@@ -42,7 +42,7 @@ public:
    *
    * @return the query_scan_consistency
    */
-  [[nodiscard]] query_scan_consistency scan_consistency() const
+  [[nodiscard]] auto scan_consistency() const -> query_scan_consistency
   {
     return scan_consistency_;
   }

--- a/test/utils/binary.cxx
+++ b/test/utils/binary.cxx
@@ -19,8 +19,8 @@
 
 namespace test::utils
 {
-[[nodiscard]] std::string
-to_string(const std::vector<std::byte>& input)
+[[nodiscard]] auto
+to_string(const std::vector<std::byte>& input) -> std::string
 {
   return { reinterpret_cast<const char*>(input.data()), input.size() };
 }

--- a/test/utils/binary.hxx
+++ b/test/utils/binary.hxx
@@ -22,6 +22,6 @@
 
 namespace test::utils
 {
-[[nodiscard]] std::string
-to_string(const std::vector<std::byte>& input);
+[[nodiscard]] auto
+to_string(const std::vector<std::byte>& input) -> std::string;
 } // namespace test::utils

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -121,8 +121,9 @@ integration_test_guard::~integration_test_guard()
   }
 }
 
-const couchbase::core::operations::management::bucket_describe_response::bucket_info&
+auto
 integration_test_guard::load_bucket_info(const std::string& bucket_name, bool refresh)
+  -> const couchbase::core::operations::management::bucket_describe_response::bucket_info&
 {
   if (info.count(bucket_name) > 0 && !refresh) {
     return info[bucket_name];
@@ -145,8 +146,9 @@ integration_test_guard::load_bucket_info(const std::string& bucket_name, bool re
   return info[bucket_name];
 }
 
-const couchbase::core::operations::management::cluster_describe_response::cluster_info&
+auto
 integration_test_guard::load_cluster_info(bool refresh)
+  -> const couchbase::core::operations::management::cluster_describe_response::cluster_info&
 {
   if (cluster_info && !refresh) {
     return cluster_info.value();
@@ -167,8 +169,8 @@ integration_test_guard::load_cluster_info(bool refresh)
   return cluster_info.value();
 }
 
-pools_response
-integration_test_guard::load_pools_info(bool refresh)
+auto
+integration_test_guard::load_pools_info(bool refresh) -> pools_response
 {
   if (pools_info && !refresh) {
     return pools_info.value();
@@ -212,8 +214,8 @@ integration_test_guard::number_of_query_nodes() -> std::size_t
   return static_cast<std::size_t>(result);
 }
 
-server_version
-integration_test_guard::cluster_version()
+auto
+integration_test_guard::cluster_version() -> server_version
 {
   load_cluster_info();
   auto runtime_pools_info = load_pools_info();

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -46,16 +46,16 @@ public:
   integration_test_guard(const couchbase::core::cluster_options& opts);
   ~integration_test_guard();
 
-  inline const couchbase::core::operations::management::bucket_describe_response::bucket_info&
-  load_bucket_info(bool refresh = false)
+  inline auto load_bucket_info(bool refresh = false)
+    -> const couchbase::core::operations::management::bucket_describe_response::bucket_info&
   {
     return load_bucket_info(ctx.bucket, refresh);
   }
 
-  const couchbase::core::operations::management::bucket_describe_response::bucket_info&
-  load_bucket_info(const std::string& bucket_name, bool refresh = false);
+  auto load_bucket_info(const std::string& bucket_name, bool refresh = false)
+    -> const couchbase::core::operations::management::bucket_describe_response::bucket_info&;
 
-  inline std::size_t number_of_nodes()
+  inline auto number_of_nodes() -> std::size_t
   {
     return load_bucket_info(ctx.bucket).number_of_nodes;
   }
@@ -63,52 +63,53 @@ public:
   auto server_groups() -> std::vector<std::string>;
   auto generate_key_not_in_server_group(const std::string& group_name) -> std::string;
 
-  std::size_t number_of_nodes(const std::string& bucket_name)
+  auto number_of_nodes(const std::string& bucket_name) -> std::size_t
   {
     return load_bucket_info(bucket_name).number_of_nodes;
   }
 
-  inline std::size_t number_of_replicas()
+  inline auto number_of_replicas() -> std::size_t
   {
     return load_bucket_info(ctx.bucket).number_of_replicas;
   }
 
-  std::size_t number_of_replicas(const std::string& bucket_name)
+  auto number_of_replicas(const std::string& bucket_name) -> std::size_t
   {
     return load_bucket_info(bucket_name).number_of_replicas;
   }
 
-  inline couchbase::core::management::cluster::bucket_storage_backend storage_backend()
+  inline auto storage_backend() -> couchbase::core::management::cluster::bucket_storage_backend
   {
     return load_bucket_info(ctx.bucket).storage_backend;
   }
 
-  inline bool has_bucket_capability(const std::string& bucket_name, const std::string& capability)
+  inline auto has_bucket_capability(const std::string& bucket_name,
+                                    const std::string& capability) -> bool
   {
     return load_bucket_info(bucket_name).has_capability(capability);
   }
 
-  inline bool has_bucket_capability(const std::string& capability)
+  inline auto has_bucket_capability(const std::string& capability) -> bool
   {
     return has_bucket_capability(ctx.bucket, capability);
   }
 
-  const couchbase::core::operations::management::cluster_describe_response::cluster_info&
-  load_cluster_info(bool refresh = false);
+  auto load_cluster_info(bool refresh = false)
+    -> const couchbase::core::operations::management::cluster_describe_response::cluster_info&;
 
-  pools_response load_pools_info(bool refresh = false);
+  auto load_pools_info(bool refresh = false) -> pools_response;
 
-  inline bool has_service(couchbase::core::service_type service)
+  inline auto has_service(couchbase::core::service_type service) -> bool
   {
     return load_cluster_info().services.count(service) > 0;
   }
 
-  inline bool has_eventing_service()
+  inline auto has_eventing_service() -> bool
   {
     return has_service(couchbase::core::service_type::eventing);
   }
 
-  inline bool has_analytics_service()
+  inline auto has_analytics_service() -> bool
   {
     return has_service(couchbase::core::service_type::analytics);
   }
@@ -132,7 +133,7 @@ public:
     return couchbase::cluster{ cluster, transactions() };
   }
 
-  server_version cluster_version();
+  auto cluster_version() -> server_version;
 
   test_context ctx;
   asio::io_context io;

--- a/test/utils/move_only_context.hxx
+++ b/test/utils/move_only_context.hxx
@@ -31,15 +31,15 @@ public:
 
   move_only_context(move_only_context&& other) = default;
 
-  move_only_context& operator=(move_only_context&& other) = default;
+  auto operator=(move_only_context&& other) -> move_only_context& = default;
 
   ~move_only_context() = default;
 
   move_only_context(const move_only_context& other) = delete;
 
-  move_only_context& operator=(const move_only_context& other) = delete;
+  auto operator=(const move_only_context& other) -> move_only_context& = delete;
 
-  [[nodiscard]] const std::string& payload() const
+  [[nodiscard]] auto payload() const -> const std::string&
   {
     return payload_;
   }

--- a/test/utils/server_version.cxx
+++ b/test/utils/server_version.cxx
@@ -21,8 +21,8 @@
 
 namespace test::utils
 {
-server_version
-server_version::parse(const std::string& str, const deployment_type deployment)
+auto
+server_version::parse(const std::string& str, const deployment_type deployment) -> server_version
 {
   std::regex version_regex(R"((\d+).(\d+).(\d+)(-(\d+))?(-(.+))?)");
   std::smatch version_match{};

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -51,233 +51,233 @@ struct server_version {
   server_config_profile profile{ server_config_profile::unknown };
   bool use_gocaves{ false };
 
-  static server_version parse(const std::string& str, deployment_type deployment);
+  static auto parse(const std::string& str, deployment_type deployment) -> server_version;
 
-  [[nodiscard]] bool is_mock() const
+  [[nodiscard]] auto is_mock() const -> bool
   {
     return use_gocaves;
   }
 
-  [[nodiscard]] bool is_alice() const
+  [[nodiscard]] auto is_alice() const -> bool
   {
     // [6.0.0, 6.5.0)
     return major == 6 && minor < 5;
   }
 
-  [[nodiscard]] bool is_mad_hatter() const
+  [[nodiscard]] auto is_mad_hatter() const -> bool
   {
     // [6.5.0, 7.0.0)
     return major == 6 && minor >= 5;
   }
 
-  [[nodiscard]] bool is_cheshire_cat() const
+  [[nodiscard]] auto is_cheshire_cat() const -> bool
   {
     // [7.0.0, 7.1.0)
     return major == 7 && minor < 1;
   }
 
-  [[nodiscard]] bool is_neo() const
+  [[nodiscard]] auto is_neo() const -> bool
   {
     // [7.1.0, inf)
     return (major == 7 && minor >= 1) || major > 7;
   }
 
-  [[nodiscard]] bool supports_gcccp() const
+  [[nodiscard]] auto supports_gcccp() const -> bool
   {
     return is_mad_hatter() || is_cheshire_cat() || is_neo();
   }
 
-  [[nodiscard]] bool supports_sync_replication() const
+  [[nodiscard]] auto supports_sync_replication() const -> bool
   {
     return is_mad_hatter() || is_cheshire_cat() || is_neo();
   }
 
-  [[nodiscard]] bool supports_enhanced_durability() const
+  [[nodiscard]] auto supports_enhanced_durability() const -> bool
   {
     return is_mad_hatter() || is_cheshire_cat() || is_neo();
   }
 
-  [[nodiscard]] bool supports_scoped_queries() const
+  [[nodiscard]] auto supports_scoped_queries() const -> bool
   {
     return is_cheshire_cat() || is_neo();
   }
 
-  [[nodiscard]] bool supports_queries_in_transactions() const
+  [[nodiscard]] auto supports_queries_in_transactions() const -> bool
   {
     return is_neo();
   }
 
-  [[nodiscard]] bool supports_collections() const
+  [[nodiscard]] auto supports_collections() const -> bool
   {
     return (is_mad_hatter() && developer_preview) || is_cheshire_cat() || is_neo();
   }
 
-  [[nodiscard]] bool supports_storage_backend() const
+  [[nodiscard]] auto supports_storage_backend() const -> bool
   {
     return is_neo() && is_enterprise();
   }
 
-  [[nodiscard]] bool supports_preserve_expiry() const
+  [[nodiscard]] auto supports_preserve_expiry() const -> bool
   {
     return !use_gocaves && (is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_preserve_expiry_for_query() const
+  [[nodiscard]] auto supports_preserve_expiry_for_query() const -> bool
   {
     return is_neo();
   }
 
-  [[nodiscard]] bool supports_user_groups() const
+  [[nodiscard]] auto supports_user_groups() const -> bool
   {
     return supports_user_management() && (is_mad_hatter() || is_cheshire_cat() || is_neo()) &&
            is_enterprise();
   }
 
-  [[nodiscard]] bool supports_query_index_management() const
+  [[nodiscard]] auto supports_query_index_management() const -> bool
   {
     return !use_gocaves && (is_mad_hatter() || is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_analytics() const
+  [[nodiscard]] auto supports_analytics() const -> bool
   {
     return !use_gocaves && is_enterprise() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_query() const
+  [[nodiscard]] auto supports_query() const -> bool
   {
     return !use_gocaves;
   }
 
-  [[nodiscard]] bool supports_search() const
+  [[nodiscard]] auto supports_search() const -> bool
   {
     return !use_gocaves;
   }
 
-  [[nodiscard]] bool supports_analytics_pending_mutations() const
+  [[nodiscard]] auto supports_analytics_pending_mutations() const -> bool
   {
     return supports_analytics() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_analytics_link_azure_blob() const
+  [[nodiscard]] auto supports_analytics_link_azure_blob() const -> bool
   {
     return supports_analytics() && is_cheshire_cat() && developer_preview;
   }
 
-  [[nodiscard]] bool supports_analytics_links() const
+  [[nodiscard]] auto supports_analytics_links() const -> bool
   {
     return supports_analytics() && ((major == 6 && minor >= 6) || major > 6);
   }
 
-  [[nodiscard]] bool supports_minimum_durability_level() const
+  [[nodiscard]] auto supports_minimum_durability_level() const -> bool
   {
     return (major == 6 && minor >= 6) || major > 6;
   }
 
-  [[nodiscard]] bool supports_bucket_history() const
+  [[nodiscard]] auto supports_bucket_history() const -> bool
   {
     return (major == 7 && minor >= 2) || major > 7;
   }
 
-  [[nodiscard]] bool supports_search_analyze() const
+  [[nodiscard]] auto supports_search_analyze() const -> bool
   {
     return supports_search() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_analytics_links_cert_auth() const
+  [[nodiscard]] auto supports_analytics_links_cert_auth() const -> bool
   {
     return supports_analytics() && is_neo();
   }
 
-  [[nodiscard]] bool supports_eventing_functions() const
+  [[nodiscard]] auto supports_eventing_functions() const -> bool
   {
     return !use_gocaves && is_enterprise() && (is_cheshire_cat() || is_neo()) &&
            deployment == deployment_type::on_prem;
   }
 
-  [[nodiscard]] bool supports_scoped_eventing_functions() const
+  [[nodiscard]] auto supports_scoped_eventing_functions() const -> bool
   {
     return !use_gocaves && is_enterprise() && is_neo() && deployment == deployment_type::on_prem;
   }
 
-  [[nodiscard]] bool supports_scope_search() const
+  [[nodiscard]] auto supports_scope_search() const -> bool
   {
     return (major == 7 && minor >= 6) || major > 7;
   }
 
-  [[nodiscard]] bool supports_vector_search() const
+  [[nodiscard]] auto supports_vector_search() const -> bool
   {
     return (major == 7 && minor >= 6) || major > 7;
   }
 
-  [[nodiscard]] bool supports_scope_search_analyze() const
+  [[nodiscard]] auto supports_scope_search_analyze() const -> bool
   {
     // Scoped endpoint for analyze_document added in 7.6.2 (MB-60643)
     return (major == 7 && minor == 6 && micro >= 2) || (major == 7 && minor > 6) || major > 7;
   }
 
-  [[nodiscard]] bool is_enterprise() const
+  [[nodiscard]] auto is_enterprise() const -> bool
   {
     return edition == server_edition::enterprise;
   }
 
-  [[nodiscard]] bool is_community() const
+  [[nodiscard]] auto is_community() const -> bool
   {
     return edition == server_edition::community;
   }
 
-  [[nodiscard]] bool supports_bucket_management() const
+  [[nodiscard]] auto supports_bucket_management() const -> bool
   {
     return !use_gocaves && deployment == deployment_type::on_prem;
   }
 
-  [[nodiscard]] bool supports_user_management() const
+  [[nodiscard]] auto supports_user_management() const -> bool
   {
     return !use_gocaves && deployment == deployment_type::on_prem;
   }
 
-  [[nodiscard]] bool requires_search_replicas() const
+  [[nodiscard]] auto requires_search_replicas() const -> bool
   {
     return deployment == deployment_type::elixir || deployment == deployment_type::capella ||
            is_serverless_config_profile();
   }
 
-  [[nodiscard]] bool supports_views() const
+  [[nodiscard]] auto supports_views() const -> bool
   {
     return !use_gocaves && deployment == deployment_type::on_prem &&
            (major < 7 || (major == 7 && minor < 2));
   }
 
-  [[nodiscard]] bool supports_memcached_buckets() const
+  [[nodiscard]] auto supports_memcached_buckets() const -> bool
   {
     return !is_serverless_config_profile();
   }
 
-  [[nodiscard]] bool is_serverless_config_profile() const
+  [[nodiscard]] auto is_serverless_config_profile() const -> bool
   {
     return profile == server_config_profile::serverless;
   }
 
-  [[nodiscard]] bool supports_search_disable_scoring() const
+  [[nodiscard]] auto supports_search_disable_scoring() const -> bool
   {
     return supports_search() && (is_mad_hatter() || is_cheshire_cat() || is_neo());
   }
 
-  [[nodiscard]] bool supports_document_not_locked_status() const
+  [[nodiscard]] auto supports_document_not_locked_status() const -> bool
   {
     return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
   }
 
-  [[nodiscard]] bool supports_collection_update_max_expiry() const
+  [[nodiscard]] auto supports_collection_update_max_expiry() const -> bool
   {
     return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
   }
 
-  [[nodiscard]] bool supports_collection_set_max_expiry_to_no_expiry() const
+  [[nodiscard]] auto supports_collection_set_max_expiry_to_no_expiry() const -> bool
   {
     return !use_gocaves && (major > 7 || (major == 7 && minor >= 6));
   }
 
-  [[nodiscard]] bool is_capella() const
+  [[nodiscard]] auto is_capella() const -> bool
   {
     return deployment == deployment_type::capella;
   }

--- a/test/utils/test_context.cxx
+++ b/test/utils/test_context.cxx
@@ -23,8 +23,8 @@
 
 namespace test::utils
 {
-test_context
-test_context::load_from_environment()
+auto
+test_context::load_from_environment() -> test_context
 {
   test_context ctx{};
 
@@ -117,8 +117,8 @@ test_context::load_from_environment()
   return ctx;
 }
 
-couchbase::core::cluster_credentials
-test_context::build_auth() const
+auto
+test_context::build_auth() const -> couchbase::core::cluster_credentials
 {
   couchbase::core::cluster_credentials auth{};
   if (certificate_path.empty()) {

--- a/test/utils/test_context.hxx
+++ b/test/utils/test_context.hxx
@@ -41,9 +41,9 @@ struct test_context {
   std::string other_bucket{ "secBucket" };
   bool use_wan_development_profile{ false };
 
-  [[nodiscard]] couchbase::core::cluster_credentials build_auth() const;
+  [[nodiscard]] auto build_auth() const -> couchbase::core::cluster_credentials;
 
-  static test_context load_from_environment();
+  static auto load_from_environment() -> test_context;
 };
 
 } // namespace test::utils

--- a/test/utils/test_data.cxx
+++ b/test/utils/test_data.cxx
@@ -26,8 +26,8 @@
 
 namespace test::utils
 {
-std::string
-uniq_id(const std::string& prefix)
+auto
+uniq_id(const std::string& prefix) -> std::string
 {
   return fmt::format("{}_{}", prefix, std::chrono::steady_clock::now().time_since_epoch().count());
 }
@@ -46,8 +46,8 @@ read_all(const std::string& path) -> std::string
 }
 } // namespace
 
-std::string
-read_test_data(const std::string& file)
+auto
+read_test_data(const std::string& file) -> std::string
 {
   std::vector candidates{
     file,

--- a/test/utils/test_data.hxx
+++ b/test/utils/test_data.hxx
@@ -21,9 +21,9 @@
 
 namespace test::utils
 {
-std::string
-uniq_id(const std::string& prefix);
+auto
+uniq_id(const std::string& prefix) -> std::string;
 
-std::string
-read_test_data(const std::string& file);
+auto
+read_test_data(const std::string& file) -> std::string;
 } // namespace test::utils

--- a/test/utils/wait_until.cxx
+++ b/test/utils/wait_until.cxx
@@ -38,8 +38,9 @@
 
 namespace test::utils
 {
-bool
-wait_until_bucket_healthy(const couchbase::core::cluster& cluster, const std::string& bucket_name)
+auto
+wait_until_bucket_healthy(const couchbase::core::cluster& cluster,
+                          const std::string& bucket_name) -> bool
 {
   return wait_until([cluster, bucket_name]() {
     couchbase::core::operations::management::bucket_get_request req{ bucket_name };
@@ -59,12 +60,12 @@ wait_until_bucket_healthy(const couchbase::core::cluster& cluster, const std::st
   });
 }
 
-bool
+auto
 wait_until_collection_manifest_propagated(const couchbase::core::cluster& cluster,
                                           const std::string& bucket_name,
                                           std::uint64_t current_manifest_uid,
                                           std::size_t successful_rounds,
-                                          std::chrono::seconds total_timeout)
+                                          std::chrono::seconds total_timeout) -> bool
 {
   std::size_t round = 0;
   auto deadline = std::chrono::system_clock::now() + total_timeout;
@@ -98,8 +99,9 @@ wait_until_collection_manifest_propagated(const couchbase::core::cluster& cluste
   return false;
 }
 
-bool
-wait_until_user_present(const couchbase::core::cluster& cluster, const std::string& username)
+auto
+wait_until_user_present(const couchbase::core::cluster& cluster,
+                        const std::string& username) -> bool
 {
   auto present = test::utils::wait_until([cluster, username]() {
     couchbase::core::operations::management::user_get_request req{};
@@ -114,10 +116,10 @@ wait_until_user_present(const couchbase::core::cluster& cluster, const std::stri
   return present;
 }
 
-bool
+auto
 wait_until_cluster_connected(const std::string& username,
                              const std::string& password,
-                             const std::string& connection_string)
+                             const std::string& connection_string) -> bool
 {
   auto cluster_options = couchbase::cluster_options(username, password);
 
@@ -149,8 +151,8 @@ to_string(std::optional<std::uint64_t> value) -> std::string
   return "(empty)";
 }
 
-static bool
-refresh_config_on_search_service(const couchbase::core::cluster& cluster)
+static auto
+refresh_config_on_search_service(const couchbase::core::cluster& cluster) -> bool
 {
   const couchbase::core::operations::management::freeform_request req{
     couchbase::core::service_type::search,
@@ -169,8 +171,8 @@ refresh_config_on_search_service(const couchbase::core::cluster& cluster)
  * and to update its runtime state to reflect the latest plan (by running the janitor,
  * if enabled).
  */
-static bool
-kick_manager_manager_on_search_service(const couchbase::core::cluster& cluster)
+static auto
+kick_manager_manager_on_search_service(const couchbase::core::cluster& cluster) -> bool
 {
   const couchbase::core::operations::management::freeform_request req{
     couchbase::core::service_type::search,
@@ -184,8 +186,8 @@ kick_manager_manager_on_search_service(const couchbase::core::cluster& cluster)
   return !resp.ctx.ec;
 }
 
-static bool
-starts_with(const std::string& str, const std::string& prefix)
+static auto
+starts_with(const std::string& str, const std::string& prefix) -> bool
 {
   if (str.length() < prefix.length()) {
     return false;
@@ -193,8 +195,8 @@ starts_with(const std::string& str, const std::string& prefix)
   return str.compare(0, prefix.length(), prefix) == 0;
 }
 
-static bool
-ends_with(const std::string& str, const std::string& suffix)
+static auto
+ends_with(const std::string& str, const std::string& suffix) -> bool
 {
   if (str.length() < suffix.length()) {
     return false;
@@ -202,10 +204,10 @@ ends_with(const std::string& str, const std::string& suffix)
   return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
 }
 
-bool
+auto
 wait_for_search_pindexes_ready(const couchbase::core::cluster& cluster,
                                const std::string& bucket_name,
-                               const std::string& index_name)
+                               const std::string& index_name) -> bool
 {
   return test::utils::wait_until(
     [&]() {
@@ -253,10 +255,10 @@ wait_for_search_pindexes_ready(const couchbase::core::cluster& cluster,
     std::chrono::seconds{ 1 });
 }
 
-bool
+auto
 wait_until_indexed(const couchbase::core::cluster& cluster,
                    const std::string& index_name,
-                   std::uint64_t expected_count)
+                   std::uint64_t expected_count) -> bool
 {
   return test::utils::wait_until(
     [cluster = std::move(cluster), &index_name, &expected_count]() {
@@ -278,8 +280,9 @@ wait_until_indexed(const couchbase::core::cluster& cluster,
     std::chrono::seconds{ 5 });
 }
 
-bool
-create_primary_index(const couchbase::core::cluster& cluster, const std::string& bucket_name)
+auto
+create_primary_index(const couchbase::core::cluster& cluster,
+                     const std::string& bucket_name) -> bool
 {
   couchbase::core::operations::management::query_index_create_response resp;
   bool operation_completed = wait_until([&cluster, &bucket_name, &resp]() {
@@ -307,12 +310,13 @@ create_primary_index(const couchbase::core::cluster& cluster, const std::string&
   return operation_completed;
 }
 
-std::pair<bool, std::string>
+auto
 create_search_index(integration_test_guard& integration,
                     const std::string& bucket_name,
                     const std::string& index_name,
                     const std::string& index_params_file_name,
                     std::size_t expected_number_of_documents_indexed)
+  -> std::pair<bool, std::string>
 {
   auto params = read_test_data(index_params_file_name);
 
@@ -369,13 +373,13 @@ create_search_index(integration_test_guard& integration,
   return { operation_completed, actual_index_name };
 }
 
-bool
+auto
 wait_for_function_created(const couchbase::core::cluster& cluster,
                           const std::string& function_name,
                           const std::optional<std::string>& bucket_name,
                           const std::optional<std::string>& scope_name,
                           std::size_t successful_rounds,
-                          std::chrono::seconds total_timeout)
+                          std::chrono::seconds total_timeout) -> bool
 {
   std::size_t round = 0;
   auto deadline = std::chrono::system_clock::now() + total_timeout;
@@ -420,8 +424,8 @@ wait_for_function_created(const couchbase::core::cluster& cluster,
   return false;
 }
 
-bool
-drop_search_index(integration_test_guard& integration, const std::string& index_name)
+auto
+drop_search_index(integration_test_guard& integration, const std::string& index_name) -> bool
 {
   couchbase::core::operations::management::search_index_drop_request req{};
   req.index_name = index_name;

--- a/test/utils/wait_until.hxx
+++ b/test/utils/wait_until.hxx
@@ -30,10 +30,10 @@
 namespace test::utils
 {
 template<class ConditionChecker>
-bool
+auto
 wait_until(ConditionChecker&& condition_checker,
            std::chrono::milliseconds timeout,
-           std::chrono::milliseconds delay)
+           std::chrono::milliseconds delay) -> bool
 {
   const auto start = std::chrono::high_resolution_clock::now();
   while (!condition_checker()) {
@@ -46,57 +46,60 @@ wait_until(ConditionChecker&& condition_checker,
 }
 
 template<class ConditionChecker>
-bool
-wait_until(ConditionChecker&& condition_checker, std::chrono::milliseconds timeout)
+auto
+wait_until(ConditionChecker&& condition_checker, std::chrono::milliseconds timeout) -> bool
 {
   return wait_until(condition_checker, timeout, std::chrono::milliseconds(100));
 }
 
 template<class ConditionChecker>
-bool
-wait_until(ConditionChecker&& condition_checker)
+auto
+wait_until(ConditionChecker&& condition_checker) -> bool
 {
   return wait_until(condition_checker, std::chrono::minutes(1));
 }
 
-bool
-wait_until_bucket_healthy(const couchbase::core::cluster& cluster, const std::string& bucket_name);
+auto
+wait_until_bucket_healthy(const couchbase::core::cluster& cluster,
+                          const std::string& bucket_name) -> bool;
 
-bool
+auto
 wait_until_collection_manifest_propagated(const couchbase::core::cluster& cluster,
                                           const std::string& bucket_name,
                                           std::uint64_t current_manifest_uid,
                                           std::size_t successful_rounds = 7,
                                           std::chrono::seconds total_timeout = std::chrono::minutes{
-                                            5 });
-bool
-wait_until_user_present(const couchbase::core::cluster& cluster, const std::string& username);
+                                            5 }) -> bool;
+auto
+wait_until_user_present(const couchbase::core::cluster& cluster,
+                        const std::string& username) -> bool;
 
-bool
+auto
 wait_until_cluster_connected(const std::string& username,
                              const std::string& password,
-                             const std::string& connection_string);
+                             const std::string& connection_string) -> bool;
 
-bool
+auto
 wait_for_search_pindexes_ready(const couchbase::core::cluster& cluster,
                                const std::string& bucket_name,
-                               const std::string& index_name);
+                               const std::string& index_name) -> bool;
 
-bool
+auto
 wait_for_function_created(const couchbase::core::cluster& cluster,
                           const std::string& function_name,
                           const std::optional<std::string>& bucket_name = {},
                           const std::optional<std::string>& scope_name = {},
                           std::size_t successful_rounds = 4,
-                          std::chrono::seconds total_timeout = std::chrono::seconds{ 120 });
+                          std::chrono::seconds total_timeout = std::chrono::seconds{ 120 }) -> bool;
 
-bool
+auto
 wait_until_indexed(const couchbase::core::cluster& cluster,
                    const std::string& index_name,
-                   std::uint64_t expected_count);
+                   std::uint64_t expected_count) -> bool;
 
-bool
-create_primary_index(const couchbase::core::cluster& cluster, const std::string& bucket_name);
+auto
+create_primary_index(const couchbase::core::cluster& cluster,
+                     const std::string& bucket_name) -> bool;
 
 class integration_test_guard;
 /**
@@ -110,13 +113,14 @@ class integration_test_guard;
  * @return pair of boolean value (success if true), and name of the index created (service might
  * rename index)
  */
-std::pair<bool, std::string>
+auto
 create_search_index(integration_test_guard& integration,
                     const std::string& bucket_name,
                     const std::string& index_name,
                     const std::string& index_params_file_name,
-                    std::size_t expected_number_of_documents_indexed = 800);
+                    std::size_t expected_number_of_documents_indexed = 800)
+  -> std::pair<bool, std::string>;
 
-bool
-drop_search_index(integration_test_guard& integration, const std::string& index_name);
+auto
+drop_search_index(integration_test_guard& integration, const std::string& index_name) -> bool;
 } // namespace test::utils


### PR DESCRIPTION
Lets use single style for return types everywhere

* it is consistent with lambda syntax
* it allows better compile type manipulations using decltype()
* it gives extra flexibility in type resolution (less often return types need clarification that it is really struct/class in case of name collisions)