### PR TITLE
CXXCBC-528: SDK API 3.6 Release Preparation Stability levels

### DIFF
--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -207,19 +207,6 @@ public:
       });
   }
 
-  void search_query(std::string index_name,
-                    const class search_query& query,
-                    const search_options::built& options,
-                    search_handler&& handler) const
-  {
-    return core_.execute(
-      core::impl::build_search_request(std::move(index_name), query, options, {}, {}),
-      [handler = std::move(handler)](auto resp) mutable {
-        return handler(core::impl::make_error(resp.ctx),
-                       search_result{ internal_search_result{ resp } });
-      });
-  }
-
   void ping(const ping_options::built& options, ping_handler&& handler) const
   {
     return core_.ping(options.report_id,
@@ -378,28 +365,6 @@ cluster::diagnostics(const couchbase::diagnostics_options& options) const
   auto barrier = std::make_shared<std::promise<std::pair<error, diagnostics_result>>>();
   diagnostics(options, [barrier](auto err, auto result) mutable {
     barrier->set_value({ std::move(err), std::move(result) });
-  });
-  return barrier->get_future();
-}
-
-void
-cluster::search_query(std::string index_name,
-                      const class search_query& query,
-                      const search_options& options,
-                      search_handler&& handler) const
-{
-  return impl_->search_query(std::move(index_name), query, options.build(), std::move(handler));
-}
-
-auto
-cluster::search_query(std::string index_name,
-                      const class search_query& query,
-                      const search_options& options) const
-  -> std::future<std::pair<error, search_result>>
-{
-  auto barrier = std::make_shared<std::promise<std::pair<error, search_result>>>();
-  search_query(std::move(index_name), query, options, [barrier](auto err, auto result) mutable {
-    barrier->set_value(std::make_pair(std::move(err), std::move(result)));
   });
   return barrier->get_future();
 }

--- a/core/impl/scope.cxx
+++ b/core/impl/scope.cxx
@@ -84,19 +84,6 @@ public:
                          });
   }
 
-  void search_query(std::string index_name,
-                    const class search_query& query,
-                    search_options::built options,
-                    search_handler&& handler) const
-  {
-    return core_.execute(
-      core::impl::build_search_request(std::move(index_name), query, options, bucket_name_, name_),
-      [handler = std::move(handler)](auto&& resp) mutable {
-        return handler(core::impl::make_error(resp.ctx),
-                       search_result{ internal_search_result{ resp } });
-      });
-  }
-
   void search(std::string index_name,
               couchbase::search_request request,
               search_options::built options,

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -166,54 +166,6 @@ public:
     -> std::future<std::pair<error, query_result>>;
 
   /**
-   * Performs a query against the full text search services.
-   *
-   * Consider using the newer @ref cluster::search() interface instead, which can be used
-   * for both traditional FTS queries, and to perform a @ref vector_search
-   *
-   * @param index_name name of the search index
-   * @param query query object, see hierarchy of @ref search_query for more details.
-   * @param options options to customize the query request.
-   * @param handler the handler that implements @ref search_handler
-   *
-   * @exception errc::common::ambiguous_timeout
-   * @exception errc::common::unambiguous_timeout
-   *
-   * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
-   *
-   * @since 1.0.0
-   * @committed
-   */
-  void search_query(std::string index_name,
-                    const search_query& query,
-                    const search_options& options,
-                    search_handler&& handler) const;
-
-  /**
-   * Performs a query against the full text search services.
-   *
-   * Consider using the newer @ref cluster::search() interface instead, which can be used
-   * for both traditional FTS queries, and to perform a vector search.
-   *
-   * @param index_name name of the search index
-   * @param query query object, see hierarchy of @ref search_query for more details.
-   * @param options options to customize the query request.
-   * @return future object that carries result of the operation
-   *
-   * @exception errc::common::ambiguous_timeout
-   * @exception errc::common::unambiguous_timeout
-   *
-   * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
-   *
-   * @since 1.0.0
-   * @committed
-   */
-  [[nodiscard]] auto search_query(std::string index_name,
-                                  const class search_query& query,
-                                  const search_options& options = {}) const
-    -> std::future<std::pair<error, search_result>>;
-
-  /**
    * Performs a request against the full text search services.
    *
    * This can be used to perform a traditional FTS query, and/or a vector search.
@@ -229,7 +181,7 @@ public:
    * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   void search(std::string index_name,
               search_request request,
@@ -252,7 +204,7 @@ public:
    * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   [[nodiscard]] auto search(std::string index_name,
                             search_request request,

--- a/couchbase/get_all_replicas_options.hxx
+++ b/couchbase/get_all_replicas_options.hxx
@@ -56,7 +56,7 @@ struct get_all_replicas_options : public common_options<get_all_replicas_options
    * @return this options builder for chaining purposes.
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   auto read_preference(read_preference preference) -> get_all_replicas_options&
   {

--- a/couchbase/get_any_replica_options.hxx
+++ b/couchbase/get_any_replica_options.hxx
@@ -55,7 +55,7 @@ struct get_any_replica_options : public common_options<get_any_replica_options> 
    * @return this options builder for chaining purposes.
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   auto read_preference(read_preference preference) -> get_any_replica_options&
   {

--- a/couchbase/lookup_in_all_replicas_options.hxx
+++ b/couchbase/lookup_in_all_replicas_options.hxx
@@ -62,7 +62,7 @@ struct lookup_in_all_replicas_options : common_options<lookup_in_all_replicas_op
    * @return this options builder for chaining purposes.
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   auto read_preference(read_preference preference) -> lookup_in_all_replicas_options&
   {

--- a/couchbase/lookup_in_any_replica_options.hxx
+++ b/couchbase/lookup_in_any_replica_options.hxx
@@ -62,7 +62,7 @@ struct lookup_in_any_replica_options : common_options<lookup_in_any_replica_opti
    * @return this options builder for chaining purposes.
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   auto read_preference(read_preference preference) -> lookup_in_any_replica_options&
   {

--- a/couchbase/scope.hxx
+++ b/couchbase/scope.hxx
@@ -129,7 +129,7 @@ public:
    * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   void search(std::string index_name,
               search_request request,
@@ -152,7 +152,7 @@ public:
    * @see https://docs.couchbase.com/server/current/fts/fts-introduction.html
    *
    * @since 1.0.0
-   * @volatile
+   * @committed
    */
   [[nodiscard]] auto search(std::string index_name,
                             search_request request,

--- a/couchbase/search_request.hxx
+++ b/couchbase/search_request.hxx
@@ -40,7 +40,7 @@ namespace couchbase
  * It can be used to send an FTS @ref search_query, and/or a @ref vector_search
  *
  * @since 1.0.0
- * @volatile
+ * @committed
  */
 class search_request
 {
@@ -51,7 +51,7 @@ public:
    * @param search_query the query to run
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   explicit search_request(const couchbase::search_query& search_query);
 
@@ -61,7 +61,7 @@ public:
    * @param vector_search the vector_search to run
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   explicit search_request(const couchbase::vector_search& vector_search);
 
@@ -74,7 +74,7 @@ public:
    * @return this search_request for chaining purposes.
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   auto search_query(const couchbase::search_query& search_query) -> search_request&;
 
@@ -87,7 +87,7 @@ public:
    * @return this search_request for chaining purposes.
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   auto vector_search(const couchbase::vector_search& vector_search) -> search_request&;
 

--- a/couchbase/vector_query.hxx
+++ b/couchbase/vector_query.hxx
@@ -23,7 +23,7 @@ namespace couchbase
 {
 /**
  * @since 1.0.0
- * @uncommitted
+ * @committed
  */
 class vector_query
 {
@@ -35,7 +35,7 @@ public:
    * @param vector_query the vector query to run. Cannot be empty.
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   vector_query(std::string vector_field_name, std::vector<double> vector_query)
     : vector_field_name_{ std::move(vector_field_name) }
@@ -54,7 +54,7 @@ public:
    *
    * @snippet test/test_unit_search.cxx base64-vector-query
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   vector_query(std::string vector_field_name, std::string base64_vector_query)
     : vector_field_name_{ std::move(vector_field_name) }
@@ -73,7 +73,7 @@ public:
    * @return this vector_query for chaining purposes
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   auto num_candidates(std::uint32_t num_candidates) -> vector_query&
   {
@@ -93,7 +93,7 @@ public:
    * @return this vector_query for chaining purposes.
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   auto boost(double boost) -> vector_query&
   {

--- a/couchbase/vector_search.hxx
+++ b/couchbase/vector_search.hxx
@@ -26,7 +26,7 @@ namespace couchbase
  * A vector_search allows one or more @ref vector_query to be executed.
  *
  * @since 1.0.0
- * @uncommitted
+ * @committed
  */
 class vector_search
 {
@@ -38,7 +38,7 @@ public:
    * @param options options to use on the vector queries
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   explicit vector_search(std::vector<vector_query> vector_queries,
                          vector_search_options options = {})
@@ -56,7 +56,7 @@ public:
    * @param query the query to be run
    *
    * @since 1.0.0
-   * @uncommitted
+   * @committed
    */
   explicit vector_search(vector_query query)
     : vector_queries_{ std::vector<vector_query>{ std::move(query) } }


### PR DESCRIPTION
Changes:
- Bumped vector search, binary transactions & zone-aware replica reads to committed stability level
- Removed `search_query()`, in favour of `search()`