### PR TITLE
Do not use default parameters for virtual functions in transactions

### DIFF
--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -135,11 +135,6 @@ class transactions : public couchbase::transactions::transactions
 {
 public:
   /**
-   * @brief Destructor
-   */
-  ~transactions();
-
-  /**
    * @brief Create a transactions object.
    *
    * Creates a transactions object, which can be used to run transactions within the current thread.
@@ -216,7 +211,7 @@ public:
 
   void run(couchbase::transactions::async_txn_logic&& code,
            couchbase::transactions::async_txn_complete_logic&& complete_cb,
-           const couchbase::transactions::transaction_options& cfg = {}) override;
+           const couchbase::transactions::transaction_options& cfg) override;
   /**
    * @internal
    * called internally - will likely move

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -47,8 +47,6 @@ transactions::transactions(core::cluster cluster,
 {
 }
 
-transactions::~transactions() = default;
-
 void
 transactions::create(
   core::cluster cluster,

--- a/couchbase/transactions.hxx
+++ b/couchbase/transactions.hxx
@@ -56,9 +56,14 @@ public:
    * @return an {@link transaction_error_context}, and a {@link transaction_result} representing the
    * results of the transaction.
    */
-  virtual std::pair<error, transaction_result> run(
-    txn_logic&& logic,
-    const transaction_options& cfg = transaction_options()) = 0;
+  virtual auto run(txn_logic&& logic,
+                   const transaction_options& cfg) -> std::pair<error, transaction_result> = 0;
+
+  auto run(txn_logic&& logic) -> std::pair<error, transaction_result>
+  {
+    return run(std::move(logic), {});
+  }
+
   /**
    * Run an asynchronous transaction.
    *
@@ -80,6 +85,11 @@ public:
    */
   virtual void run(async_txn_logic&& logic,
                    async_txn_complete_logic&& complete_callback,
-                   const transaction_options& cfg = transaction_options()) = 0;
+                   const transaction_options& cfg) = 0;
+
+  void run(async_txn_logic&& logic, async_txn_complete_logic&& complete_callback)
+  {
+    return run(std::move(logic), std::move(complete_callback), {});
+  }
 };
 } // namespace couchbase::transactions


### PR DESCRIPTION
Default parameters for virtual functions have weird rules, so better avoid them. Use overloading as a workaround.