### PR TITLE
Fix test build issue on CentOS 8

### DIFF
--- a/test/test_unit_binary_transcoder.cxx
+++ b/test/test_unit_binary_transcoder.cxx
@@ -58,7 +58,7 @@ TEST_CASE("unit: binary_raw_transcoder checks flags", "[unit]")
 
   REQUIRE_THROWS_AS(
     [](auto encoded) {
-      couchbase::codec::raw_binary_transcoder::decode(encoded);
+      return couchbase::codec::raw_binary_transcoder::decode(encoded);
     }(encoded),
     std::system_error);
 }


### PR DESCRIPTION
error: useless cast to type ‘void’ in test/test_unit_binary_transcoder.cxx