### PR TITLE
Finalize transaction_get_result API

### DIFF
--- a/core/impl/transaction_get_result.cxx
+++ b/core/impl/transaction_get_result.cxx
@@ -33,20 +33,8 @@ transaction_get_result::content() const -> const codec::encoded_value&
   return base_->content();
 }
 
-void
-transaction_get_result::content(const codec::encoded_value& content)
-{
-  return base_->content(content);
-}
-
-void
-transaction_get_result::content(codec::encoded_value&& content)
-{
-  return base_->content(std::move(content));
-}
-
 auto
-transaction_get_result::key() const -> const std::string&
+transaction_get_result::id() const -> const std::string&
 {
   return base_->key();
 }

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -179,3 +179,8 @@
  * transaction_op error codes do not have 'exception' suffix
  */
 #define COUCHBASE_CXX_CLIENT_TRANSACTION_OP_ERRC_NO_EXCEPTION_SUFFIX 1
+
+/**
+ * transactions_get_result has `content_as` and `id` methods
+ */
+#define COUCHBASE_CXX_CLIENT_TXNS_GET_RESULT_FINAL_API

--- a/core/transactions/transaction_get_result.hxx
+++ b/core/transactions/transaction_get_result.hxx
@@ -80,7 +80,7 @@ public:
 
   explicit transaction_get_result(const couchbase::transactions::transaction_get_result& res)
     : cas_(res.cas())
-    , document_id_(res.bucket(), res.scope(), res.collection(), res.key())
+    , document_id_(res.bucket(), res.scope(), res.collection(), res.id())
     , links_(res.base_->links())
     , content_(std::move(res.content()))
     , metadata_(res.base_->metadata_)

--- a/examples/async_game_server.cxx
+++ b/examples/async_game_server.cxx
@@ -164,7 +164,7 @@ public:
               exists = false;
               return;
             }
-            auto monster_body = monster.template content<Monster>();
+            auto monster_body = monster.template content_as<Monster>();
             auto monster_hitpoints = monster_body.hitpoints;
             auto monster_new_hitpoints = monster_hitpoints - damage;
 
@@ -188,7 +188,7 @@ public:
                     std::cout << "error getting player: " << e.ec().message() << std::endl;
                     return;
                   }
-                  const Player& player_body = player.template content<Player>();
+                  const Player& player_body = player.template content_as<Player>();
 
                   // the player earns experience for killing the monster
                   int experience_for_killing_monster = monster_body.experience_when_killed;

--- a/examples/game_server.cxx
+++ b/examples/game_server.cxx
@@ -156,7 +156,7 @@ public:
           exists = false;
           return {};
         }
-        const Monster& monster_body = monster.content<Monster>();
+        const Monster& monster_body = monster.content_as<Monster>();
 
         int monster_hitpoints = monster_body.hitpoints;
         int monster_new_hitpoints = monster_hitpoints - damage_;
@@ -176,7 +176,7 @@ public:
           // set a "dead" flag or similar.
           ctx->remove(monster);
 
-          const Player& player_body = player.content<Player>();
+          const Player& player_body = player.content_as<Player>();
 
           // the player earns experience for killing the monster
           int experience_for_killing_monster = monster_body.experience_when_killed;

--- a/test/test_transaction_examples.cxx
+++ b/test/test_transaction_examples.cxx
@@ -129,14 +129,14 @@ main(int argc, const char* argv[])
           // [4.4] replace document's content
           ctx->replace(doc,
                        tao::json::value{ { "some", "other async content" } },
-                       [=](auto err_ctx_2, auto res) {
+                       [=](auto err_ctx_2, auto /*res*/) {
                          if (err_ctx_2.ec()) {
                            fmt::print(stderr,
                                       "error replacing content in doc {}: {}\n",
                                       id_1,
                                       err_ctx_2.ec().message());
                          } else {
-                           fmt::print("successfully replaced: {}, cas={}\n", id_1, res.cas());
+                           fmt::print("successfully replaced: {}\n", id_1);
                          }
                        });
         });
@@ -147,14 +147,14 @@ main(int argc, const char* argv[])
           }
           ctx->replace(doc,
                        tao::json::value{ { "some", "other async content" } },
-                       [=](auto err_ctx_2, auto res) {
+                       [=](auto err_ctx_2, auto /*res*/) {
                          if (err_ctx_2.ec()) {
                            fmt::print(stderr,
                                       "error replacing content in doc {}: {}\n",
                                       id_2,
                                       err_ctx_2.ec().message());
                          } else {
-                           fmt::print("successfully replaced: {}, cas={}\n", id_2, res.cas());
+                           fmt::print("successfully replaced: {}\n", id_2);
                          }
                        });
         });
@@ -165,14 +165,14 @@ main(int argc, const char* argv[])
           }
           ctx->replace(doc,
                        tao::json::value{ { "some", "other async content" } },
-                       [=](auto err_ctx_2, auto res) {
+                       [=](auto err_ctx_2, auto /*res*/) {
                          if (err_ctx_2.ec()) {
                            fmt::print(stderr,
                                       "error replacing content in doc {}: {}\n",
                                       id_3,
                                       err_ctx_2.ec().message());
                          } else {
-                           fmt::print("successfully replaced: {}, cas={}\n", id_3, res.cas());
+                           fmt::print("successfully replaced: {}\n", id_3);
                          }
                        });
         });
@@ -286,7 +286,7 @@ main(int argc, const char* argv[])
           return {};
         }
         fmt::println("document content: {}",
-                     tao::json::to_string(doc.template content<tao::json::value>()));
+                     tao::json::to_string(doc.template content_as<tao::json::value>()));
         return {};
       });
 
@@ -313,7 +313,7 @@ main(int argc, const char* argv[])
             return;
           }
           fmt::println("document content: {}",
-                       tao::json::to_string(doc.template content<tao::json::value>()));
+                       tao::json::to_string(doc.template content_as<tao::json::value>()));
         });
         return {};
       },

--- a/test/test_transaction_public_async_api.cxx
+++ b/test/test_transaction_public_async_api.cxx
@@ -49,8 +49,8 @@ TEST_CASE("transactions public async API: can async get", "[transactions]")
       std::shared_ptr<couchbase::transactions::async_attempt_context> ctx) -> couchbase::error {
       ctx->get(coll, id, [id](auto e, auto res) {
         CHECK_FALSE(e.ec());
-        CHECK(res.key() == id);
-        CHECK(res.template content<tao::json::value>() == async_content);
+        CHECK(res.id() == id);
+        CHECK(res.template content_as<tao::json::value>() == async_content);
       });
       return {};
     },
@@ -236,9 +236,9 @@ TEST_CASE("transactions public async API: can async replace", "[transactions]")
   c.transactions()->run(
     [id, coll, new_content](
       std::shared_ptr<couchbase::transactions::async_attempt_context> ctx) -> couchbase::error {
-      ctx->get(coll, id, [new_content, ctx](auto, auto res) {
-        ctx->replace(res, new_content, [](auto replace_e, auto replace_result) {
-          CHECK(!replace_result.cas().empty());
+      ctx->get(coll, id, [new_content, ctx, id](auto, auto res) {
+        ctx->replace(res, new_content, [id](auto replace_e, auto replace_result) {
+          CHECK(replace_result.id() == id);
           CHECK_FALSE(replace_e.ec());
         });
       });

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -121,9 +121,8 @@ TEST_CASE("transactions public blocking API: can get", "[transactions]")
     [id, &coll](std::shared_ptr<couchbase::transactions::attempt_context> ctx) -> couchbase::error {
       auto [e, doc] = ctx->get(coll, id);
       CHECK_FALSE(e.ec());
-      CHECK(doc.key() == id);
-      CHECK_FALSE(doc.cas().empty());
-      CHECK(doc.content<tao::json::value>() == content);
+      CHECK(doc.id() == id);
+      CHECK(doc.content_as<tao::json::value>() == content);
       return {};
     },
     txn_opts());
@@ -164,11 +163,10 @@ TEST_CASE("transactions public blocking API: can insert", "[transactions]")
     [id, coll](std::shared_ptr<couchbase::transactions::attempt_context> ctx) -> couchbase::error {
       auto [e, doc] = ctx->insert(coll, id, content);
       CHECK_FALSE(e.ec());
-      CHECK(doc.key() == id);
-      CHECK_FALSE(doc.cas().empty());
+      CHECK(doc.id() == id);
       auto [e2, inserted_doc] = ctx->get(coll, id);
       CHECK_FALSE(e2.ec());
-      CHECK(inserted_doc.content<tao::json::value>() == content);
+      CHECK(inserted_doc.content_as<tao::json::value>() == content);
       return {};
     },
     txn_opts());
@@ -231,9 +229,8 @@ TEST_CASE("transactions public blocking API: can replace", "[transactions]")
       auto [_, doc] = ctx->get(coll, id);
       auto [e, replaced_doc] = ctx->replace(doc, new_content);
       CHECK_FALSE(e.ec());
-      CHECK(doc.key() == replaced_doc.key());
-      CHECK(doc.cas() != replaced_doc.cas());
-      CHECK(doc.content<tao::json::value>() == content);
+      CHECK(doc.id() == replaced_doc.id());
+      CHECK(doc.content_as<tao::json::value>() == content);
       // FIXME(JCBC-2152)
       // CHECK(replaced_doc.content<tao::json::value>() == new_content);
       return {};
@@ -665,7 +662,7 @@ TEST_CASE("transactions public blocking API: can get doc from bucket not yet ope
        &coll](std::shared_ptr<couchbase::transactions::attempt_context> ctx) -> couchbase::error {
         auto [e, doc] = ctx->get(coll, id);
         CHECK_FALSE(e.ec());
-        CHECK(doc.content<tao::json::value>() == content);
+        CHECK(doc.content_as<tao::json::value>() == content);
         return {};
       },
       txn_opts());
@@ -691,7 +688,7 @@ TEST_CASE("transactions public blocking API: can insert doc into bucket not yet 
        &coll](std::shared_ptr<couchbase::transactions::attempt_context> ctx) -> couchbase::error {
         auto [e, doc] = ctx->insert(coll, id, content);
         CHECK_FALSE(e.ec());
-        CHECK_FALSE(doc.cas().empty());
+        CHECK(doc.id() == id);
         return {};
       },
       txn_opts());
@@ -729,7 +726,7 @@ TEST_CASE("transactions public blocking API: can replace doc in bucket not yet o
         CHECK_FALSE(get_err.ec());
         auto [e, doc] = ctx->replace(get_doc, new_content);
         CHECK_FALSE(e.ec());
-        CHECK_FALSE(doc.cas().empty());
+        CHECK(doc.id() == id);
         return {};
       },
       txn_opts());

--- a/test/test_unit_transaction_utils.cxx
+++ b/test/test_unit_transaction_utils.cxx
@@ -302,13 +302,8 @@ TEST_CASE("transaction_get_result: can convert core transaction_get_result to "
     couchbase::core::transactions::transaction_get_result core_result(
       { bucket, scope, collection, key }, json_content, cas.value(), links, metadata);
     auto public_result = core_result.to_public_result();
-    REQUIRE(public_result.collection() == collection);
-    REQUIRE(public_result.bucket() == bucket);
-    REQUIRE(public_result.scope() == scope);
-    REQUIRE(public_result.cas() == cas);
-    REQUIRE(public_result.key() == key);
-    REQUIRE(public_result.content() == json_content);
-    REQUIRE(public_result.content<tao::json::value>() == content);
+    REQUIRE(public_result.id() == key);
+    REQUIRE(public_result.content_as<tao::json::value>() == content);
     REQUIRE(core_result.collection() == collection);
     REQUIRE(core_result.bucket() == bucket);
     REQUIRE(core_result.scope() == scope);
@@ -360,13 +355,13 @@ TEST_CASE("transaction_get_result: can convert core transaction_get_result to "
   {
     couchbase::core::transactions::transaction_get_result core_result{};
     auto final_public_result = core_result.to_public_result();
-    REQUIRE(final_public_result.cas().empty());
+    REQUIRE(final_public_result.id().empty());
   }
   SECTION("default constructed public->core->public")
   {
     couchbase::transactions::transaction_get_result public_res;
     couchbase::core::transactions::transaction_get_result core_res(public_res);
     auto final_public_res = core_res.to_public_result();
-    REQUIRE(final_public_res.cas().empty());
+    REQUIRE(final_public_res.id().empty());
   }
 }


### PR DESCRIPTION
* Remove `content()` overloads that are not in spec.
* Rename `content` to `content_as`
* Rename `key()` to `id()`
* Make bucket/scope/collection accessors private