### PR TITLE
CXXCBC-530: Include 'min' parameter when encoding disjunction FTS queries

### DIFF
--- a/core/impl/disjunction_query.cxx
+++ b/core/impl/disjunction_query.cxx
@@ -35,6 +35,7 @@ disjunction_query::encode() const -> encoded_search_query
   if (boost_) {
     built.query["boost"] = boost_.value();
   }
+  built.query["min"] = min_;
 
   tao::json::value disjuncts = tao::json::empty_array;
   for (const auto& disjunct : disjuncts_) {

--- a/test/test_unit_search.cxx
+++ b/test/test_unit_search.cxx
@@ -130,8 +130,9 @@ TEST_CASE("unit: disjunction search query", "[unit]")
 //! [search-disjunction]
 auto query = couchbase::disjunction_query{
   couchbase::match_query("location hostel").field("reviews.content"),
-  couchbase::boolean_field_query(true).field("free_breakfast")
-};
+  couchbase::boolean_field_query(true).field("free_breakfast"),
+  couchbase::boolean_field_query(true).field("late_check_in"),
+}.min(2);
 //! [search-disjunction]
   // clang-format on
   const auto encoded = query.encode();
@@ -139,8 +140,10 @@ auto query = couchbase::disjunction_query{
   REQUIRE(encoded.query == R"(
 {"disjuncts":[
     {"field":"reviews.content","match":"location hostel"},
-    {"bool":true,"field":"free_breakfast"}
-]}
+    {"bool":true,"field":"free_breakfast"},
+    {"bool":true,"field":"late_check_in"}
+],
+"min": 2}
 )"_json);
 }
 
@@ -177,8 +180,8 @@ query.must_not(
   REQUIRE_FALSE(encoded.ec);
   REQUIRE(encoded.query == R"(
 {"must":     {"conjuncts":[{"field":"reviews.content","match":"hostel room"},{"bool":true,"field":"free_breakfast"}]},
- "must_not": {"disjuncts":[{"field":"city","match":"Padfield Gilingham"}]},
- "should":   {"disjuncts":[{"field":"reviews.ratings.Overall","min":4},{"field":"reviews.ratings.Service","min":5}]}}
+ "must_not": {"disjuncts":[{"field":"city","match":"Padfield Gilingham"}], "min": 1},
+ "should":   {"disjuncts":[{"field":"reviews.ratings.Overall","min":4},{"field":"reviews.ratings.Service","min":5}], "min": 1}}
 )"_json);
 }
 


### PR DESCRIPTION
'min' should be encoded in the request, and defaults to 1: [RFC](https://github.com/couchbaselabs/sdk-rfcs/blob/master/rfc/0052-sdk3-full-text-search.md#disjunctionquery)