### PR TITLE
CXXCBC-517:  Add HTTP session retries

### DIFF
--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -127,15 +127,25 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
     deadline.cancel();
   }
 
-  void send_to(std::shared_ptr<io::http_session> session)
+  void send_to()
   {
     if (!handler_) {
       return;
     }
-    session_ = std::move(session);
     if (span_->uses_tags())
       span_->add_tag(tracing::attributes::local_id, session_->id());
     send();
+  }
+
+  void set_command_session(std::shared_ptr<io::http_session> session)
+  {
+    session_.reset();
+    session_ = std::move(session);
+  }
+
+  [[nodiscard]] auto deadline_expired() const -> bool
+  {
+    return deadline.expiry() < std::chrono::steady_clock::now();
   }
 
 private:

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -136,37 +136,9 @@ public:
         }
         std::uint16_t port = node.port_or(options_.network, type, options_.enable_tls, 0);
         if (port != 0) {
-          std::shared_ptr<http_session> session;
           const auto& hostname = node.hostname_for(options_.network);
-          session = options_.enable_tls
-                      ? std::make_shared<http_session>(
-                          type,
-                          client_id_,
-                          ctx_,
-                          tls_,
-                          credentials,
-                          hostname,
-                          std::to_string(port),
-                          http_context{ config_, options_, query_cache_, hostname, port })
-                      : std::make_shared<http_session>(
-                          type,
-                          client_id_,
-                          ctx_,
-                          credentials,
-                          hostname,
-                          std::to_string(port),
-                          http_context{ config_, options_, query_cache_, hostname, port });
-          session->start();
-          session->on_stop([type, id = session->id(), self = this->shared_from_this()]() {
-            std::scoped_lock lock(self->sessions_mutex_);
-            self->busy_sessions_[type].remove_if([&id](const auto& s) {
-              return !s || s->id() == id;
-            });
-            self->idle_sessions_[type].remove_if([&id](const auto& s) {
-              return !s || s->id() == id;
-            });
-          });
-          {
+          auto session = create_session(type, credentials, hostname, port);
+          if (session->is_connected()) {
             std::scoped_lock lock(sessions_mutex_);
             busy_sessions_[type].push_back(session);
           }
@@ -193,19 +165,31 @@ public:
                 error.emplace(fmt::format(
                   "code={}, message={}, http_code={}", ec.value(), ec.message(), msg.status_code));
               }
+              auto remote_address = cmd->session_->remote_address();
+              // If not connected, the remote address will be empty.  Better to
+              // give the user some context on the "attempted" remote address.
+              if (remote_address.empty()) {
+                remote_address =
+                  fmt::format("{}:{}", cmd->session_->hostname(), cmd->session_->port());
+              }
               handler->report(
                 diag::endpoint_ping_info{ type,
                                           cmd->session_->id(),
                                           std::chrono::duration_cast<std::chrono::microseconds>(
                                             std::chrono::steady_clock::now() - start),
-                                          cmd->session_->remote_address(),
+                                          remote_address,
                                           cmd->session_->local_address(),
                                           state,
                                           {},
                                           error });
               self->check_in(type, cmd->session_);
             });
-          cmd->send_to(session);
+          cmd->set_command_session(session);
+          if (!session->is_connected()) {
+            connect_then_send(session, cmd, {}, true);
+          } else {
+            cmd->send_to();
+          }
         }
       }
     }
@@ -245,7 +229,7 @@ public:
           }
         } else {
           auto [hostname, port] = split_host_port(preferred_node);
-          session = bootstrap_session(type, credentials, hostname, port);
+          session = create_session(type, credentials, hostname, port);
           break;
         }
       }
@@ -262,14 +246,20 @@ public:
       if (port == 0) {
         return { errc::common::service_not_available, nullptr };
       }
-      session = bootstrap_session(type, credentials, hostname, port);
+      session = create_session(type, credentials, hostname, port);
     }
-    busy_sessions_[type].push_back(session);
+    if (session->is_connected()) {
+      busy_sessions_[type].push_back(session);
+    }
     return { {}, session };
   }
 
   void check_in(service_type type, std::shared_ptr<http_session> session)
   {
+    if (!session->is_connected()) {
+      CB_LOG_DEBUG("{} HTTP session never connected.  Skipping check-in", session->log_prefix());
+      return session.reset();
+    }
     {
       std::scoped_lock lock(config_mutex_);
       if (!session->keep_alive() || !config_.has_node(options_.network,
@@ -325,11 +315,10 @@ public:
       using response_type = typename Request::encoded_response_type;
       return handler(request.make_response(std::move(ctx), response_type{}));
     }
-    const auto& http_ctx = session->http_context();
 
     auto cmd = std::make_shared<operations::http_command<Request>>(
       ctx_, request, tracer_, meter_, options_.default_timeout_for(request.type));
-    cmd->start([self = shared_from_this(), cmd, http_ctx, handler = std::forward<Handler>(handler)](
+    cmd->start([self = shared_from_this(), cmd, handler = std::forward<Handler>(handler)](
                  std::error_code ec, io::http_response&& msg) mutable {
       using command_type = typename decltype(cmd)::element_type;
       using encoded_response_type = typename command_type::encoded_response_type;
@@ -340,23 +329,74 @@ public:
       ctx.client_context_id = cmd->client_context_id_;
       ctx.method = cmd->encoded.method;
       ctx.path = cmd->encoded.path;
-      ctx.last_dispatched_from = cmd->session_->local_address();
-      ctx.last_dispatched_to = cmd->session_->remote_address();
       ctx.http_status = resp.status_code;
       ctx.http_body = resp.body.data();
-      ctx.hostname = http_ctx.hostname;
-      ctx.port = http_ctx.port;
+      ctx.last_dispatched_from = cmd->session_->local_address();
+      ctx.last_dispatched_to = cmd->session_->remote_address();
+      ctx.hostname = cmd->session_->http_context().hostname;
+      ctx.port = cmd->session_->http_context().port;
       handler(cmd->request.make_response(std::move(ctx), std::move(resp)));
       self->check_in(cmd->request.type, cmd->session_);
     });
-    cmd->send_to(session);
+    cmd->set_command_session(session);
+    if (!session->is_connected()) {
+      connect_then_send(session, cmd, preferred_node);
+    } else {
+      cmd->send_to();
+    }
   }
 
 private:
-  auto bootstrap_session(service_type type,
-                         const couchbase::core::cluster_credentials& credentials,
-                         const std::string& hostname,
-                         std::uint16_t port) -> std::shared_ptr<http_session>
+  template<typename Request>
+  void connect_then_send(std::shared_ptr<http_session> session,
+                         std::shared_ptr<operations::http_command<Request>> cmd,
+                         const std::string& preferred_node,
+                         bool reuse_session = false)
+  {
+    session->connect([self = shared_from_this(),
+                      session,
+                      cmd,
+                      preferred_node = std::move(preferred_node),
+                      reuse_session]() mutable {
+      if (!session->is_connected()) {
+        if (cmd->deadline_expired()) {
+          // The http command will stop its session when the deadline expires.
+          return;
+        }
+        if (reuse_session) {
+          return self->connect_then_send(session, cmd, preferred_node, reuse_session);
+        }
+        // stop this session and create a new one w/ new hostname + port
+        session->stop();
+        auto [hostname, port] = preferred_node.empty()
+                                  ? self->next_node(session->type())
+                                  : self->lookup_node(session->type(), preferred_node);
+        if (port == 0) {
+          cmd->invoke_handler(errc::common::service_not_available, {});
+          return;
+        }
+        auto new_session =
+          self->create_session(session->type(), session->credentials(), hostname, port);
+        cmd->set_command_session(new_session);
+        if (new_session->is_connected()) {
+          std::scoped_lock inner_lock(self->sessions_mutex_);
+          self->busy_sessions_[new_session->type()].push_back(new_session);
+          cmd->send_to();
+        } else {
+          self->connect_then_send(new_session, cmd, preferred_node);
+        }
+      } else {
+        std::scoped_lock inner_lock(self->sessions_mutex_);
+        self->busy_sessions_[session->type()].push_back(session);
+        cmd->send_to();
+      }
+    });
+  }
+
+  auto create_session(service_type type,
+                      const couchbase::core::cluster_credentials& credentials,
+                      const std::string& hostname,
+                      std::uint16_t port) -> std::shared_ptr<http_session>
   {
     std::shared_ptr<http_session> session;
     if (options_.enable_tls) {
@@ -379,7 +419,6 @@ private:
         std::to_string(port),
         http_context{ config_, options_, query_cache_, hostname, port });
     }
-    session->start();
 
     session->on_stop([type, id = session->id(), self = this->shared_from_this()]() {
       std::scoped_lock inner_lock(self->sessions_mutex_);


### PR DESCRIPTION
Motivation
==========
The client does not currently attempt to retry if the HTTP session fails to resolve or connect.  Adding retries will help to improve user experience.

Changes
=======
* Add retries if resolve or connect fails.
* If connect fails, and resolve provided multiple endpoints, attempt to connect to next endpoint in list of provided endpoints.
* If ping() fails due to resolve/connect issue, list "attempted" hostname and port in `remote_address` property of `endpoint_ping_info`