### PR TITLE
Do not expose FIT-specific transaction errors in public API

### DIFF
--- a/core/impl/query.cxx
+++ b/core/impl/query.cxx
@@ -206,7 +206,7 @@ build_transaction_query_result(operations::query_response resp,
     if (!txn_ec) {
       // TODO: review what our default should be...
       // no override error code was passed in, so default to not_set
-      txn_ec = errc::transaction_op::not_set;
+      txn_ec = errc::transaction_op::generic;
     }
   }
   return {

--- a/core/impl/transaction_op_error_category.cxx
+++ b/core/impl/transaction_op_error_category.cxx
@@ -30,8 +30,8 @@ struct transaction_op_error_category : std::error_category {
   [[nodiscard]] auto message(int ev) const noexcept -> std::string override
   {
     switch (static_cast<errc::transaction_op>(ev)) {
-      case errc::transaction_op::unknown:
-        return "unknown (1300)";
+      case errc::transaction_op::generic:
+        return "generic (1300)";
       case errc::transaction_op::active_transaction_record_entry_not_found:
         return "active_transaction_record_entry_not_found (1301)";
       case errc::transaction_op::active_transaction_record_full:
@@ -44,36 +44,32 @@ struct transaction_op_error_category : std::error_category {
         return "document_exists (1305)";
       case errc::transaction_op::document_not_found:
         return "document_not_found (1306)";
-      case errc::transaction_op::not_set:
-        return "not_set (1307)";
       case errc::transaction_op::feature_not_available:
-        return "feature_not_available (1308)";
+        return "feature_not_available (1307)";
       case errc::transaction_op::transaction_aborted_externally:
-        return "transaction_aborted_externally (1309)";
+        return "transaction_aborted_externally (1308)";
       case errc::transaction_op::previous_operation_failed:
-        return "previous_operation_failed (1310)";
+        return "previous_operation_failed (1309)";
       case errc::transaction_op::forward_compatibility_failure:
-        return "forward_compatibility_failure (1311)";
+        return "forward_compatibility_failure (1310)";
       case errc::transaction_op::parsing_failure:
-        return "parsing_failure (1312)";
+        return "parsing_failure (1311)";
       case errc::transaction_op::illegal_state:
-        return "illegal_state (1313)";
-      case errc::transaction_op::couchbase_error:
-        return "couchbase_error (1314)";
+        return "illegal_state (1312)";
       case errc::transaction_op::service_not_available:
-        return "service_not_available (1315)";
+        return "service_not_available (1313)";
       case errc::transaction_op::request_canceled:
-        return "request_canceled (1316)";
+        return "request_canceled (1314)";
       case errc::transaction_op::concurrent_operations_detected_on_same_document:
-        return "concurrent_operations_detected_on_same_document (1317)";
+        return "concurrent_operations_detected_on_same_document (1315)";
       case errc::transaction_op::commit_not_permitted:
-        return "commit_not_permitted (1318)";
+        return "commit_not_permitted (1316)";
       case errc::transaction_op::rollback_not_permitted:
-        return "rollback_not_permitted (1319)";
+        return "rollback_not_permitted (1317)";
       case errc::transaction_op::transaction_already_aborted:
-        return "transaction_already_aborted (1320)";
+        return "transaction_already_aborted (1318)";
       case errc::transaction_op::transaction_already_committed:
-        return "transaction_already_committed (1321)";
+        return "transaction_already_committed (1319)";
       case errc::transaction_op::transaction_op_failed:
         return "transaction_op_failed (1399)";
     }

--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -60,7 +60,7 @@ wrap_err_callback_for_async_api(std::exception_ptr err, std::function<void(couch
     } catch (const transaction_operation_failed& e) {
       return cb(core::impl::make_error(e));
     } catch (...) {
-      return cb({ errc::transaction_op::unknown });
+      return cb({ errc::transaction_op::generic });
     }
   }
   return cb({});
@@ -76,7 +76,7 @@ wrap_void_call_for_public_api(std::function<void()>&& handler) -> couchbase::err
     return core::impl::make_error(e);
   } catch (...) {
     // the handler should catch everything else, but just in case...
-    return { errc::transaction_op::unknown };
+    return { errc::transaction_op::generic };
   }
 }
 
@@ -92,7 +92,7 @@ wrap_call_for_public_api(std::function<transaction_get_result()>&& handler)
     return { core::impl::make_error(ex.ctx()), {} };
   } catch (...) {
     // the handler should catch everything else, but just in case...
-    return { { errc::transaction_op::unknown }, {} };
+    return { { errc::transaction_op::generic }, {} };
   }
 }
 
@@ -113,10 +113,10 @@ wrap_callback_for_async_public_api(
     } catch (const transaction_operation_failed& e) {
       return cb(core::impl::make_error(e), {});
     } catch (...) {
-      return cb({ errc::transaction_op::unknown }, {});
+      return cb({ errc::transaction_op::generic }, {});
     }
   }
-  return cb({ errc::transaction_op::unknown }, {});
+  return cb({ errc::transaction_op::generic }, {});
 }
 
 } // namespace
@@ -1766,7 +1766,7 @@ attempt_context_impl::do_public_query(
     return { core::impl::make_error(qe.ctx()), {} };
   } catch (...) {
     // should not be necessary, but just in case...
-    return { { couchbase::errc::transaction_op::unknown }, {} };
+    return { { couchbase::errc::transaction_op::generic }, {} };
   }
 }
 
@@ -3530,7 +3530,7 @@ attempt_context_impl::query(std::string statement,
               return handler(core::impl::make_error(ex.ctx()), {});
             } catch (...) {
               // just in case...
-              return handler({ couchbase::errc::transaction_op::unknown }, {});
+              return handler({ couchbase::errc::transaction_op::generic }, {});
             }
           }
           auto [ctx, res] = core::impl::build_transaction_query_result(*resp);

--- a/core/transactions/exceptions.cxx
+++ b/core/transactions/exceptions.cxx
@@ -116,7 +116,9 @@ transaction_op_errc_from_external_exception(external_exception e) -> errc::trans
 {
   switch (e) {
     case external_exception::UNKNOWN:
-      return errc::transaction_op::unknown;
+    case external_exception::COUCHBASE_EXCEPTION:
+    case external_exception::NOT_SET:
+      return errc::transaction_op::generic;
     case external_exception::ACTIVE_TRANSACTION_RECORD_ENTRY_NOT_FOUND:
       return errc::transaction_op::active_transaction_record_entry_not_found;
     case external_exception::ACTIVE_TRANSACTION_RECORD_FULL:
@@ -127,8 +129,6 @@ transaction_op_errc_from_external_exception(external_exception e) -> errc::trans
       return errc::transaction_op::active_transaction_record_not_found;
     case external_exception::CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT:
       return errc::transaction_op::concurrent_operations_detected_on_same_document;
-    case external_exception::COUCHBASE_EXCEPTION:
-      return errc::transaction_op::couchbase_error;
     case external_exception::DOCUMENT_ALREADY_IN_TRANSACTION:
       return errc::transaction_op::document_already_in_transaction;
     case external_exception::DOCUMENT_EXISTS_EXCEPTION:
@@ -143,8 +143,6 @@ transaction_op_errc_from_external_exception(external_exception e) -> errc::trans
       return errc::transaction_op::illegal_state;
     case external_exception::PARSING_FAILURE:
       return errc::transaction_op::parsing_failure;
-    case external_exception::NOT_SET:
-      return errc::transaction_op::not_set;
     case external_exception::PREVIOUS_OPERATION_FAILED:
       return errc::transaction_op::previous_operation_failed;
     case external_exception::REQUEST_CANCELED_EXCEPTION:
@@ -160,14 +158,14 @@ transaction_op_errc_from_external_exception(external_exception e) -> errc::trans
     case external_exception::TRANSACTION_ALREADY_COMMITTED:
       return errc::transaction_op::transaction_already_committed;
   }
-  return errc::transaction_op::unknown;
+  return errc::transaction_op::generic;
 }
 
 auto
 external_exception_from_transaction_op_errc(errc::transaction_op ec) -> external_exception
 {
   switch (ec) {
-    case errc::transaction_op::unknown:
+    case errc::transaction_op::generic:
       return external_exception::UNKNOWN;
     case errc::transaction_op::active_transaction_record_entry_not_found:
       return external_exception::ACTIVE_TRANSACTION_RECORD_ENTRY_NOT_FOUND;
@@ -181,8 +179,6 @@ external_exception_from_transaction_op_errc(errc::transaction_op ec) -> external
       return external_exception::DOCUMENT_EXISTS_EXCEPTION;
     case errc::transaction_op::document_not_found:
       return external_exception::DOCUMENT_NOT_FOUND_EXCEPTION;
-    case errc::transaction_op::not_set:
-      return external_exception::NOT_SET;
     case errc::transaction_op::feature_not_available:
       return external_exception::FEATURE_NOT_AVAILABLE_EXCEPTION;
     case errc::transaction_op::transaction_aborted_externally:
@@ -195,8 +191,6 @@ external_exception_from_transaction_op_errc(errc::transaction_op ec) -> external
       return external_exception::PARSING_FAILURE;
     case errc::transaction_op::illegal_state:
       return external_exception::ILLEGAL_STATE_EXCEPTION;
-    case errc::transaction_op::couchbase_error:
-      return external_exception::COUCHBASE_EXCEPTION;
     case errc::transaction_op::service_not_available:
       return external_exception::SERVICE_NOT_AVAILABLE_EXCEPTION;
     case errc::transaction_op::request_canceled:

--- a/couchbase/error_codes.hxx
+++ b/couchbase/error_codes.hxx
@@ -1118,28 +1118,30 @@ enum class transaction {
  * @uncommitted
  */
 enum class transaction_op {
-  unknown = 1300,
+    /**
+     * @internal
+     */
+  generic = 1300,
+
   active_transaction_record_entry_not_found = 1301,
   active_transaction_record_full = 1302,
   active_transaction_record_not_found = 1303,
   document_already_in_transaction = 1304,
   document_exists = 1305,
   document_not_found = 1306,
-  not_set = 1307,
-  feature_not_available = 1308,
-  transaction_aborted_externally = 1309,
-  previous_operation_failed = 1310,
-  forward_compatibility_failure = 1311,
-  parsing_failure = 1312,
-  illegal_state = 1313,
-  couchbase_error = 1314,
-  service_not_available = 1315,
-  request_canceled = 1316,
-  concurrent_operations_detected_on_same_document = 1317,
-  commit_not_permitted = 1318,
-  rollback_not_permitted = 1319,
-  transaction_already_aborted = 1320,
-  transaction_already_committed = 1321,
+  feature_not_available = 1307,
+  transaction_aborted_externally = 1308,
+  previous_operation_failed = 1309,
+  forward_compatibility_failure = 1310,
+  parsing_failure = 1311,
+  illegal_state = 1312,
+  service_not_available = 1313,
+  request_canceled = 1314,
+  concurrent_operations_detected_on_same_document = 1315,
+  commit_not_permitted = 1316,
+  rollback_not_permitted = 1317,
+  transaction_already_aborted = 1318,
+  transaction_already_committed = 1319,
 
   /**
    * @internal

--- a/couchbase/error_codes.hxx
+++ b/couchbase/error_codes.hxx
@@ -1118,9 +1118,9 @@ enum class transaction {
  * @uncommitted
  */
 enum class transaction_op {
-    /**
-     * @internal
-     */
+  /**
+   * @internal
+   */
   generic = 1300,
 
   active_transaction_record_entry_not_found = 1301,

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -340,7 +340,7 @@ TEST_CASE("transactions public blocking API: remove fails as expected with missi
       // the doc is 'blank', so trying to use it results in failure
       auto err = ctx->remove(doc);
       CHECK(err.cause().has_value());
-      CHECK(err.cause().value().ec() == couchbase::errc::transaction_op::unknown);
+      CHECK(err.cause().value().ec() == couchbase::errc::transaction_op::generic);
       return {};
     },
     txn_opts());
@@ -348,7 +348,7 @@ TEST_CASE("transactions public blocking API: remove fails as expected with missi
   CHECK_FALSE(result.unstaging_complete);
   CHECK(tx_err.ec() == couchbase::errc::transaction::failed);
   CHECK(tx_err.cause().has_value());
-  CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::unknown);
+  CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::generic);
 }
 
 TEST_CASE("transactions public blocking API: get doc not found and propagating error",
@@ -398,7 +398,7 @@ TEST_CASE(
   CHECK_FALSE(result.unstaging_complete);
   CHECK(tx_err.ec() == couchbase::errc::transaction::failed);
   CHECK(tx_err.cause().has_value());
-  CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::unknown);
+  CHECK(tx_err.cause().value().ec() == couchbase::errc::transaction_op::generic);
 }
 
 TEST_CASE("transactions public blocking API: can pass per-transaction configs", "[transactions]")


### PR DESCRIPTION
Changes:
- Replaced transaction_op::unknown with transaction_op::generic
- Removed FIT-specific not_set & couchbase_error from errc::transaction_op